### PR TITLE
fix(notifications): complete notification system standardization

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,169 @@
+# Plan: eBoekhouden HTTP Client Enhancements
+
+## Context
+
+Code review identified gaps in the HTTP client mixin. After verification, 3 of 6 issues were already addressed. This plan covers the remaining valid concerns.
+
+## Issues to Address
+
+### 1. Retry-After Header Handling (Issue #3)
+
+**Problem**: When API returns 429 (rate limit), we retry with exponential backoff but ignore the `Retry-After` header that tells us exactly how long to wait.
+
+**Solution**: Enhance `_request_with_retry()` to:
+- Check for `Retry-After` header on 429 responses
+- Use header value instead of calculated backoff when present
+- Cap maximum wait to prevent excessive delays
+
+**Changes**:
+- `http_client_mixin.py`: Add `_get_retry_delay()` method that checks headers
+
+```python
+def _get_retry_delay(self, response, attempt: int) -> float:
+    """Calculate retry delay, preferring Retry-After header if present."""
+    # Check for Retry-After header (can be seconds or HTTP date)
+    retry_after = response.headers.get("Retry-After")
+    if retry_after:
+        try:
+            # Try parsing as seconds first
+            delay = float(retry_after)
+            return min(delay, 60.0)  # Cap at 60 seconds
+        except ValueError:
+            pass  # Could be HTTP date, fall through to default
+
+    # Default exponential backoff
+    return self.RETRY_BACKOFF_FACTOR * (2 ** attempt)
+```
+
+---
+
+### 2. Thread Safety for Token Management (Issue #4)
+
+**Problem**: Multiple threads could race to refresh tokens or update caches, causing:
+- Double token refresh
+- Stale token usage
+- Cache corruption
+
+**Solution**: Add `threading.Lock()` around critical sections.
+
+**Changes**:
+- `http_client_mixin.py`: Add lock for token operations
+
+```python
+import threading
+
+class EBoekhoudenHTTPClientMixin:
+    def _init_http_client(self, settings=None) -> None:
+        # ... existing code ...
+        self._token_lock = threading.Lock()
+
+    def _get_session_token(self) -> Optional[str]:
+        with self._token_lock:
+            if not self._token_is_expired():
+                return self._session_token
+            # ... fetch new token ...
+
+    def invalidate_token(self) -> None:
+        with self._token_lock:
+            self._session_token = None
+            self._token_obtained_at = None
+```
+
+- `eboekhouden_rest_client.py`: Add lock for cache operations
+
+```python
+def __init__(self, settings=None):
+    self._init_http_client(settings)
+    self._cache_lock = threading.Lock()
+    self._ledger_cache = None
+    self._relation_cache = None
+
+def get_ledgers(self) -> Dict[str, Any]:
+    with self._cache_lock:
+        if self._ledger_cache is not None:
+            return {"success": True, "ledgers": self._ledger_cache}
+    # ... fetch and cache ...
+```
+
+---
+
+### 3. Metrics/Instrumentation (Issue #5)
+
+**Problem**: No visibility into API behavior during migrations. Hard to diagnose issues or monitor health.
+
+**Solution**: Add lightweight counters for key metrics.
+
+**Changes**:
+- `http_client_mixin.py`: Add metrics tracking
+
+```python
+from dataclasses import dataclass, field
+
+@dataclass
+class HTTPClientMetrics:
+    """Metrics for HTTP client operations."""
+    requests_total: int = 0
+    requests_success: int = 0
+    requests_failed: int = 0
+    retries_total: int = 0
+    token_refreshes: int = 0
+    rate_limits_hit: int = 0
+
+    def to_dict(self) -> Dict[str, int]:
+        return {
+            "requests_total": self.requests_total,
+            "requests_success": self.requests_success,
+            "requests_failed": self.requests_failed,
+            "retries_total": self.retries_total,
+            "token_refreshes": self.token_refreshes,
+            "rate_limits_hit": self.rate_limits_hit,
+        }
+
+class EBoekhoudenHTTPClientMixin:
+    def _init_http_client(self, settings=None) -> None:
+        # ... existing code ...
+        self.metrics = HTTPClientMetrics()
+
+    def get_metrics(self) -> Dict[str, int]:
+        """Return current metrics for monitoring."""
+        return self.metrics.to_dict()
+
+    def reset_metrics(self) -> None:
+        """Reset metrics counters."""
+        self.metrics = HTTPClientMetrics()
+```
+
+Update `_request_with_retry()` to increment counters at appropriate points.
+
+---
+
+## New Tests Required
+
+Add tests for:
+1. `Retry-After` header handling (seconds and edge cases)
+2. Thread safety (concurrent token refresh)
+3. Metrics collection accuracy
+
+---
+
+## Implementation Order
+
+1. **Thread safety** (highest risk if not addressed)
+2. **Retry-After handling** (improves reliability)
+3. **Metrics** (nice to have for observability)
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `http_client_mixin.py` | Add lock, Retry-After handling, metrics |
+| `eboekhouden_rest_client.py` | Add cache lock |
+| `test_http_client_mixin.py` | Add new tests |
+
+## Estimated Scope
+
+- ~100 lines of new code
+- ~50 lines of new tests
+- No breaking changes to existing API

--- a/scripts/monitoring/zabbix_integration.py
+++ b/scripts/monitoring/zabbix_integration.py
@@ -978,15 +978,29 @@ def create_issue_from_alert(alert):
     issue.issue_type = "System Alert"
     issue.insert(ignore_permissions=True)
     
-    # Send email notification
+    # Send email notification via EmailService for central control
     recipients = frappe.conf.get("alert_recipients", [])
     if recipients:
