### PR TITLE
fix(permissions,auth): correct wrong role-name literals (audit T4.5 follow-up)

### DIFF
--- a/verenigingen/auth_hooks.py
+++ b/verenigingen/auth_hooks.py
@@ -199,8 +199,8 @@ def has_volunteer_role(user):
 
         user_roles = safe_get_roles(user)
         volunteer_roles = [
-            "Volunteer",
-            "Chapter Board Member",
+            Roles.VOLUNTEER,
+            Roles.CHAPTER_BOARD_MEMBER,
         ]
         return any(role in user_roles for role in volunteer_roles)
     except Exception as e:

--- a/verenigingen/permissions.py
+++ b/verenigingen/permissions.py
@@ -1588,7 +1588,7 @@ def update_all_chapter_board_roles():
 def _users_with_chapter_board_role():
     """Return user emails that currently hold the Chapter Board Member role."""
     rows = frappe.db.sql(
-        "SELECT parent as user_email FROM `tabHas Role` WHERE role = %s",
+        "SELECT parent as user_email FROM `tabHas Role` WHERE role = %s AND parenttype = 'User'",
         Roles.CHAPTER_BOARD_MEMBER,
         as_dict=True,
     )

--- a/verenigingen/permissions.py
+++ b/verenigingen/permissions.py
@@ -1478,9 +1478,6 @@ def assign_chapter_board_role(user_email):
         # Get user's member record
         user_member = get_member_name_for_user(user_email)
         if not user_member:
-            user_member = get_member_name_for_user(user_email)
-
-        if not user_member:
             frappe.logger().debug(f"No member record found for user {user_email}")
             return False
 
@@ -1572,21 +1569,8 @@ def update_all_chapter_board_roles():
                 success_count += 1
 
         # Also check for users who should have the role removed
-        users_with_role = frappe.db.sql(
-            """
-            SELECT parent as user_email
-            FROM `tabHas Role`
-            WHERE role = 'Chapter Board Member'
-        """,
-            as_dict=True,
-        )
-
-        for user_role in users_with_role:
-            user_email = user_role.user_email
+        for user_email in _users_with_chapter_board_role():
             user_member = get_member_name_for_user(user_email)
-            if not user_member:
-                user_member = get_member_name_for_user(user_email)
-
             if user_member:
                 board_positions = get_user_chapter_board_positions(user_member)
                 if not board_positions:
@@ -1599,6 +1583,16 @@ def update_all_chapter_board_roles():
     except Exception as e:
         frappe.log_error(f"Error updating all chapter board roles: {str(e)}")
         return 0
+
+
+def _users_with_chapter_board_role():
+    """Return user emails that currently hold the Chapter Board Member role."""
+    rows = frappe.db.sql(
+        "SELECT parent as user_email FROM `tabHas Role` WHERE role = %s",
+        Roles.CHAPTER_BOARD_MEMBER,
+        as_dict=True,
+    )
+    return [r.user_email for r in rows]
 
 
 def get_volunteer_permission_query(user):

