### PR TITLE
fix(mijnrood-sync): non-Admin dues-rate sync + log_error arg order

### DIFF
--- a/verenigingen/mijnrood_sync/services/event_application/related_records_orchestrator.py
+++ b/verenigingen/mijnrood_sync/services/event_application/related_records_orchestrator.py
@@ -121,8 +121,8 @@ class MijnRoodRelatedRecordsOrchestrator:
         except Exception as e:
             self.logger.error("Address creation failed for %s: %s", member_name, e)
             frappe.log_error(
-                frappe.get_traceback(),
-                f"MijnRood Sync - Address Creation Failed: {member_name}",
+                title=f"MijnRood Sync - Address Creation Failed: {member_name}",
+                message=frappe.get_traceback(),
             )
             return _("Address creation failed: {0}").format(str(e)[:200])
 
@@ -162,8 +162,8 @@ class MijnRoodRelatedRecordsOrchestrator:
         except Exception as e:
             self.logger.error("Mollie sync failed for %s: %s", member_name, e)
             frappe.log_error(
-                frappe.get_traceback(),
-                f"MijnRood Sync - Mollie Sync Failed: {member_name}",
+                title=f"MijnRood Sync - Mollie Sync Failed: {member_name}",
+                message=frappe.get_traceback(),
             )
             return _("Mollie sync failed: {0}").format(str(e)[:200])
 
@@ -217,7 +217,10 @@ class MijnRoodRelatedRecordsOrchestrator:
             return None
         except Exception as e:
             self.logger.error("Chapter assignment failed for %s: %s", member_name, e)
-            frappe.log_error(frappe.get_traceback(), f"MijnRood Chapter Assignment Failed: {member_name}")
+            frappe.log_error(
+                title=f"MijnRood Chapter Assignment Failed: {member_name}",
+                message=frappe.get_traceback(),
+            )
             return _("Chapter assignment error: {0}").format(str(e))
 
         if result.get("success"):
@@ -366,8 +369,8 @@ class MijnRoodRelatedRecordsOrchestrator:
         except Exception as e:
             self.logger.error("Membership creation failed for %s: %s", member_name, e)
             frappe.log_error(
-                frappe.get_traceback(),
-                f"MijnRood Sync - Membership Creation Failed: {member_name}",
+                title=f"MijnRood Sync - Membership Creation Failed: {member_name}",
+                message=frappe.get_traceback(),
             )
             return _("Membership creation failed: {0}").format(str(e)[:200])
 
@@ -424,8 +427,8 @@ class MijnRoodRelatedRecordsOrchestrator:
         except Exception as e:
             self.logger.error("Dues schedule backfill failed for %s: %s", member_doc.name, e)
             frappe.log_error(
-                frappe.get_traceback(),
-                f"MijnRood Sync - Dues Schedule Backfill Failed: {member_doc.name}",
+                title=f"MijnRood Sync - Dues Schedule Backfill Failed: {member_doc.name}",
+                message=frappe.get_traceback(),
             )
             return _("Dues schedule backfill failed: {0}").format(str(e)[:200])
 
@@ -449,13 +452,19 @@ class MijnRoodRelatedRecordsOrchestrator:
             schedule_name=schedule.name,
             new_rate=new_rate,
             reason="MijnRood sync",
+            # Security: MijnRood sync is a trusted system process running
+            # outside a permissive user context. It bypasses DocPerms like
+            # every other write in this module (event/chapter/state writes
+            # all use ignore_permissions). Data originates from the
+            # authenticated MijnRood SSH tunnel, not from end users.
+            ignore_permissions=True,
         )
 
         if not result.success:
             self.logger.error("Dues schedule update failed for %s: %s", member_name, result.message)
             frappe.log_error(
-                "; ".join(result.errors or [result.message]),
-                f"MijnRood Sync - Dues Schedule Update Failed: {member_name}",
+                title=f"MijnRood Sync - Dues Schedule Update Failed: {member_name}",
+                message="; ".join(result.errors or [result.message]),
             )
             return _("Dues schedule update failed: {0}").format(result.message[:200])
 