-        frappe.sendmail(
-            recipients=recipients,
-            subject=issue.subject,
-            message=issue.description,
-            delayed=False
-        )
+        try:
+            from verenigingen.services.communication.email_service import get_email_service
+
+            email_service = get_email_service()
+            email_service.send_simple_email(
+                recipients=recipients,
+                subject=issue.subject,
+                message=issue.description,
+                notification_key="zabbix_system_alert",
+                reference_doctype="Issue",
+                reference_name=issue.name,
+            )
+        except ImportError:
+            # Fallback if EmailService not available (e.g., during migrations)
+            frappe.sendmail(
+                recipients=recipients,
+                subject=issue.subject,
+                message=issue.description,
+                delayed=False,
+            )
     
     return {"action": "created_issue", "reference": issue.name}
 

--- a/verenigingen/api/email_template_manager.py
+++ b/verenigingen/api/email_template_manager.py
@@ -652,15 +652,30 @@ def send_template_email(template_name, recipients, context=None, **kwargs):
         template_name: Name of the Email Template
         recipients: List of email addresses
         context: Dict of variables for template rendering
-        **kwargs: Additional email options (reference_doctype, reference_name, etc.)
+        **kwargs: Additional email options:
+            - reference_doctype: DocType for reference
+            - reference_name: Document name for reference
+            - notification_key: REQUIRED - notification key from registry for central control
 
     Returns:
         bool: Success status
+
+    Note:
+        notification_key is required to enable central notification configuration.
+        Callers must explicitly provide a notification_key from the registry.
     """
     from verenigingen.services.communication.email_service import get_email_service
 
     if context is None:
         context = {}
+
+    # Require explicit notification_key - do not default to a test key
+    notification_key = kwargs.get("notification_key")
+    if not notification_key:
+        frappe.logger().warning(
+            f"send_template_email called without notification_key for template '{template_name}'. "
+            "Add a notification_key parameter to enable central notification control."
+        )
 
     try:
         # Get rendered template
@@ -674,7 +689,7 @@ def send_template_email(template_name, recipients, context=None, **kwargs):
             message=template["message"],
             reference_doctype=kwargs.get("reference_doctype"),
             reference_name=kwargs.get("reference_name"),
-            notification_key=kwargs.get("notification_key", "email_template_test"),
+            notification_key=notification_key,
         )
 
         return result.get("success", False)

--- a/verenigingen/api/email_template_manager.py
+++ b/verenigingen/api/email_template_manager.py
@@ -674,6 +674,7 @@ def send_template_email(template_name, recipients, context=None, **kwargs):
             message=template["message"],
             reference_doctype=kwargs.get("reference_doctype"),
             reference_name=kwargs.get("reference_name"),
+            notification_key=kwargs.get("notification_key", "email_template_test"),
         )
 
         return result.get("success", False)

--- a/verenigingen/api/membership_application_review.py
+++ b/verenigingen/api/membership_application_review.py
@@ -1916,6 +1916,7 @@ def notify_chapter_of_overdue_applications(chapter_name, applications):
             View All Pending Applications</a></p>
             """,
             now=True,
+            notification_key="member_application_overdue",
         )
 
 
@@ -1958,6 +1959,7 @@ def notify_managers_of_overdue_applications(applications):
                 View Unassigned Applications</a></p>
                 """,
                 now=True,
+                notification_key="member_application_overdue",
             )
 
 

--- a/verenigingen/api/newsletter_demo.py
+++ b/verenigingen/api/newsletter_demo.py
@@ -328,18 +328,23 @@ def send_test_newsletter(email_group=None):
     <p><strong>No action is required.</strong></p>
     """
 
-    # Send to recipients
-    for recipient in recipients:
-        frappe.sendmail(
-            recipients=[recipient.email],
-            subject=subject,
-            message=content,
-            reference_doctype="Email Group",
-            reference_name=email_group,
-        )
+    # Send to recipients via EmailService for central control
+    from verenigingen.services.communication.email_service import get_email_service
+
+    email_service = get_email_service()
+    recipient_emails = [r.email for r in recipients]
+
+    result = email_service.send_simple_email(
+        recipients=recipient_emails,
+        subject=subject,
+        message=content,
+        reference_doctype="Email Group",
+        reference_name=email_group,
+        notification_key="newsletter_campaign",
+    )
 
     return {
-        "success": True,
+        "success": result.get("success", False),
         "recipients_count": len(recipients),
         "message": f"Test newsletter sent to {len(recipients)} recipients",
     }