--- a/verenigingen/tests/security/test_role_name_fixes.py
+++ b/verenigingen/tests/security/test_role_name_fixes.py
@@ -1,0 +1,54 @@
+"""Tests for the role-name bug fixes surfaced by the audit T4.5 review.
+
+Two production helpers checked roles against the wrong (un-prefixed)
+role names — the canonical roles all carry a "Verenigingen " prefix:
+
+* auth_hooks.has_volunteer_role() checked "Volunteer" / "Chapter Board
+  Member" — neither role exists, so it always returned False.
+* permissions.update_all_chapter_board_roles() queried the Has Role
+  table for "Chapter Board Member", so its stale-role cleanup never
+  matched anyone (the role keeps the CBM role after losing the board
+  position — an over-grant).
+
+Run with:
+    bench --site veg11.veganisme.org run-tests --app verenigingen \
+        --module verenigingen.tests.security.test_role_name_fixes
+"""
+
+from verenigingen.auth_hooks import has_volunteer_role
+from verenigingen.permissions import _users_with_chapter_board_role
+from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
+from verenigingen.utils.constants import Roles
+
+
+class TestHasVolunteerRole(EnhancedTestCase):
+    """has_volunteer_role must recognise the real, prefixed volunteer roles."""
+
+    def test_recognises_verenigingen_volunteer_role(self):
+        """A user holding the 'Verenigingen Volunteer' role is volunteer-related."""
+        user = self.create_test_user_with_roles(roles=[Roles.VOLUNTEER])
+        self.assertTrue(has_volunteer_role(user.name))
+
+    def test_recognises_chapter_board_member_role(self):
+        """A chapter board member is volunteer-related."""
+        user = self.create_test_user_with_roles(roles=[Roles.CHAPTER_BOARD_MEMBER])
+        self.assertTrue(has_volunteer_role(user.name))
+
+    def test_plain_member_is_not_volunteer(self):
+        """A user with only the Member role is not volunteer-related."""
+        user = self.create_test_user_with_roles(roles=[Roles.VERENIGINGEN_MEMBER])
+        self.assertFalse(has_volunteer_role(user.name))
+
+
+class TestUsersWithChapterBoardRole(EnhancedTestCase):
+    """_users_with_chapter_board_role must find users holding the CBM role."""
+
+    def test_finds_user_holding_the_role(self):
+        """A user granted the canonical CBM role is returned by the helper."""
+        user = self.create_test_user_with_roles(roles=[Roles.CHAPTER_BOARD_MEMBER])
+        self.assertIn(user.name, _users_with_chapter_board_role())
+
+    def test_excludes_user_without_the_role(self):
+        """A user without the CBM role is not returned."""
+        user = self.create_test_user_with_roles(roles=[Roles.VERENIGINGEN_MEMBER])
+        self.assertNotIn(user.name, _users_with_chapter_board_role())


### PR DESCRIPTION
## Summary

Follow-up to PR #41 — the T4.5 double review surfaced two production helpers that checked roles against **un-prefixed role names**. Every canonical role in this app carries a `Verenigingen ` prefix (confirmed in `fixtures/role.json`), so these checks silently never matched. Both are real latent bugs; each fix is a behaviour change, so each is covered by a TDD test.

## Bugs fixed

### 1. `auth_hooks.has_volunteer_role()` — always returned `False`
Checked `["Volunteer", "Chapter Board Member"]` — neither role exists. A genuine volunteer or chapter board member was never recognised as volunteer-related. Now checks `Roles.VOLUNTEER` / `Roles.CHAPTER_BOARD_MEMBER`. (Used by the post-login redirect and `get_default_home_page`.)

### 2. `permissions.update_all_chapter_board_roles()` — stale roles never cleaned up
The cleanup query asked `Has Role` for role `'Chapter Board Member'` (missing the prefix), so it matched nobody — a user **kept the Chapter Board Member role after losing their board position** (an over-grant). The query is extracted into a testable helper `_users_with_chapter_board_role()` and now uses `Roles.CHAPTER_BOARD_MEMBER` as a bound parameter.

### 3. Dead code
Removed an `if not x: x = <identical call>` no-op duplicate `get_member_name_for_user()` call in both `assign_chapter_board_role()` and `update_all_chapter_board_roles()`.

## Verification (TDD)

`tests/security/test_role_name_fixes.py` (new, 5 tests):
- **RED confirmed first** — volunteer/board users not recognised by `has_volunteer_role`; `_users_with_chapter_board_role()` returned `[]` for a user holding the CBM role.
- **GREEN after fix** — 5/5 pass.

`test_has_volunteer_role_with_invalid_user` (existing) — passes.

`ruff check` clean; `compileall` clean.

### Pre-existing failures (NOT caused by this PR)
`test_auth_hooks_security` has 5 failures in unrelated code paths (`before_request`/session creation/`get_default_home_page` with an *invalid* user/API-security) caused by an environmental `frappe.local.request` `AttributeError`. My change to `has_volunteer_role` only alters behaviour for users *holding* a volunteer role — invalid users hit the guard clause and return `False` either way. (Also: a stale `Customer 'Test Member1'` row was blocking the member factory in that module; cleared during testing.)