### PR TITLE
docs(notifications): add naming convention and registry validation

### DIFF
--- a/verenigingen/notification_registry.py
+++ b/verenigingen/notification_registry.py
@@ -21,6 +21,23 @@ Adding new notification keys:
     1. Add the key to NOTIFICATION_KEYS below with all required fields
     2. Use the key in your code with notification_key="your_key"
     3. Run "Sync Registry" in Email Configuration to add it to the database
+
+Naming Convention:
+    Keys follow the pattern: {entity}_{action}[_{qualifier}]
+
+    Examples:
+        - member_activated          (entity: member, action: activated)
+        - member_application_approved (entity: member_application, action: approved)
+        - payment_alert_overpayment (entity: payment_alert, action: overpayment)
+        - sepa_batch_scheduler_alert (entity: sepa_batch_scheduler, action: alert)
+
+    Guidelines:
+        - Use snake_case for all keys
+        - Start with the entity/domain (member, payment, chapter, sepa, etc.)
+        - End with the action or event (activated, submitted, approved, alert, etc.)
+        - Use past tense for completed events (activated, approved, rejected)
+        - Use present tense for ongoing states (alert, reminder, notification)
+        - Keep keys concise but descriptive (aim for 2-4 words)
 """
 
 # Category constants for consistency

--- a/verenigingen/services/communication/email_service.py
+++ b/verenigingen/services/communication/email_service.py
@@ -456,6 +456,9 @@ class EmailService(StatelessService):
 
                 # Check notification-specific settings if key provided
                 if notification_key:
+                    # Validate notification_key exists in registry
+                    self._validate_notification_key(notification_key)
+
                     if not config_service.is_notification_enabled(notification_key):
                         self.logger.info(f"Notification '{notification_key}' disabled in Email Configuration")
                         return create_service_result(
@@ -666,6 +669,34 @@ class EmailService(StatelessService):
                     config_service.record_send(notification_key, recipient)
         except Exception as e:
             self.logger.debug(f"Cooldown recording failed: {e}")
+
+    def _validate_notification_key(self, notification_key: str) -> bool:
+        """Validate that a notification_key exists in the registry.
+
+        Logs a warning if the key is not found but does not raise an exception.
+        This allows emails to still be sent while alerting developers to add
+        missing keys to the registry.
+
+        Args:
+            notification_key: The notification type key to validate.
+
+        Returns:
+            True if key exists in registry, False otherwise.
+        """
+        try:
+            from verenigingen.notification_registry import NOTIFICATION_KEYS
+
+            if notification_key not in NOTIFICATION_KEYS:
+                self.logger.warning(
+                    f"notification_key '{notification_key}' not found in NOTIFICATION_KEYS registry. "
+                    f"Add it to verenigingen/notification_registry.py for proper configuration control. "
+                    f"Email will still be sent."
+                )
+                return False
+            return True
+        except ImportError:
+            # Registry module not available - skip validation
+            return True
 
     def _get_template(self, template_name: str) -> Optional[Dict[str, Any]]:
         """Load email template with bounded caching."""


### PR DESCRIPTION
## Summary
Follow-up to PR #6 code quality review addressing issues 1-6.

## Changes

### 1. Document notification_key naming convention
Added to `notification_registry.py` module docstring:
- Pattern: `{entity}_{action}[_{qualifier}]`
- Guidelines for snake_case, entity prefixes, action suffixes
- Examples showing proper key naming

### 2. Add registry validation in EmailService
New `_validate_notification_key()` method:
- Logs warning if key not found in `NOTIFICATION_KEYS`
- Non-blocking: emails still send but developers are alerted
- Graceful fallback if registry module unavailable

## Issues Addressed
| # | Issue | Resolution |
|---|-------|------------|
| 1 | PLAN.md committed | Already removed (not on develop) |
| 2 | Naming convention | ✅ Documented in registry |
| 3 | Missing keys | Already existed in registry |
| 4 | Duplicate usage | Informational only (correct) |
| 5 | Import locations | Pattern is intentional for graceful fallback |
| 6 | No validation | ✅ Added warning-level validation |

## Test plan
- [ ] Verify email sending still works with valid notification_key
- [ ] Verify warning is logged for unknown notification_key
- [ ] Verify naming convention documentation is clear