--- a/verenigingen/api/periodic_donation_operations.py
+++ b/verenigingen/api/periodic_donation_operations.py
@@ -539,6 +539,7 @@ def send_renewal_reminders(days_before_expiry=90) -> OperationResult[Dict[str, A
                     message=get_renewal_reminder_email(agreement, days_remaining),
                     reference_doctype="Periodic Donation Agreement",
                     reference_name=agreement.name,
+                    notification_key="periodic_donation_expiry",
                 )
 
                 # Log the reminder

--- a/verenigingen/notification_registry.py
+++ b/verenigingen/notification_registry.py
@@ -600,6 +600,37 @@ NOTIFICATION_KEYS = {
         "priority": PRIORITY_LOW,
         "recipient_policy": POLICY_FIXED,
     },
+    # =========================================================================
+    # PAYMENT ALERT NOTIFICATIONS
+    # =========================================================================
+    "payment_alert_overpayment": {
+        "label": "Overpayment Alert",
+        "category": CATEGORY_PAYMENT,
+        "description": "Alert sent to financial admins when an overpayment is detected.",
+        "priority": PRIORITY_HIGH,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "payment_alert_failure": {
+        "label": "Payment Entry Failure Alert",
+        "category": CATEGORY_PAYMENT,
+        "description": "Alert sent when automatic Payment Entry creation fails.",
+        "priority": PRIORITY_HIGH,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "payment_alert_reconciliation": {
+        "label": "Payment Reconciliation Alert",
+        "category": CATEGORY_PAYMENT,
+        "description": "Alert for payment reconciliation issues requiring manual review.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "zabbix_system_alert": {
+        "label": "Zabbix System Alert",
+        "category": CATEGORY_SYSTEM,
+        "description": "System alert forwarded from Zabbix monitoring integration.",
+        "priority": PRIORITY_HIGH,
+        "recipient_policy": POLICY_FIXED,
+    },
 }
 
 

--- a/verenigingen/notification_registry.py
+++ b/verenigingen/notification_registry.py
@@ -177,6 +177,27 @@ NOTIFICATION_KEYS = {
         "priority": PRIORITY_LOW,
         "recipient_policy": POLICY_ROLE_BASED,
     },
+    "chapter_join_request_submitted": {
+        "label": "Chapter Join Request Submitted",
+        "category": CATEGORY_CHAPTER,
+        "description": "Sent to chapter board members when a member submits a request to join their chapter.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "chapter_join_request_approved": {
+        "label": "Chapter Join Request Approved",
+        "category": CATEGORY_CHAPTER,
+        "description": "Sent to the member when their chapter join request is approved.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_DOCUMENT_FIELD,
+    },
+    "chapter_join_request_rejected": {
+        "label": "Chapter Join Request Rejected",
+        "category": CATEGORY_CHAPTER,
+        "description": "Sent to the member when their chapter join request is rejected, including the reason.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_DOCUMENT_FIELD,
+    },
     # =========================================================================
     # PAYMENT NOTIFICATIONS
     # =========================================================================
@@ -322,6 +343,34 @@ NOTIFICATION_KEYS = {
         "priority": PRIORITY_HIGH,
         "recipient_policy": POLICY_ROLE_BASED,
     },
+    "sepa_member_pre_notification": {
+        "label": "SEPA Pre-Notification",
+        "category": CATEGORY_PAYMENT,
+        "description": "Notification sent to members before SEPA direct debit collection occurs.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_DOCUMENT_FIELD,
+    },
+    "sepa_batch_scheduler_alert": {
+        "label": "SEPA Scheduler Alert",
+        "category": CATEGORY_PAYMENT,
+        "description": "Alert from SEPA batch scheduler about processing issues or delays.",
+        "priority": PRIORITY_HIGH,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "balance_monitor_alert": {
+        "label": "Balance Monitor Alert",
+        "category": CATEGORY_PAYMENT,
+        "description": "Alert when account balance falls below configured threshold.",
+        "priority": PRIORITY_HIGH,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "mollie_security_alert": {
+        "label": "Mollie Security Alert",
+        "category": CATEGORY_PAYMENT,
+        "description": "Security alert for suspicious activity in Mollie payment processing.",
+        "priority": PRIORITY_CRITICAL,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
     # =========================================================================
     # PONTO NOTIFICATIONS
     # =========================================================================
@@ -415,6 +464,41 @@ NOTIFICATION_KEYS = {
         "priority": PRIORITY_LOW,
         "recipient_policy": POLICY_ROLE_BASED,
     },
+    "security_alert": {
+        "label": "Security Alert",
+        "category": CATEGORY_SYSTEM,
+        "description": "Real-time alert for security events requiring immediate attention.",
+        "priority": PRIORITY_CRITICAL,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "audit_alert": {
+        "label": "Audit Alert",
+        "category": CATEGORY_SYSTEM,
+        "description": "Alert triggered by audit logging rules for suspicious or critical operations.",
+        "priority": PRIORITY_HIGH,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "auth_monitoring_alert": {
+        "label": "Authentication Alert",
+        "category": CATEGORY_SYSTEM,
+        "description": "Alert for authentication anomalies like failed logins or suspicious access patterns.",
+        "priority": PRIORITY_HIGH,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "business_logic_alert": {
+        "label": "Business Logic Alert",
+        "category": CATEGORY_SYSTEM,
+        "description": "Alert triggered by business logic monitoring rules detecting anomalies.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "system_alert": {
+        "label": "System Alert",
+        "category": CATEGORY_SYSTEM,
+        "description": "Generic system alert for operational issues and warnings.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
     # =========================================================================
     # ADMIN NOTIFICATIONS
     # =========================================================================
@@ -422,6 +506,41 @@ NOTIFICATION_KEYS = {
         "label": "ANBI Consent Request",
         "category": CATEGORY_ADMIN,
         "description": "Sent to donors requesting consent for ANBI tax deduction reporting.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_DOCUMENT_FIELD,
+    },
+    "contact_request_assigned": {
+        "label": "Contact Request Assigned",
+        "category": CATEGORY_ADMIN,
+        "description": "Sent to staff member when a contact request is assigned to them.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_DOCUMENT_FIELD,
+    },
+    "contact_request_escalated": {
+        "label": "Contact Request Escalated",
+        "category": CATEGORY_ADMIN,
+        "description": "Sent to managers when a contact request is escalated due to SLA breach or priority.",
+        "priority": PRIORITY_HIGH,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "contact_request_response_sent": {
+        "label": "Contact Request Response",
+        "category": CATEGORY_MEMBER,
+        "description": "Sent to member when their contact request receives a response.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_DOCUMENT_FIELD,
+    },
+    "expulsion_report_submitted": {
+        "label": "Expulsion Report Submitted",
+        "category": CATEGORY_ADMIN,
+        "description": "Sent to governance committee when a new expulsion report is submitted.",
+        "priority": PRIORITY_HIGH,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "member_activation_reminder": {
+        "label": "Member Activation Reminder",
+        "category": CATEGORY_MEMBER,
+        "description": "Reminder sent to pending members who haven't completed activation.",
         "priority": PRIORITY_MEDIUM,
         "recipient_policy": POLICY_DOCUMENT_FIELD,
     },

--- a/verenigingen/notification_registry.py
+++ b/verenigingen/notification_registry.py
@@ -90,6 +90,27 @@ NOTIFICATION_KEYS = {
         "priority": PRIORITY_MEDIUM,
         "recipient_policy": POLICY_DOCUMENT_FIELD,
     },
+    "member_application_submitted": {
+        "label": "Application Submitted (Admin)",
+        "category": CATEGORY_ADMIN,
+        "description": "Sent to reviewers/admins when a new membership application is submitted.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "member_application_approved": {
+        "label": "Application Approved",
+        "category": CATEGORY_MEMBER,
+        "description": "Sent to applicants when their membership application is approved.",
+        "priority": PRIORITY_HIGH,
+        "recipient_policy": POLICY_DOCUMENT_FIELD,
+    },
+    "member_application_overdue": {
+        "label": "Application Overdue Alert",
+        "category": CATEGORY_ADMIN,
+        "description": "Alert sent to reviewers when membership applications have been pending too long.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
     "member_application_rejected": {
         "label": "Application Rejected",
         "category": CATEGORY_MEMBER,
@@ -550,6 +571,34 @@ NOTIFICATION_KEYS = {
         "description": "Reminder sent to pending members who haven't completed activation.",
         "priority": PRIORITY_MEDIUM,
         "recipient_policy": POLICY_DOCUMENT_FIELD,
+    },
+    "newsletter_campaign": {
+        "label": "Newsletter Campaign",
+        "category": CATEGORY_MEMBER,
+        "description": "Automated newsletter or campaign emails sent to members or segments.",
+        "priority": PRIORITY_LOW,
+        "recipient_policy": POLICY_CUSTOM,
+    },
+    "chapter_generic_notification": {
+        "label": "Chapter Generic Notification",
+        "category": CATEGORY_CHAPTER,
+        "description": "Generic chapter-level notifications using custom templates.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_CUSTOM,
+    },
+    "contribution_sync_failed": {
+        "label": "Contribution Sync Failed",
+        "category": CATEGORY_PAYMENT,
+        "description": "Alert when Mollie contribution synchronization fails.",
+        "priority": PRIORITY_HIGH,
+        "recipient_policy": POLICY_ROLE_BASED,
+    },
+    "email_template_test": {
+        "label": "Email Template Test",
+        "category": CATEGORY_ADMIN,
+        "description": "Test email sent when previewing or testing email templates.",
+        "priority": PRIORITY_LOW,
+        "recipient_policy": POLICY_FIXED,
     },
 }
 

--- a/verenigingen/notification_registry.py
+++ b/verenigingen/notification_registry.py
@@ -509,6 +509,13 @@ NOTIFICATION_KEYS = {
         "priority": PRIORITY_MEDIUM,
         "recipient_policy": POLICY_DOCUMENT_FIELD,
     },
+    "anbi_tax_receipt": {
+        "label": "ANBI Tax Receipt",
+        "category": CATEGORY_PAYMENT,
+        "description": "Tax deduction receipt sent to donors for ANBI-eligible donations.",
+        "priority": PRIORITY_MEDIUM,
+        "recipient_policy": POLICY_DOCUMENT_FIELD,
+    },
     "contact_request_assigned": {
         "label": "Contact Request Assigned",
         "category": CATEGORY_ADMIN,

--- a/verenigingen/services/communication/email_configuration_service.py
+++ b/verenigingen/services/communication/email_configuration_service.py
@@ -219,6 +219,16 @@ class EmailConfigurationService:
     def _is_suppressed(self) -> bool:
         """Check if notifications are suppressed by flags.
 
+        Canonical suppression flags (set via context managers in notification_suppression.py):
+        - suppress_notifications: Suppresses ALL notifications (set by suppress_all_notifications())
+        - suppress_chapter_notifications: Suppresses chapter-related notifications only
+          (set by suppress_chapter_notifications())
+
+        Import-related flags (checked if suppress_during_imports is enabled):
+        - in_import: Standard Frappe import flag
+        - in_bulk_import: Bulk import operations
+        - bulk_member_operations: Member bulk operations
+
         Returns:
             True if notifications should be suppressed.
         """
@@ -233,9 +243,8 @@ class EmailConfigurationService:
             if getattr(frappe.flags, "bulk_member_operations", False):
                 return True
 
+        # Check explicit suppression flags (set by context managers)
         if getattr(frappe.flags, "suppress_notifications", False):
-            return True
-        if getattr(frappe.flags, "suppress_all_notifications", False):
             return True
 
         return False

--- a/verenigingen/tests/backend/unit/services/test_email_configuration_service.py
+++ b/verenigingen/tests/backend/unit/services/test_email_configuration_service.py
@@ -174,9 +174,9 @@ class TestEmailConfigurationServiceShouldSend(FrappeTestCase):
         """Set up test fixtures."""
         super().setUp()
         self.service = EmailConfigurationService()
-        # Clear suppression flags
+        # Clear suppression flags (canonical flags only)
         frappe.flags.suppress_notifications = False
-        frappe.flags.suppress_all_notifications = False
+        frappe.flags.suppress_chapter_notifications = False
         frappe.flags.in_import = False
         frappe.flags.in_bulk_import = False
         frappe.flags.bulk_member_operations = False
@@ -184,7 +184,7 @@ class TestEmailConfigurationServiceShouldSend(FrappeTestCase):
     def tearDown(self):
         """Clean up flags."""
         frappe.flags.suppress_notifications = False
-        frappe.flags.suppress_all_notifications = False
+        frappe.flags.suppress_chapter_notifications = False
         frappe.flags.in_import = False
         frappe.flags.in_bulk_import = False
         frappe.flags.bulk_member_operations = False
@@ -362,20 +362,28 @@ class TestEmailConfigurationServiceSuppression(FrappeTestCase):
         super().tearDown()
 
     def _clear_flags(self):
-        """Clear all suppression flags."""
+        """Clear all suppression flags.
+
+        Canonical suppression flags (see notification_suppression.py):
+        - suppress_notifications: Set by suppress_all_notifications() context manager
+        - suppress_chapter_notifications: Set by suppress_chapter_notifications() context manager
+
+        Import-related flags:
+        - in_import, in_bulk_import, bulk_member_operations
+        """
         for flag in [
-            'suppress_notifications', 'suppress_all_notifications',
+            'suppress_notifications', 'suppress_chapter_notifications',
             'in_import', 'in_bulk_import', 'bulk_member_operations'
         ]:
             setattr(frappe.flags, flag, False)
 
-    def test_is_suppressed_checks_all_notification_flags(self):
-        """Test _is_suppressed checks suppress_notifications flag."""
-        frappe.flags.suppress_notifications = True
-        self.assertTrue(self.service._is_suppressed())
+    def test_is_suppressed_checks_suppress_notifications_flag(self):
+        """Test _is_suppressed checks the canonical suppress_notifications flag.
 
-        frappe.flags.suppress_notifications = False
-        frappe.flags.suppress_all_notifications = True
+        Note: The suppress_all_notifications() context manager sets suppress_notifications=True.
+        This is the canonical flag checked by _is_suppressed().
+        """
+        frappe.flags.suppress_notifications = True
         self.assertTrue(self.service._is_suppressed())
 
     def test_is_suppressed_checks_import_flags(self):

--- a/verenigingen/utils/alert_manager.py
+++ b/verenigingen/utils/alert_manager.py
@@ -103,6 +103,7 @@ class AlertManager:
                 subject=f"[{severity}] {alert_type}: {message}",
                 message=self.format_alert_email(alert_type, severity, message, details),
                 delayed=False,
+                notification_key="system_alert",
             )
 
             return alert_doc
@@ -144,6 +145,7 @@ class AlertManager:
                 subject="Daily Monitoring Report",
                 message=self.format_daily_report(daily_stats),
                 delayed=False,
+                notification_key="system_alert",
             )
 
         except Exception as e:

--- a/verenigingen/utils/application_notifications.py
+++ b/verenigingen/utils/application_notifications.py
@@ -85,6 +85,7 @@ def send_application_confirmation_email(member, application_id):
             now=True,
             reference_doctype="Member",
             reference_name=member.name,
+            notification_key="member_application_confirmation",
         )
     except Exception as e:
         frappe.log_error(f"Error sending confirmation email: {str(e)}", "Email Error")
@@ -146,6 +147,7 @@ def notify_reviewers_of_new_application(member, application_id):
             subject=f"New Application: {application_id} - {member.full_name}",
             message=message,
             now=True,
+            notification_key="member_application_submitted",
         )
 
 
@@ -208,6 +210,7 @@ def send_approval_email(member, invoice):
             now=True,
             reference_doctype="Member",
             reference_name=member.name,
+            notification_key="member_application_approved",
         )
     except Exception as e:
         frappe.log_error(f"Error sending approval email: {str(e)}", "Email Error")
@@ -256,6 +259,7 @@ def send_rejection_email(member, reason):
             now=True,
             reference_doctype="Member",
             reference_name=member.name,
+            notification_key="member_application_rejected",
         )
     except Exception as e:
         frappe.log_error(f"Error sending rejection email: {str(e)}", "Email Error")
@@ -320,6 +324,7 @@ def send_payment_confirmation_email(member, invoice):
             now=True,
             reference_doctype="Member",
             reference_name=member.name,
+            notification_key="member_activated",
         )
     except Exception as e:
         frappe.log_error(f"Error sending payment confirmation email: {str(e)}", "Email Error")
@@ -448,6 +453,7 @@ def notify_admins_of_new_application(member, invoice=None):
             subject=f"New Application: {member.full_name}",
             message=message,
             now=True,
+            notification_key="member_application_submitted",
         )
     except Exception as e:
         frappe.log_error(f"Error notifying admins: {str(e)}", "Notification Error")
@@ -500,6 +506,7 @@ def check_overdue_applications():
                             subject=frappe.render_template(email_template_doc.subject, args),
                             message=frappe.render_template(email_template_doc.response, args),
                             now=True,
+                            notification_key="member_application_overdue",
                         )
                     else:
                         # Fallback to simple message
@@ -523,6 +530,7 @@ def check_overdue_applications():
                             subject="Overdue Membership Applications",
                             message=message,
                             now=True,
+                            notification_key="member_application_overdue",
                         )
         except Exception as e:
             frappe.log_error(f"Error notifying about overdue applications: {str(e)}")
@@ -565,6 +573,7 @@ def send_simple_notification(data, member_id):
             subject="Membership Application Submitted",
             message=message,
             now=True,
+            notification_key="member_application_confirmation",
         )
     except Exception as e:
         frappe.log_error(f"Error sending simple notification: {str(e)}", "Notification Error")

--- a/verenigingen/utils/auth_monitoring.py
+++ b/verenigingen/utils/auth_monitoring.py
@@ -173,7 +173,11 @@ def alert_if_auth_issues():
             if recipients:
                 email_service = get_email_service()
                 email_service.send_simple_email(
-                    recipients=recipients, subject=subject, message=message, delayed=False
+                    recipients=recipients,
+                    subject=subject,
+                    message=message,
+                    delayed=False,
+                    notification_key="auth_monitoring_alert",
                 )
 
             frappe.logger().error(f"AUTH_MONITOR: Critical alert sent to {len(recipients)} administrators")

--- a/verenigingen/utils/business_logic_monitor.py
+++ b/verenigingen/utils/business_logic_monitor.py
@@ -553,7 +553,11 @@ class BusinessLogicMonitor:
             # Send email notification
             email_service = get_email_service()
             email_service.send_simple_email(
-                recipients=admin_emails, subject=subject, message=message, send_priority=1
+                recipients=admin_emails,
+                subject=subject,
+                message=message,
+                send_priority=1,
+                notification_key="business_logic_alert",
             )
 
             logger.info(f"Sent business logic alerts to {len(admin_emails)} administrators")

--- a/verenigingen/utils/donation_emails.py
+++ b/verenigingen/utils/donation_emails.py
@@ -53,6 +53,7 @@ def send_donation_confirmation(donation_id):
             reference_doctype="Donation",
             reference_name=donation.name,
             send_priority=1,
+            notification_key="donation_confirmation",
         )
 
         # Log email sent
@@ -111,6 +112,7 @@ def send_payment_confirmation(donation_id):
             reference_doctype="Donation",
             reference_name=donation.name,
             send_priority=1,
+            notification_key="donation_payment_confirmation",
         )
 
         # Send ANBI receipt if applicable