--- a/verenigingen/repositories/dues_schedule_repository.py
+++ b/verenigingen/repositories/dues_schedule_repository.py
@@ -655,6 +655,7 @@ class DuesScheduleRepository:
         new_rate: float,
         reason: str,
         mark_as_custom: bool = True,
+        ignore_permissions: bool = False,
     ) -> CancellationResult:
         """Update a dues schedule's rate with audit trail.
 
@@ -670,6 +671,9 @@ class DuesScheduleRepository:
             new_rate: New dues rate amount (must be non-negative)
             reason: Reason for the change (appended to notes + custom_amount_reason)
             mark_as_custom: Set uses_custom_amount=1 and record reason
+            ignore_permissions: Skip the DocPerm write check and save with
+                ignore_permissions. For trusted system callers (e.g. MijnRood
+                sync) that run outside a permissive user context.
 
         Returns:
             CancellationResult — method_used is "no_change_needed" when rates match
@@ -694,7 +698,7 @@ class DuesScheduleRepository:
             )
 
         try:
-            if not frappe.has_permission(self.doctype, "write", schedule_name):
+            if not ignore_permissions and not frappe.has_permission(self.doctype, "write", schedule_name):
                 return CancellationResult(
                     success=False,
                     schedule_name=schedule_name,
@@ -704,6 +708,14 @@ class DuesScheduleRepository:
                 )
 
             schedule = frappe.get_doc(self.doctype, schedule_name)
+            if ignore_permissions:
+                # Security: the Membership Dues Schedule controller runs a
+                # custom validate()-level permission gate
+                # (DuesSchedulePermissionService) that save(ignore_permissions=...)
+                # does NOT skip. _ignore_permissions is the per-document hook
+                # that service explicitly honours. Set only when the caller
+                # already opted into ignore_permissions (trusted system code).
+                schedule._ignore_permissions = True
             old_rate = flt(schedule.dues_rate)
 
             if old_rate == new_rate:
@@ -728,7 +740,7 @@ class DuesScheduleRepository:
                 f"{schedule.notes or ''}\n" f"[{today()}] Rate: {old_rate} → {new_rate}. {reason}"
             ).strip()
 
-            schedule.save()
+            schedule.save(ignore_permissions=ignore_permissions)
 
             frappe.logger().info(
                 "Updated schedule %s rate: %s → %s (%s)",

--- a/verenigingen/services/billing/fee_change_tracking_service.py
+++ b/verenigingen/services/billing/fee_change_tracking_service.py
@@ -46,10 +46,19 @@ class FeeChangeTrackingService(StatelessService):
         super().__init__(service_name="FeeChangeTrackingService")
 
     def update_member_dues_rate(self, schedule_doc: "Document") -> None:
-        """
-        Update the member's dues_rate field to match the schedule.
+        """Mirror the schedule's dues_rate onto the member's dues_rate field.
 
-        Uses secure operations with explicit permission validation.
+        Member.dues_rate is a denormalized copy of the active schedule rate —
+        the Member controller has no logic keyed on it. This runs as an
+        automatic consequence of an already-authorized dues schedule change
+        (the schedule's own DuesSchedulePermissionService gate ran on save),
+        so it writes the mirror directly with set_value.
+
+        It was previously routed through secure_document_operation, which
+        required the *triggering* user to hold elevated-operation privileges.
+        That silently dropped the propagation for member self-service edits
+        and for non-Admin background syncs (e.g. MijnRood) — the schedule
+        rate updated but Member.dues_rate went stale.
 
         Args:
             schedule_doc: The dues schedule document with the new rate
@@ -58,35 +67,21 @@ class FeeChangeTrackingService(StatelessService):
             return
 
         try:
-            member_doc = frappe.get_doc("Member", schedule_doc.member)
-
-            if member_doc.dues_rate == schedule_doc.dues_rate:
+            current_rate = frappe.db.get_value("Member", schedule_doc.member, "dues_rate")
+            if current_rate == schedule_doc.dues_rate:
                 return  # No change needed
 
-            member_doc.dues_rate = schedule_doc.dues_rate
-
-            # Use secure operations with explicit permission validation
-            from verenigingen.utils.secure_operations import secure_document_operation
-
-            result = secure_document_operation(
-                operation="save",
-                doc=member_doc,
-                justification=f"Update member dues rate from schedule {schedule_doc.name}",
-                required_permissions=["Member:write"],
-            )
-
-            if not result.success:
-                self.logger.error(f"Failed to update member dues rate: {'; '.join(result.errors)}")
-            else:
-                self.logger.info(
-                    f"Updated member {schedule_doc.member} dues rate to {schedule_doc.dues_rate}"
-                )
+            # Security: denormalized mirror of an already-authorized schedule
+            # change, not a user-initiated Member edit — writes the field
+            # directly like the rest of this system-triggered sync path.
+            frappe.db.set_value("Member", schedule_doc.member, "dues_rate", schedule_doc.dues_rate)
+            self.logger.info(f"Updated member {schedule_doc.member} dues rate to {schedule_doc.dues_rate}")
 
         except Exception as e:
             self.logger.error(f"Error updating member dues rate: {str(e)}")
             frappe.log_error(
-                f"Error updating member dues rate: {str(e)}",
-                "Member Dues Rate Update",
+                title="Member Dues Rate Update",
+                message=f"Error updating member dues rate: {str(e)}",
             )
 
     def handle_schedule_update(self, schedule_doc: "Document") -> None:

--- a/verenigingen/tests/payment/test_billing_service_coverage.py
+++ b/verenigingen/tests/payment/test_billing_service_coverage.py
@@ -70,11 +70,11 @@ class TestDuesScheduleAutoCreator(EnhancedTestCase):
         self.assertEqual(result, expected)
 
     def test_calculate_next_invoice_date_annual(self):
+        from frappe.utils import add_years
+
         from verenigingen.services.billing.dues_schedule_auto_creator import (
             _calculate_next_invoice_date,
         )
-
-        from frappe.utils import add_years
 
         result = getdate(_calculate_next_invoice_date("Annual"))
         expected = getdate(add_years(today(), 1))
@@ -873,6 +873,31 @@ class TestFeeChangeTrackingService(EnhancedTestCase):
         schedule = SimpleNamespace(member=None, dues_rate=25.0)
         # Should not raise
         self.svc.update_member_dues_rate(schedule)
+
+    def test_update_member_dues_rate_propagates_for_non_elevated_user(self):
+        """The schedule->member dues_rate mirror runs even when the triggering
+        user holds no elevated-operation privileges.
+
+        update_member_dues_rate is a system denormalization triggered by an
+        already-authorized dues schedule change — it must not depend on the
+        caller being trusted internal staff. Regression guard for the
+        secure_document_operation elevation gate that silently dropped the
+        propagation for member self-service edits and background syncs.
+        """
+        member = self.factory.create_member(
+            first_name="DuesMirror", last_name="Test",
+            email="dues-mirror@example.org",
+        )
+        schedule = SimpleNamespace(member=member.name, dues_rate=42.00, name="DS-TEST-001")
+
+        # Verenigingen Volunteer cannot request elevated system operations.
+        with self.as_role("Verenigingen Volunteer"):
+            self.svc.update_member_dues_rate(schedule)
+
+        self.assertEqual(
+            float(frappe.db.get_value("Member", member.name, "dues_rate")),
+            42.00,
+        )
 
     def test_handle_schedule_update_template_skips(self):
         """Template schedules skip fee tracking."""

--- a/verenigingen/tests/services/event_application/test_related_records_orchestrator.py
+++ b/verenigingen/tests/services/event_application/test_related_records_orchestrator.py
@@ -991,6 +991,44 @@ class TestUpdateExistingDuesSchedule(EnhancedTestCase):
         )
         self.assertEqual(float(new_rate), 75.00)
 
+    def test_updates_rate_as_non_admin_role(self):
+        """The MijnRood sync updates the dues rate even when the calling user
+        lacks Membership Dues Schedule write permission.
+
+        The sync is a trusted system process and bypasses DocPerms like every
+        other write in the mijnrood_sync module. Regression guard for the
+        permission-gate inconsistency in
+        DuesScheduleRepository.update_schedule_rate().
+        """
+        membership_type = self.factory.ensure_membership_type(
+            "Related Records Dues Test Type"
+        )
+        member = self.factory.create_member(
+            first_name="NonAdminRate", last_name="Test",
+            email="non-admin-rate@example.org",
+        )
+        self.addCleanup(_cleanup_member_and_customer, self, member.name)
+        self._create_active_membership(member.name, membership_type.name)
+        schedule = self._create_active_dues_schedule(
+            member.name, membership_type.name, rate=50.00
+        )
+
+        # Verenigingen Volunteer holds no write DocPerm on Membership Dues
+        # Schedule — without the orchestrator passing ignore_permissions the
+        # rate update is rejected with "Permission denied".
+        with self.as_role("Verenigingen Volunteer"):
+            result = get_related_records_orchestrator()._update_existing_dues_schedule(
+                member.name, 75.00
+            )
+
+        self.assertIsNotNone(result)
+        self.assertNotIn("failed", result.lower())
+
+        new_rate = frappe.db.get_value(
+            "Membership Dues Schedule", schedule.name, "dues_rate"
+        )
+        self.assertEqual(float(new_rate), 75.00)
+
 
 class TestCreateRelatedRecords(EnhancedTestCase):
     """Entry-point orchestrator — fans out to sub-methods per row_data shape."""


### PR DESCRIPTION
## Summary

Fixes two permission-related defects in the dues-schedule update path that surfaced while debugging a `MijnRood Sync - Dues Schedule Update Failed` Error Log entry. The MijnRood sync itself is healthy — these are latent bugs the investigation uncovered.

## Bug A — permission gate inconsistent with the rest of the sync

`related_records_orchestrator._update_existing_dues_schedule()` delegates to `DuesScheduleRepository.update_schedule_rate()`, which was the **only** write path in the `mijnrood_sync` module that did *not* bypass permissions — it gated on `frappe.has_permission()` and `schedule.save()` while every other write (event/chapter/state) uses `ignore_permissions=True`.

Result: a non-Admin-triggered sync (e.g. manual *batch apply* by a non-`System Manager`) updated address/Mollie/membership but **failed the dues-rate update with "Permission denied"** — a silent partial sync.

- `update_schedule_rate()` gains an `ignore_permissions` flag — skips the `has_permission` check, passes it to `schedule.save()`, and sets `schedule._ignore_permissions` so the `Membership Dues Schedule` controller's **custom `validate()`-level gate** (`DuesSchedulePermissionService`) is also bypassed. `save(ignore_permissions=True)` alone does not skip that gate.
- `_update_existing_dues_schedule()` now passes `ignore_permissions=True`.

## Bug B — `frappe.log_error()` argument order

All 6 `frappe.log_error()` calls in the orchestrator used the old positional `(message, title)` order; modern Frappe is `log_error(title, message)`. When the message was a short single line (the dues-update failure), Frappe's heuristic mis-assigned it and produced **swapped Error Log entries**. Now all use explicit `title=`/`message=` keywords.

## Follow-up — `FeeChangeTrackingService` elevation gate

`update_member_dues_rate()` mirrors the schedule rate onto `Member.dues_rate` via `secure_document_operation`, whose "elevated system operations" gate requires the *triggering* user to be trusted internal staff. That silently dropped the mirror for **any** non-elevated trigger — including a **member editing their own dues schedule**. `Member.dues_rate` is a plain denormalized field (no controller logic keyed on it), so it now writes directly with `frappe.db.set_value`.

## Tests

- `test_updates_rate_as_non_admin_role` — orchestrator dues-rate update as `Verenigingen Volunteer`.
- `test_update_member_dues_rate_propagates_for_non_elevated_user` — Member mirror as `Verenigingen Volunteer`.
- Both written test-first (observed RED → GREEN). Full modules: orchestrator 31/31, billing 101/101.