@@ -173,6 +175,7 @@ def send_anbi_receipt(donation_id):
             reference_doctype="Donation",
             reference_name=donation.name,
             send_priority=1,
+            notification_key="anbi_tax_receipt",
         )
 
         donation.add_comment(

--- a/verenigingen/utils/member_performance_optimizer.py
+++ b/verenigingen/utils/member_performance_optimizer.py
@@ -411,6 +411,7 @@ def process_member_post_creation(member_name: str):
                     """,
                     reference_doctype="Member",
                     reference_name=member.name,
+                    notification_key="member_activated",
                 )
 
                 if result.get("success"):

--- a/verenigingen/utils/notification_suppression.py
+++ b/verenigingen/utils/notification_suppression.py
@@ -5,11 +5,31 @@ Provides safe, explicit context managers for suppressing notifications during
 bulk operations. This prevents accidental email floods and makes bulk operation
 intent clear in code.
 
+Canonical Suppression Flags:
+---------------------------
+The following frappe.flags are the canonical suppression flags. They are
+checked by EmailConfigurationService._is_suppressed() before sending any email.
+
+1. suppress_notifications (bool):
+   - Suppresses ALL notifications when True
+   - Set by: suppress_all_notifications() context manager
+   - Use case: Large-scale imports, migrations, bulk operations
+
+2. suppress_chapter_notifications (bool):
+   - Suppresses chapter-related notifications only
+   - Set by: suppress_chapter_notifications() context manager
+   - Use case: Bulk chapter member assignments
+
 Example usage:
     with suppress_chapter_notifications():
         for member in bulk_member_list:
             ChapterMembershipManager.assign_member_to_chapter(member, chapter)
-            # Notifications automatically suppressed within this block
+            # Chapter notifications automatically suppressed within this block
+
+    with suppress_all_notifications():
+        for record in import_records:
+            process_import(record)
+            # ALL notifications suppressed within this block
 """
 
 from contextlib import contextmanager

--- a/verenigingen/utils/payment_alert_service.py
+++ b/verenigingen/utils/payment_alert_service.py
@@ -215,6 +215,8 @@ class PaymentAlertService:
         Returns:
             True if sent successfully, False otherwise
         """
+        from verenigingen.services.communication.email_service import get_email_service
+
         try:
             recipients = self.alert_recipients
             if not recipients:
@@ -227,12 +229,22 @@ class PaymentAlertService:
                 )
                 return False
 
-            frappe.sendmail(
+            # Map alert_type to notification_key
+            notification_key_map = {
+                "overpayment": "payment_alert_overpayment",
+                "payment_entry_failure": "payment_alert_failure",
+                "reconciliation": "payment_alert_reconciliation",
+            }
+            notification_key = notification_key_map.get(alert_type, "payment_alert_failure")
+
+            email_service = get_email_service()
+            result = email_service.send_simple_email(
                 recipients=recipients,
                 subject=subject,
                 message=message,
+                notification_key=notification_key,
             )
-            return True
+            return result.get("success", False)
         except Exception as e:
             frappe.logger().warning(f"Failed to send {alert_type} alert email: {e}")
             return False

--- a/verenigingen/utils/security/audit_logging.py
+++ b/verenigingen/utils/security/audit_logging.py
@@ -452,6 +452,7 @@ class SEPAAuditLogger:
                     <p>Please review the audit logs for more details.</p>
                     """,
                     now=True,
+                    notification_key="audit_alert",
                 )
 
         except Exception as e:

--- a/verenigingen/utils/security/security_monitoring.py
+++ b/verenigingen/utils/security/security_monitoring.py
@@ -812,6 +812,7 @@ def run_business_rule_monitoring():
                             subject=subject,
                             message=message,
                             send_priority=1 if alert["severity"] == "CRITICAL" else 0,
+                            notification_key="business_logic_alert",
                         )
                 except Exception as e:
                     frappe.log_error(f"Failed to send business rule alert notification: {str(e)}")

--- a/verenigingen/verenigingen/doctype/chapter/managers/communication_manager.py
+++ b/verenigingen/verenigingen/doctype/chapter/managers/communication_manager.py
@@ -318,6 +318,7 @@ class CommunicationManager(BaseManager):
                     context=context,
                     reference_doctype="Chapter",
                     reference_name=self.chapter_name,
+                    notification_key="chapter_generic_notification",
                 )
 
                 if success:

--- a/verenigingen/verenigingen/doctype/chapter_join_request/chapter_join_request.py
+++ b/verenigingen/verenigingen/doctype/chapter_join_request/chapter_join_request.py
@@ -223,6 +223,9 @@ class ChapterJoinRequest(Document):
                         "Please review and approve/reject this request."
                     ).format(self.member_name, self.chapter, self.request_date),
                     header=[_("Chapter Join Request"), "blue"],
+                    notification_key="chapter_join_request_submitted",
+                    reference_doctype="Chapter Join Request",
+                    reference_name=self.name,
                 )
         except Exception as e:
             frappe.log_error(f"Failed to send chapter board notification: {str(e)}")
@@ -239,6 +242,9 @@ class ChapterJoinRequest(Document):
                     "Welcome to the chapter!"
                 ).format(self.chapter),
                 header=[_("Request Approved"), "green"],
+                notification_key="chapter_join_request_approved",
+                reference_doctype="Chapter Join Request",
+                reference_name=self.name,
             )
         except Exception as e:
             frappe.log_error(f"Failed to send member approval notification: {str(e)}")
@@ -256,6 +262,9 @@ class ChapterJoinRequest(Document):
                 subject=_("Chapter Join Request Rejected - {0}").format(self.chapter),
                 message=message,
                 header=[_("Request Rejected"), "red"],
+                notification_key="chapter_join_request_rejected",
+                reference_doctype="Chapter Join Request",
+                reference_name=self.name,
             )
         except Exception as e:
             frappe.log_error(f"Failed to send member rejection notification: {str(e)}")

--- a/verenigingen/verenigingen/doctype/contribution_amendment_request/contribution_amendment_request.py
+++ b/verenigingen/verenigingen/doctype/contribution_amendment_request/contribution_amendment_request.py
@@ -419,6 +419,7 @@ class ContributionAmendmentRequest(Document):
                     },
                     reference_doctype="Contribution Amendment Request",
                     reference_name=self.name,
+                    notification_key="contribution_sync_failed",
                 )
 
                 if result.get("success"):

--- a/verenigingen/verenigingen/doctype/expulsion_report_entry/expulsion_report_entry.py
+++ b/verenigingen/verenigingen/doctype/expulsion_report_entry/expulsion_report_entry.py
@@ -144,6 +144,7 @@ class ExpulsionReportEntry(Document):
                 reference_doctype=self.doctype,
                 reference_name=self.name,
                 header=["New Expulsion Entry", "red"],
+                notification_key="expulsion_report_submitted",
             )
 
         except Exception as e:
@@ -222,6 +223,7 @@ class ExpulsionReportEntry(Document):
                 reference_doctype=self.doctype,
                 reference_name=self.name,
                 header=["Expulsion Reversed", "green"],
+                notification_key="expulsion_report_submitted",
             )
 
         except Exception as e:

--- a/verenigingen/verenigingen/doctype/member_contact_request/contact_request_automation.py
+++ b/verenigingen/verenigingen/doctype/member_contact_request/contact_request_automation.py
@@ -71,6 +71,7 @@ def send_follow_up_reminders():
                     message=message,
                     reference_doctype="Member Contact Request",
                     reference_name=request.name,
+                    notification_key="contact_request_assigned",
                 )
 
                 # Update follow-up date to avoid duplicate reminders
@@ -161,6 +162,7 @@ def escalate_contact_request(request, overdue_days):
             message=message,
             reference_doctype="Member Contact Request",
             reference_name=request.name,
+            notification_key="contact_request_escalated",
         )
 
         # Add escalation note to the request
@@ -255,6 +257,7 @@ def auto_close_resolved_requests():
                     message=message,
                     reference_doctype="Member Contact Request",
                     reference_name=request.name,
+                    notification_key="contact_request_response_sent",
                 )
 
             frappe.logger().info(f"Auto-closed contact request {request.name}")

--- a/verenigingen/verenigingen/doctype/member_contact_request/member_contact_request.py
+++ b/verenigingen/verenigingen/doctype/member_contact_request/member_contact_request.py
@@ -154,6 +154,7 @@ class MemberContactRequest(Document):
                 message=message,
                 reference_doctype=self.doctype,
                 reference_name=self.name,
+                notification_key="contact_request_escalated",
             )
 
         except Exception as e:
@@ -266,6 +267,7 @@ class MemberContactRequest(Document):
                         message=message,
                         reference_doctype=self.doctype,
                         reference_name=self.name,
+                        notification_key="contact_request_assigned",
                     )
             except Exception as e:
                 frappe.log_error(f"Failed to notify assigned user: {str(e)}", "Assignment Notification Error")

--- a/verenigingen/verenigingen_payments/api/dd_batch_api.py
+++ b/verenigingen/verenigingen_payments/api/dd_batch_api.py
@@ -605,6 +605,7 @@ def escalate_conflicts(batch_id, conflicts):
             subject=f"Direct Debit Batch Conflicts - {batch_id}",
             message=escalation_message,
             delayed=False,
+            notification_key="sepa_batch_error",
         )
 
     # Update batch status

--- a/verenigingen/verenigingen_payments/api/dd_batch_scheduler.py
+++ b/verenigingen/verenigingen_payments/api/dd_batch_scheduler.py
@@ -384,7 +384,11 @@ def send_batch_creation_notification(result):
         email_service = get_email_service()
         for manager in finance_managers:
             email_service.send_simple_email(
-                recipients=[manager.email], subject=subject, message=message, delayed=False
+                recipients=[manager.email],
+                subject=subject,
+                message=message,
+                delayed=False,
+                notification_key="sepa_batch_scheduler_alert",
             )
 
     except Exception as e:

--- a/verenigingen/verenigingen_payments/api/sepa_batch_notifications.py
+++ b/verenigingen/verenigingen_payments/api/sepa_batch_notifications.py
@@ -352,6 +352,7 @@ def test_notification_system():
             subject_override=subject,
             reference_doctype=None,
             reference_name=None,
+            notification_key="email_template_test",
         )
 
         return {

--- a/verenigingen/verenigingen_payments/core/security/mollie_security_manager.py
+++ b/verenigingen/verenigingen_payments/core/security/mollie_security_manager.py
@@ -375,6 +375,7 @@ class MollieSecurityManager:
                         <p>Please investigate this security incident immediately.</p>
                         """,
                         now=True,
+                        notification_key="mollie_security_alert",
                     )
             except Exception as e:
                 frappe.log_error(f"Failed to send security alert email: {str(e)}", "Mollie Security")

--- a/verenigingen/verenigingen_payments/monitoring/balance_monitor.py
+++ b/verenigingen/verenigingen_payments/monitoring/balance_monitor.py
@@ -455,6 +455,7 @@ class BalanceMonitor:
 
                 Please review immediately.
                 """,
+                notification_key="balance_monitor_alert",
             )
 
             # Send realtime notification

--- a/verenigingen/verenigingen_payments/services/sepa_batch_processor.py
+++ b/verenigingen/verenigingen_payments/services/sepa_batch_processor.py
@@ -646,6 +646,7 @@ class SEPABatchProcessor:
                 message=message,
                 reference_doctype="Membership Dues Schedule",
                 reference_name=schedule.name,
+                notification_key="payment_failure_final",
             )
 
         except Exception:

--- a/verenigingen/verenigingen_payments/utils/sepa_notification_manager.py
+++ b/verenigingen/verenigingen_payments/utils/sepa_notification_manager.py
@@ -594,6 +594,7 @@ Generated at: {timestamp}
                 message=content["message"],
                 reference_doctype=context.get("reference_doctype"),
                 reference_name=context.get("reference_name"),
+                notification_key=context.get("notification_key", "sepa_member_pre_notification"),
             )
 
             return {"success": True, "recipients_count": len(recipients)}

--- a/verenigingen/verenigingen_payments/utils/sepa_rollback_manager.py
+++ b/verenigingen/verenigingen_payments/utils/sepa_rollback_manager.py
@@ -890,6 +890,7 @@ class SEPARollbackManager:
                         message=message,
                         reference_doctype="Direct Debit Batch",
                         reference_name=operation.batch_name,
+                        notification_key="sepa_batch_error",
                     )
                 except Exception as e:
                     frappe.logger().warning(f"Failed to send notification to {recipient}: {str(e)}")

--- a/verenigingen/web_form/donation_form/donation_form.py
+++ b/verenigingen/web_form/donation_form/donation_form.py
@@ -245,6 +245,7 @@ def send_donation_confirmation(donation):
                 message=get_confirmation_email_content(donation, donor),
                 reference_doctype="Donation",
                 reference_name=donation.name,
+                notification_key="donation_confirmation",
             )
     except Exception as e:
         frappe.log_error(f"Failed to send donation confirmation: {str(e)}", "Donation Email Error")
@@ -314,6 +315,7 @@ def send_periodic_agreement_info(donor_name, agreement_name):
                 """,
                 reference_doctype="Periodic Donation Agreement",
                 reference_name=agreement.name,
+                notification_key="periodic_donation_confirmation",
             )
     except Exception as e:
         frappe.log_error(f"Failed to send agreement info: {str(e)}", "Agreement Email Error")

--- a/verenigingen/web_form/periodic_donation_agreement_form/periodic_donation_agreement_form.py
+++ b/verenigingen/web_form/periodic_donation_agreement_form/periodic_donation_agreement_form.py
@@ -278,6 +278,7 @@ def send_agreement_submission_confirmation(agreement):
                 message=get_submission_email_content(agreement, donor),
                 reference_doctype="Periodic Donation Agreement",
                 reference_name=agreement.name,
+                notification_key="periodic_donation_confirmation",
             )
     except Exception as e:
         frappe.log_error(f"Failed to send submission confirmation: {str(e)}", "Agreement Email Error")


### PR DESCRIPTION
## Summary
- Added `notification_key` parameter to all ~48 email calls enabling central configuration control
- Added ~25 new notification keys to the registry with proper metadata (category, priority, recipient_policy)
- Standardized and documented canonical suppression flags (`suppress_notifications`, `suppress_chapter_notifications`)
- Removed redundant flag checks in `_is_suppressed()`

## Changes by Phase

**Phase 1:** ChapterJoinRequest, contact request, SEPA batch processor notifications
**Phase 2:** Donation emails, alerts, monitoring, payment modules  
**Phase 2.5:** Complete migration of all remaining email calls
**Phase 3:** Standardize and document suppression flag names

## Test plan
- [ ] Verify email notifications still work for chapter join requests
- [ ] Verify donation confirmation emails are sent correctly
- [ ] Verify bulk operations properly suppress notifications
- [ ] Verify notification registry contains all expected keys