### PR TITLE
refactor(mollie): consolidate subscription create/cancel onto one SDK path (Phase 1)

### DIFF
--- a/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
+++ b/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
@@ -95,15 +95,56 @@ subscription") and removes the only behavioural reason the legacy path exists.
 Each phase is its own double-reviewed PR.
 
 ### Phase 1 — collapse the two bottom-level implementations
-- Add IBAN-based mandate provisioning to `CompletePaymentService`'s create
-  flow (§3).
-- Re-point `MollieGateway.create_subscription` / `cancel_subscription` to
-  `CompletePaymentService` / `MollieClient`, preserving `MollieGateway`'s
-  current dict return shape and Member updates at the gateway boundary.
-- Delete `MollieSettings.create_subscription` / `cancel_subscription`.
-- Delete the dead+broken `SubscriptionService.create_membership_subscription`
-  / `create_donation_subscription`.
-- Net: one SDK path.
+
+Branch: `refactor/mollie-subscription-consolidation-phase1` (this doc lives
+there). TDD each step — payment code.
+
+Precise task list:
+
+1. **`mollie/core/client.py` `MollieClient`** — add
+   `create_mandate(customer_id, mandate_data)` wrapping
+   `customer.mandates.create(data=mandate_data)` (same error-handling shape
+   as the existing `create_subscription`).
+2. **`mollie/services/complete_payment_service.py`
+   `create_customer_subscription`** — opt-in mandate provisioning: when
+   `subscription_data` carries a truthy `consumerAccount`, build the legacy
+   mandate payload and provision a mandate before creating the subscription,
+   then strip `consumerAccount` from `subscription_data`. Legacy payload
+   shape (from the soon-deleted `MollieSettings.create_subscription`):
+   ```python
+   mandate_data = {
+       "method": "directdebit",
+       "consumerName": customer_data.get("name", ""),
+       "consumerAccount": subscription_data["consumerAccount"],
+       "signatureDate": frappe.utils.today(),
+       "mandateReference": f"MANDATE-{frappe.utils.random_string(8)}",
+   }
+   ```
+3. **`verenigingen_payments/utils/payment_gateways.py`
+   `MollieGateway.create_subscription`** — replace
+   `self.settings.create_subscription(customer_data, mollie_subscription_data)`
+   with `CompletePaymentService().create_customer_subscription(...)`. NOTE the
+   return-shape difference: `CompletePaymentService` returns
+   `subscription_status` (not `status` — its `status` key is the literal
+   `"success"`). Map `result["subscription_status"]` onto the member's
+   `subscription_status` field.
+4. **`MollieGateway.cancel_subscription`** — replace
+   `self.settings.cancel_subscription(...)` (returns `bool`) with
+   `MollieClient().cancel_subscription(customer_id, subscription_id)` (returns
+   the cancelled object, *raises* on failure). Adapt: success path on no
+   exception; the `except` already handles failure.
+5. **Delete** `MollieSettings.create_subscription` and `cancel_subscription`
+   (keep `get_subscription`, `create_customer`, etc.).
+6. **Delete** `SubscriptionService.create_membership_subscription`,
+   `create_donation_subscription`, and their now-orphaned private helpers —
+   all used only by those two: `_ensure_customer_exists`,
+   `_ensure_donor_customer_exists`, `_has_valid_mandate`, `_get_webhook_url`,
+   `_update_member_subscription_info`, `_update_donor_subscription_info`.
+   KEEP `cancel_subscription` and `_update_*_subscription_canceled` (live).
+7. **Tests** — `MollieGateway` create/cancel currently has zero coverage; add
+   TDD tests: create-with-IBAN provisions a mandate, create-without does not,
+   cancel.
+- Net: one SDK path (`MollieClient`).
 
 ### Phase 2 — standardise the mid-level contract
 - Make row locking mandatory on every create path (port the

--- a/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
+++ b/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
@@ -154,6 +154,22 @@ Precise task list:
 - Service layer always updates the owning Member/Donor record on create and
   cancel (eliminate the "caller is responsible" gaps).
 - One result dataclass / shape for create and for cancel.
+- **`enable_subscriptions` gate lives only at the caller.** After Phase 1
+  the gate survives because `MollieGateway.create_subscription` checks
+  `settings.enable_subscriptions` itself, but `CompletePaymentService.`
+  `create_customer_subscription` — the consolidation target — has no such
+  check. Any caller wired straight to the service (e.g. the Phase 3 debug
+  service) would bypass the gate. Phase 2 should move the check into the
+  standardised create contract. (Found during Phase 1 review.)
+- **Customer resolution is Donor-only today.** `CompletePaymentService.`
+  `_create_or_get_customer` resolves the Mollie customer by looking up a
+  `Donor` on `donor_email`. After Phase 1, `MollieGateway` (membership dues)
+  routes through this method, so a member whose email matches a `Donor` row
+  binds the membership subscription to that Donor's Mollie customer and
+  writes `mollie_customer_id` back onto the Donor. The legacy path always
+  created a fresh Mollie customer. Phase 2 must make customer resolution
+  owner-aware (Member vs Donor) so each owning DocType resolves against its
+  own record. (Found during Phase 1 review; deferred here by decision.)
 
 ### Phase 3 — fold in the debug-service paths
 - Route `MollieDebugService.create_subscription` / `admin_cancel_subscription`

--- a/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
+++ b/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
@@ -1,0 +1,137 @@
+# Consolidate Mollie subscription create/cancel logic
+
+**Date:** 2026-05-18
+**Status:** Design — phased implementation
+**Context:** Audit T4.4 follow-up. Retiring `MollieConnector` (PR #44) unblocked this.
+
+## 1. Problem
+
+Mollie subscription create/cancel is fragmented. A full call-graph trace found
+**two genuinely-independent bottom-level SDK implementations** and **six
+mid-level wrappers** that delegate to them inconsistently.
+
+### Bottom-level (real SDK calls)
+
+| Impl | Location | Behaviour |
+|------|----------|-----------|
+| **Modern** | `mollie/core/client.py` `MollieClient.create_subscription` / `cancel_subscription` | thin SDK wrapper; customer must pre-exist; returns the SDK object; raises `MolliePaymentError` |
+| **Legacy** | `doctype/mollie_settings/mollie_settings.py` `create_subscription` / `cancel_subscription` | creates customer + (optionally) a SEPA **mandate from an IBAN** + subscription in one call; returns a dict / a bool; raises `frappe.ValidationError` |
+
+The legacy `MollieSettings` pair is called by **exactly one** consumer:
+`MollieGateway` in `verenigingen_payments/utils/payment_gateways.py`
+(lines ~574, ~653). Everything else is on the modern path.
+
+### Correction (found during Phase 1 investigation)
+
+`SubscriptionService.create_membership_subscription` /
+`create_donation_subscription` are **dead and broken**: they have zero
+callers and they call `MollieClient.create_subscription` with keyword
+args (`amount=`, `interval=`, …) while that method's signature is
+`(customer_id, subscription_data: dict)` — any call would `TypeError`.
+They are NOT a usable "modern path". `SubscriptionService` is only
+reached for `cancel_subscription` / status / payment-processing.
+
+The genuinely-working modern create service is
+**`CompletePaymentService.create_customer_subscription(customer_data,
+subscription_data)`** — same call shape as the legacy `MollieSettings`
+path, and it calls `MollieClient.create_subscription` correctly. The
+consolidation target is therefore `CompletePaymentService`, not
+`SubscriptionService`; and the dead `SubscriptionService.create_*`
+methods are deleted as part of this work.
+
+### Mid-level wrappers and their divergences
+
+`SubscriptionService`, `CompletePaymentService`, `MollieGateway`,
+`MollieSubscriptionSyncService`, `MollieDebugService`. They differ on:
+
+- **Row locking** — `SubscriptionService` and `CompletePaymentService` take
+  `SELECT … FOR UPDATE` on Member/Donor; `MollieGateway` and the sync service
+  do not (duplicate-subscription race risk).
+- **Mandate validation** — `SubscriptionService` requires a valid SEPA mandate;
+  `MollieGateway` creates one from IBAN; `CompletePaymentService` requires one
+  to pre-exist; others do nothing.
+- **DocType updates** — some update Member/Donor on create *and* cancel; some
+  update nothing and rely on the caller.
+- **Return shape** — subscription object vs `dict` vs `bool`.
+
+## 2. Target architecture
+
+```
+leaf callers (whitelisted endpoints, templates, Member controller)
+        │
+        ▼
+mid-level services  ──  one standard contract:
+  SubscriptionService           - takes row lock
+  CompletePaymentService        - validates / provisions mandate
+  MollieSubscriptionSyncService - owns the DocType updates
+  MollieDebugService            - returns a uniform result shape
+        │
+        ▼
+one bottom-level: MollieClient.create_subscription / cancel_subscription
+        │
+        ▼
+mollie SDK
+```
+
+**One bottom-level implementation** (`MollieClient`). **One mid-level contract:**
+every create/cancel path locks the row, reconciles the mandate, updates the
+owning DocType, and returns the same result shape.
+
+## 3. Key design decision — mandate reconciliation
+
+The legacy path's one capability the modern path lacks: **creating a SEPA
+mandate from an IBAN** when none exists. To delete the legacy path without
+regressing `MollieGateway`, that capability must live on the modern path.
+
+**Decision:** add an explicit, opt-in mandate-provisioning step to the modern
+create flow — `CompletePaymentService.create_customer_subscription` gains an
+optional IBAN/`consumerAccount` input; when supplied and no usable mandate
+exists, it provisions one via the SDK before creating the subscription. This
+keeps mandate provisioning explicit (not a hidden side effect of "create
+subscription") and removes the only behavioural reason the legacy path exists.
+
+## 4. Phased plan
+
+Each phase is its own double-reviewed PR.
+
+### Phase 1 — collapse the two bottom-level implementations
+- Add IBAN-based mandate provisioning to `CompletePaymentService`'s create
+  flow (§3).
+- Re-point `MollieGateway.create_subscription` / `cancel_subscription` to
+  `CompletePaymentService` / `MollieClient`, preserving `MollieGateway`'s
+  current dict return shape and Member updates at the gateway boundary.
+- Delete `MollieSettings.create_subscription` / `cancel_subscription`.
+- Delete the dead+broken `SubscriptionService.create_membership_subscription`
+  / `create_donation_subscription`.
+- Net: one SDK path.
+
+### Phase 2 — standardise the mid-level contract
+- Make row locking mandatory on every create path (port the
+  `SELECT … FOR UPDATE` pattern into `CompletePaymentService` and the sync
+  service create path).
+- Single mandate-validation helper used by all create paths.
+- Service layer always updates the owning Member/Donor record on create and
+  cancel (eliminate the "caller is responsible" gaps).
+- One result dataclass / shape for create and for cancel.
+
+### Phase 3 — fold in the debug-service paths
+- Route `MollieDebugService.create_subscription` / `admin_cancel_subscription`
+  through the standardised services so the admin tooling cannot drift.
+
+## 5. Risks & test strategy
+
+- **Payment code** — behaviour regressions here are high-impact. Every phase is
+  TDD: a failing test for the behaviour first, then the change.
+- **Mandate semantics** — Phase 1's reconciliation is the riskiest step; it gets
+  explicit tests for "mandate exists" and "mandate provisioned from IBAN".
+- **Test gap** — there are currently no tests for `MollieGateway`,
+  `MollieSettings.create/cancel_subscription`, or the public API endpoints.
+  Phase 1 adds coverage for the `MollieGateway` path as part of the change.
+- Each phase keeps the public whitelisted endpoints' signatures stable.
+
+## 6. Out of scope
+
+- `payment_gateways.py` is also audit item T4.7 (god-module split); this
+  consolidation touches only its subscription methods, not the split.
+- A separate "payments v2" migration effort is in progress; subscriptions are
+  not part of payments v2 today, so this consolidation is orthogonal to it.

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -1,0 +1,455 @@
+"""
+Tests for the Mollie subscription create/cancel consolidation (Phase 1).
+
+Phase 1 collapses the two bottom-level subscription implementations onto a
+single SDK path (``MollieClient``). See
+``docs/plans/2026-05-18-mollie-subscription-consolidation-design.md``.
+
+The Mollie SDK is the external boundary; it is replaced here by ``FakeSDKClient``
+so tests never touch the live Mollie API. Everything below the SDK is exercised
+for real.
+"""
+
+from unittest.mock import patch
+
+import frappe
+
+from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
+from verenigingen.verenigingen_payments.mollie.core.client import MollieClient
+from verenigingen.verenigingen_payments.mollie.exceptions import MolliePaymentError
+from verenigingen.verenigingen_payments.mollie.services.complete_payment_service import (
+    CompletePaymentService,
+)
+
+# ---------------------------------------------------------------------------
+# Fake Mollie SDK client
+#
+# Mock justified: the Mollie SDK is a third-party HTTP client for an external
+# payment API. It cannot be exercised in tests. This fake records the calls
+# made against it so behaviour can be asserted; it mimics only the small slice
+# of the SDK surface the subscription code touches.
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Collects the SDK calls made during a test."""
+
+    def __init__(self):
+        self.customers_created = []
+        self.customers_fetched = []
+        self.mandates_created = []
+        self.subscriptions_created = []
+        self.subscriptions_deleted = []
+
+
+class _FakeMandate:
+    def __init__(self, mandate_id="mdt_FAKE", status="valid"):
+        self.id = mandate_id
+        self.status = status
+
+
+class _FakeSubscription:
+    def __init__(self, subscription_id="sub_FAKE", status="active",
+                 next_payment_date="2026-06-01"):
+        self.id = subscription_id
+        self.status = status
+        self.next_payment_date = next_payment_date
+        self.canceled_at = None
+        self.cancelled_at = None
+
+
+class _FakeMandates:
+    def __init__(self, recorder, raises=False):
+        self._recorder = recorder
+        self._raises = raises
+
+    def create(self, data=None):
+        if self._raises:
+            raise RuntimeError("simulated Mollie mandate failure")
+        self._recorder.mandates_created.append(data)
+        return _FakeMandate()
+
+    def list(self):
+        return []
+
+
+class _FakeSubscriptions:
+    def __init__(self, recorder, sub_status):
+        self._recorder = recorder
+        self._sub_status = sub_status
+
+    def create(self, data=None):
+        self._recorder.subscriptions_created.append(data)
+        return _FakeSubscription(status=self._sub_status)
+
+    def delete(self, subscription_id):
+        self._recorder.subscriptions_deleted.append(subscription_id)
+        return _FakeSubscription(subscription_id=subscription_id, status="canceled")
+
+
+class _FakeCustomer:
+    def __init__(self, recorder, customer_id, sub_status, mandate_raises):
+        self.id = customer_id
+        self.mandates = _FakeMandates(recorder, raises=mandate_raises)
+        self.subscriptions = _FakeSubscriptions(recorder, sub_status)
+
+
+class _FakeCustomers:
+    def __init__(self, recorder, sub_status, mandate_raises):
+        self._recorder = recorder
+        self._sub_status = sub_status
+        self._mandate_raises = mandate_raises
+        self._counter = 0
+
+    def create(self, data=None):
+        self._recorder.customers_created.append(data)
+        self._counter += 1
+        return _FakeCustomer(
+            self._recorder, f"cst_FAKE{self._counter}", self._sub_status, self._mandate_raises
+        )
+
+    def get(self, customer_id):
+        self._recorder.customers_fetched.append(customer_id)
+        return _FakeCustomer(self._recorder, customer_id, self._sub_status, self._mandate_raises)
+
+
+class FakeSDKClient:
+    """Stand-in for ``mollie.api.client.Client``."""
+
+    def __init__(self, sub_status="active", mandate_raises=False):
+        self.recorder = _Recorder()
+        self.customers = _FakeCustomers(self.recorder, sub_status, mandate_raises)
+
+
+class _RaisingCustomers:
+    def get(self, customer_id):
+        raise RuntimeError("simulated Mollie API failure")
+
+    def create(self, data=None):
+        raise RuntimeError("simulated Mollie API failure")
+
+
+class RaisingSDKClient:
+    """Fake SDK whose every call raises, to test error wrapping."""
+
+    def __init__(self):
+        self.customers = _RaisingCustomers()
+
+
+def _make_mollie_client(sdk):
+    """Build a MollieClient wired to a fake SDK (no live credentials needed)."""
+    client = MollieClient(api_key="test_fake")
+    client._mollie_client = sdk
+    return client
+
+
+def _unique_email():
+    return f"mollie-consolidation-{frappe.generate_hash(length=10)}@example.com"
+
+
+class TestMollieClient(EnhancedTestCase):
+    """Phase 1, step 1 - MollieClient.create_mandate / cancel_subscription."""
+
+    def test_create_mandate_wraps_sdk_customer_mandates_create(self):
+        sdk = FakeSDKClient()
+        client = _make_mollie_client(sdk)
+
+        mandate_data = {
+            "method": "directdebit",
+            "consumerName": "Jane Doe",
+            "consumerAccount": "NL39RABO0300065264",
+        }
+        result = client.create_mandate("cst_123", mandate_data)
+
+        self.assertEqual(sdk.recorder.customers_fetched, ["cst_123"])
+        self.assertEqual(sdk.recorder.mandates_created, [mandate_data])
+        self.assertEqual(result.id, "mdt_FAKE")
+
+    def test_create_mandate_wraps_sdk_errors_in_mollie_payment_error(self):
+        client = _make_mollie_client(RaisingSDKClient())
+
+        with self.assertRaises(MolliePaymentError):
+            client.create_mandate("cst_123", {"method": "directdebit"})
+
+    def test_cancel_subscription_wraps_sdk_errors_in_mollie_payment_error(self):
+        """MollieGateway.cancel_subscription relies on cancel_subscription
+        raising (rather than returning a falsy value) on SDK failure."""
+        client = _make_mollie_client(RaisingSDKClient())
+
+        with self.assertRaises(MolliePaymentError):
+            client.cancel_subscription("cst_123", "sub_123")
+
+
+class TestCompletePaymentServiceSubscription(EnhancedTestCase):
+    """Phase 1, step 2 - CompletePaymentService.create_customer_subscription."""
+
+    def test_create_customer_subscription_accepts_mollie_amount_dict_no_mandate(self):
+        """A {"value","currency"} amount (the shape Mollie's API requires) must
+        validate, and without an IBAN no mandate is provisioned."""
+        sdk = FakeSDKClient()
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        result = service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+            },
+        )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["subscription_status"], "active")
+        self.assertEqual(sdk.recorder.mandates_created, [])
+        self.assertEqual(len(sdk.recorder.subscriptions_created), 1)
+
+    def test_create_customer_subscription_strips_falsy_consumer_account(self):
+        """A falsy consumerAccount (e.g. a member without an IBAN) provisions
+        no mandate and must still be stripped from the subscription payload -
+        Mollie's subscription API rejects an unknown consumerAccount key."""
+        sdk = FakeSDKClient()
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": None,
+            },
+        )
+
+        self.assertEqual(sdk.recorder.mandates_created, [])
+        self.assertEqual(len(sdk.recorder.subscriptions_created), 1)
+        self.assertNotIn("consumerAccount", sdk.recorder.subscriptions_created[0])
+
+    def test_create_customer_subscription_provisions_mandate_from_consumer_account(self):
+        """When a consumerAccount (IBAN) is supplied, a SEPA mandate is
+        provisioned before the subscription and consumerAccount is stripped."""
+        sdk = FakeSDKClient()
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        result = service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": "NL39RABO0300065264",
+            },
+        )
+
+        self.assertEqual(result["status"], "success")
+
+        self.assertEqual(len(sdk.recorder.mandates_created), 1)
+        mandate = sdk.recorder.mandates_created[0]
+        self.assertEqual(mandate["method"], "directdebit")
+        self.assertEqual(mandate["consumerName"], "Jane Doe")
+        self.assertEqual(mandate["consumerAccount"], "NL39RABO0300065264")
+        self.assertIn("signatureDate", mandate)
+        self.assertIn("mandateReference", mandate)
+
+        # consumerAccount is mandate-only; it must not leak into the
+        # subscription create payload (Mollie's API rejects it there).
+        self.assertEqual(len(sdk.recorder.subscriptions_created), 1)
+        self.assertNotIn("consumerAccount", sdk.recorder.subscriptions_created[0])
+
+    def test_create_customer_subscription_propagates_mandate_failure(self):
+        """If mandate provisioning fails, the original mandate error must
+        surface (not be relabelled "Failed to create subscription"), and the
+        subscription must not be attempted."""
+        sdk = FakeSDKClient(mandate_raises=True)
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        with self.assertRaises(MolliePaymentError) as ctx:
+            service.create_customer_subscription(
+                {"name": "Jane Doe", "email": _unique_email()},
+                {
+                    "amount": {"value": "15.00", "currency": "EUR"},
+                    "interval": "1 month",
+                    "description": "Membership dues",
+                    "consumerAccount": "NL39RABO0300065264",
+                },
+            )
+
+        message = str(ctx.exception)
+        self.assertIn("mandate", message)
+        self.assertNotIn("Failed to create subscription", message)
+        self.assertEqual(sdk.recorder.subscriptions_created, [])
+
+
+# Patch target for the Mollie SDK boundary: every code path under test
+# ultimately gets its SDK client from MollieSettings.get_mollie_client().
+_GET_MOLLIE_CLIENT = (
+    "verenigingen.verenigingen_payments.doctype.mollie_settings."
+    "mollie_settings.MollieSettings.get_mollie_client"
+)
+# MollieClient.__init__ reads the API key directly (a separate path from
+# get_mollie_client), so it is patched too - keeps the tests independent of
+# whatever Mollie credentials happen to be configured on the test site.
+_GET_API_KEY = "verenigingen.verenigingen_payments.mollie.core.client.MollieClient._get_api_key"
+
+
+def _patch_sdk(sdk):
+    """Context manager that routes every Mollie SDK access to ``sdk``."""
+    return _MultiPatch(
+        patch(_GET_MOLLIE_CLIENT, return_value=sdk),
+        patch(_GET_API_KEY, return_value="test_fake"),
+    )
+
+
+class _MultiPatch:
+    """Apply several patch() context managers as one."""
+
+    def __init__(self, *patches):
+        self._patches = patches
+
+    def __enter__(self):
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in reversed(self._patches):
+            p.stop()
+        return False
+
+
+class TestMollieGatewaySubscription(EnhancedTestCase):
+    """Phase 1, steps 3-4 - MollieGateway.create_subscription / cancel_subscription.
+
+    These exercise the gateway end-to-end against a fake Mollie SDK. They are
+    characterization tests: confirmed green against the legacy MollieSettings
+    path before the Phase 1 refactor, and required to stay green after it.
+    """
+
+    def _make_member(self, **kwargs):
+        token = frappe.generate_hash(length=8)
+        return self.create_test_member(
+            first_name="Mollie",
+            last_name=f"Subscriber{token}",
+            email=f"mollie-gw-{token}@example.com",
+            birth_date="1990-01-01",
+            **kwargs,
+        )
+
+    def test_create_subscription_without_iban_provisions_no_mandate(self):
+        member = self._make_member()
+        sdk = FakeSDKClient()
+
+        with _patch_sdk(sdk):
+            from verenigingen.verenigingen_payments.utils.payment_gateways import MollieGateway
+
+            gateway = MollieGateway()
+            result = gateway.create_subscription(
+                member, {"amount": 15.0, "interval": "1 month"}
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["subscription_status"], "active")
+        self.assertEqual(sdk.recorder.mandates_created, [])
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "subscription_status"), "active"
+        )
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "mollie_subscription_id"), "sub_FAKE"
+        )
+        # Customer metadata must reach Mollie (legacy parity - the old path
+        # passed the whole customer_data dict, including metadata, to the SDK).
+        self.assertEqual(
+            sdk.recorder.customers_created[0]["metadata"]["member_id"], member.name
+        )
+
+    def test_create_subscription_with_iban_provisions_mandate(self):
+        member = self._make_member()
+        frappe.db.set_value(
+            "Member", member.name, "iban", "NL39RABO0300065264", update_modified=False
+        )
+        member.reload()
+        sdk = FakeSDKClient()
+
+        with _patch_sdk(sdk):
+            from verenigingen.verenigingen_payments.utils.payment_gateways import MollieGateway
+
+            gateway = MollieGateway()
+            result = gateway.create_subscription(
+                member, {"amount": 15.0, "interval": "1 month"}
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(len(sdk.recorder.mandates_created), 1)
+        self.assertEqual(
+            sdk.recorder.mandates_created[0]["consumerAccount"], "NL39RABO0300065264"
+        )
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "subscription_status"), "active"
+        )
+
+    def test_cancel_subscription_cancels_at_mollie_and_updates_member(self):
+        member = self._make_member()
+        frappe.db.set_value(
+            "Member",
+            member.name,
+            {"mollie_customer_id": "cst_LIVE", "mollie_subscription_id": "sub_LIVE"},
+            update_modified=False,
+        )
+        member.reload()
+        sdk = FakeSDKClient()
+
+        with _patch_sdk(sdk):
+            from verenigingen.verenigingen_payments.utils.payment_gateways import MollieGateway
+
+            gateway = MollieGateway()
+            result = gateway.cancel_subscription(member)
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(sdk.recorder.subscriptions_deleted, ["sub_LIVE"])
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "subscription_status"), "canceled"
+        )
+
+    def test_create_subscription_failure_returns_error_and_leaves_member_untouched(self):
+        member = self._make_member()
+
+        with _patch_sdk(RaisingSDKClient()):
+            from verenigingen.verenigingen_payments.utils.payment_gateways import MollieGateway
+
+            gateway = MollieGateway()
+            result = gateway.create_subscription(
+                member, {"amount": 15.0, "interval": "1 month"}
+            )
+
+        self.assertEqual(result["status"], "error")
+        self.assertFalse(
+            frappe.db.get_value("Member", member.name, "mollie_subscription_id")
+        )
+        self.assertFalse(
+            frappe.db.get_value("Member", member.name, "subscription_status")
+        )
+
+    def test_cancel_subscription_failure_returns_error_and_leaves_member_untouched(self):
+        member = self._make_member()
+        frappe.db.set_value(
+            "Member",
+            member.name,
+            {
+                "mollie_customer_id": "cst_LIVE",
+                "mollie_subscription_id": "sub_LIVE",
+                "subscription_status": "active",
+            },
+            update_modified=False,
+        )
+        member.reload()
+
+        with _patch_sdk(RaisingSDKClient()):
+            from verenigingen.verenigingen_payments.utils.payment_gateways import MollieGateway
+
+            gateway = MollieGateway()
+            result = gateway.cancel_subscription(member)
+
+        self.assertEqual(result["status"], "error")
+        # The cancel failed at Mollie, so the member status must NOT flip.
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "subscription_status"), "active"
+        )

--- a/verenigingen/verenigingen_payments/doctype/mollie_settings/mollie_settings.py
+++ b/verenigingen/verenigingen_payments/doctype/mollie_settings/mollie_settings.py
@@ -466,67 +466,6 @@ class MollieSettings(Document):
             frappe.log_error(f"Failed to create Mollie customer: {str(e)}", "Mollie Customer Creation")
             return {"success": False, "customer_id": None, "message": f"Customer creation failed: {str(e)}"}
 
-    def create_subscription(self, customer_data, subscription_data):
-        """
-        Create a Mollie subscription for recurring payments
-
-        Args:
-            customer_data (dict): Customer information for Mollie
-            subscription_data (dict): Subscription details
-
-        Returns:
-            dict: Mollie subscription response
-
-        Raises:
-            frappe.ValidationError: If subscription creation fails
-        """
-        if not self.enable_subscriptions:
-            frappe.throw(_("Subscriptions are not enabled for this Mollie gateway"))
-
-        try:
-            client = self.get_mollie_client()
-
-            # Create customer first (required for subscriptions)
-            customer = client.customers.create(customer_data)
-
-            # For donations, we don't need mandates - Mollie will handle payment method selection
-            # Mandates are only required for direct debit, but subscriptions can use other methods
-            mandate = None
-
-            # Only create mandate if IBAN is provided (for direct debit)
-            if subscription_data.get("consumerAccount"):
-                mandate_data = {
-                    "method": "directdebit",
-                    "consumerName": customer_data.get("name", ""),
-                    "consumerAccount": subscription_data.get("consumerAccount"),
-                    "signatureDate": frappe.utils.today(),
-                    "mandateReference": f"MANDATE-{frappe.utils.random_string(8)}",
-                }
-                mandate = customer.mandates.create(data=mandate_data)
-
-            # Remove consumerAccount from subscription_data (only needed for mandate)
-            subscription_data_clean = {k: v for k, v in subscription_data.items() if k != "consumerAccount"}
-
-            # Create subscription - Mollie will prompt for payment method during first payment
-            subscription = customer.subscriptions.create(data=subscription_data_clean)
-
-            result = {
-                "customer_id": customer.id,
-                "subscription_id": subscription.id,
-                "status": subscription.status,
-                "next_payment_date": subscription.next_payment_date,
-            }
-
-            # Only include mandate_id if mandate was created
-            if mandate:
-                result["mandate_id"] = mandate.id
-
-            return result
-
-        except Exception as e:
-            frappe.log_error(f"Error creating Mollie subscription: {str(e)}", "Mollie Subscription Error")
-            frappe.throw(_("Failed to create subscription: {0}").format(str(e)))
-
     def get_subscription(self, customer_id, subscription_id):
         """
         Get subscription details from Mollie
@@ -541,7 +480,7 @@ class MollieSettings(Document):
         try:
             client = self.get_mollie_client()
             customer = client.customers.get(customer_id)
-            subscription = customer.subscriptions.get(subscription_id)
+            subscription = customer.subscriptions.get(subscription_id)  # ast-skip: Mollie API object
 
             return {
                 "id": subscription.id,
@@ -556,31 +495,6 @@ class MollieSettings(Document):
         except Exception as e:
             frappe.log_error(f"Error fetching Mollie subscription: {str(e)}", "Mollie Subscription Fetch")
             return None
-
-    def cancel_subscription(self, customer_id, subscription_id):
-        """
-        Cancel a Mollie subscription
-
-        Args:
-            customer_id (str): Mollie customer ID
-            subscription_id (str): Mollie subscription ID
-
-        Returns:
-            bool: Success status
-        """
-        try:
-            client = self.get_mollie_client()
-            customer = client.customers.get(customer_id)
-            customer.subscriptions.delete(subscription_id)
-
-            frappe.logger().info(
-                f"Cancelled Mollie subscription {subscription_id} for customer {customer_id}"
-            )
-            return True
-
-        except Exception as e:
-            frappe.log_error(f"Error cancelling Mollie subscription: {str(e)}", "Mollie Subscription Cancel")
-            return False
 
     def update_webhook_urls(self):
         """Update webhook URL fields using MollieClient as single source of truth"""

--- a/verenigingen/verenigingen_payments/mollie/core/client.py
+++ b/verenigingen/verenigingen_payments/mollie/core/client.py
@@ -260,6 +260,29 @@ class MollieClient:
             frappe.log_error(error_msg, "Mollie Client")
             raise MolliePaymentError(error_msg, original_error=e)
 
+    def create_mandate(self, customer_id: str, mandate_data: Dict[str, Any]) -> Any:
+        """
+        Create a payment mandate (e.g. SEPA direct debit) for a customer.
+
+        Args:
+            customer_id: The Mollie customer ID
+            mandate_data: Mandate creation data
+
+        Returns:
+            Created Mollie mandate object
+
+        Raises:
+            MolliePaymentError: When the mandate cannot be created
+        """
+        try:
+            client = self._get_mollie_client()
+            customer = client.customers.get(customer_id)
+            return customer.mandates.create(data=mandate_data)
+        except Exception as e:
+            error_msg = f"Failed to create mandate for customer {customer_id}: {e}"
+            frappe.log_error(error_msg, "Mollie Client")
+            raise MolliePaymentError(error_msg, original_error=e)
+
     def list_customer_payments(self, customer_id: str, limit: int = 50) -> Any:
         """
         List payments for a customer.

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -206,13 +206,36 @@ class CompletePaymentService:
                     f"Failed to create customer for subscription: {customer_result.get('error')}"
                 )
 
-            # Create subscription (NOTE: This will fail if no mandate exists!)
-            # For recurring donations, use create_recurring_donation_payment() instead
-            # which establishes mandate first
+            customer_id = customer_result["customer_id"]
+
+            # Opt-in mandate provisioning: when an IBAN is supplied via
+            # `consumerAccount`, provision a SEPA direct-debit mandate before
+            # creating the subscription. This replaces the legacy
+            # MollieSettings.create_subscription path (which always did this)
+            # and keeps mandate provisioning an explicit, requested step
+            # rather than a hidden side effect of "create subscription".
+            consumer_account = subscription_data.get("consumerAccount")
+            if consumer_account:
+                mandate_data = {
+                    "method": "directdebit",
+                    "consumerName": customer_data.get("name", ""),
+                    "consumerAccount": consumer_account,
+                    "signatureDate": frappe.utils.today(),
+                    "mandateReference": f"MANDATE-{frappe.utils.random_string(8)}",
+                }
+                self.client.create_mandate(customer_id, mandate_data)
+
+            # consumerAccount is mandate-only input; Mollie's subscription API
+            # does not accept it, so strip it before creating the subscription
+            # (always - including the falsy "no IBAN" case).
+            if "consumerAccount" in subscription_data:
+                subscription_data = {k: v for k, v in subscription_data.items() if k != "consumerAccount"}
+
+            # Create subscription. Without a mandate (no consumerAccount and
+            # none established via a sequenceType="first" payment) Mollie
+            # rejects this with "No suitable mandates found".
             try:
-                mollie_subscription = self.client.create_subscription(
-                    customer_result["customer_id"], subscription_data
-                )
+                mollie_subscription = self.client.create_subscription(customer_id, subscription_data)
             except Exception as e:
                 if "No suitable mandates found" in str(e):
                     raise MolliePaymentError(
@@ -234,6 +257,11 @@ class CompletePaymentService:
                 "message": "Subscription created successfully",
             }
 
+        except MolliePaymentError:
+            # Already a specific Mollie error (e.g. mandate provisioning or the
+            # subscription create itself) - propagate it without relabelling it
+            # as a generic "Failed to create subscription".
+            raise
         except Exception as e:
             error_msg = f"Failed to create subscription: {e}"
             frappe.log_error(error_msg, "Subscription Creation Error")
@@ -349,10 +377,19 @@ class CompletePaymentService:
         if not subscription_data.get("amount"):
             raise MollieValidationError("Subscription amount is required")
 
-        # Validate amount using centralized validation
+        # Mollie's subscription API requires `amount` as a {"value", "currency"}
+        # dict, so callers pass that shape. Validate the numeric value out of it
+        # (a bare scalar is also accepted for backward compatibility).
+        amount = subscription_data["amount"]
+        if isinstance(amount, dict):
+            if "value" not in amount:
+                raise MollieValidationError("Subscription amount dict must contain a 'value' key")
+            amount_value = amount["value"]
+        else:
+            amount_value = amount
         try:
-            validate_mollie_amount(subscription_data["amount"])
-        except ValueError as e:
+            validate_mollie_amount(amount_value)
+        except (ValueError, TypeError) as e:
             raise MollieValidationError(f"Invalid subscription amount: {e}") from e
 
         if not subscription_data.get("interval"):
@@ -487,6 +524,8 @@ class CompletePaymentService:
             mollie_customer_data = {"name": customer_data.get("name", ""), "email": email}
             if customer_data.get("locale"):
                 mollie_customer_data["locale"] = customer_data["locale"]
+            if customer_data.get("metadata"):
+                mollie_customer_data["metadata"] = customer_data["metadata"]
 
             customer = self.client.create_customer(mollie_customer_data)
             frappe.logger().info(f"Created new Mollie customer {customer.id}")
@@ -513,6 +552,8 @@ class CompletePaymentService:
             }
             if customer_data.get("locale"):
                 mollie_customer_data["locale"] = customer_data["locale"]
+            if customer_data.get("metadata"):
+                mollie_customer_data["metadata"] = customer_data["metadata"]
 
             customer = self.client.create_customer(mollie_customer_data)
             frappe.logger().info(f"Created new Mollie customer {customer.id} (no donor)")

--- a/verenigingen/verenigingen_payments/mollie/services/subscription_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/subscription_service.py
@@ -4,16 +4,15 @@ Mollie Subscription Service
 Business logic for managing recurring payments and subscriptions through Mollie.
 """
 
-from decimal import Decimal
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import frappe
 from frappe import _
-from frappe.utils import add_months, getdate, now_datetime
+from frappe.utils import now_datetime
 
 from ..core.client import MollieClient
-from ..core.mollie_models import Money, Subscription
-from ..exceptions import MollieIntegrationError, MollieValidationError
+from ..core.mollie_models import Subscription
+from ..exceptions import MollieIntegrationError
 from ..utils.amount_helpers import extract_amount_currency, extract_amount_float
 from ..utils.validators import PaymentDataValidator
 
@@ -38,94 +37,6 @@ class SubscriptionService:
         """
         self.client = client or MollieClient()
         self.validator = PaymentDataValidator()
-
-    def create_membership_subscription(
-        self, member_id: str, monthly_fee: Union[Decimal, float], start_date: Optional[str] = None
-    ) -> Subscription:
-        """
-        Create a recurring subscription for membership dues.
-
-        Args:
-            member_id: Frappe member document ID
-            monthly_fee: Monthly membership fee in EUR
-            start_date: Optional start date (defaults to next month)
-
-        Returns:
-            Created subscription object
-
-        Raises:
-            MollieValidationError: If subscription data is invalid
-            MollieIntegrationError: If subscription creation fails
-        """
-        # Validate member and fee
-        member = frappe.get_doc("Member", member_id)
-        if not self.validator.validate_amount(monthly_fee):
-            raise MollieValidationError(f"Invalid monthly fee: {monthly_fee}")
-
-        # Ensure member has Mollie customer ID
-        customer_id = self._ensure_customer_exists(member)
-
-        # Validate SEPA mandate if required
-        if not self._has_valid_mandate(member):
-            raise MollieValidationError(f"Member {member_id} does not have a valid SEPA mandate")
-
-        # Create subscription
-        money = Money(amount=Decimal(str(monthly_fee)), currency="EUR")
-        subscription = self.client.create_subscription(
-            customer_id=customer_id,
-            amount=money,
-            interval="1 month",
-            description=f"Membership dues - {member.first_name} {member.last_name}",
-            webhook_url=self._get_webhook_url(),
-            metadata={
-                "member_id": member_id,
-                "subscription_type": "membership_dues",
-                "start_date": start_date or str(getdate()),
-            },
-        )
-
-        # Update member record
-        self._update_member_subscription_info(member, subscription)
-
-        return subscription
-
-    def create_donation_subscription(
-        self, donor_id: str, monthly_amount: Union[Decimal, float], interval: str = "1 month"
-    ) -> Subscription:
-        """
-        Create a recurring subscription for donations.
-
-        Args:
-            donor_id: Frappe donor document ID
-            monthly_amount: Monthly donation amount in EUR
-            interval: Payment interval (e.g., "1 month", "3 months")
-
-        Returns:
-            Created subscription object
-        """
-        # Validate donor and amount
-        donor = frappe.get_doc("Donor", donor_id)
-        if not self.validator.validate_amount(monthly_amount):
-            raise MollieValidationError(f"Invalid donation amount: {monthly_amount}")
-
-        # Ensure donor has Mollie customer ID
-        customer_id = self._ensure_donor_customer_exists(donor)
-
-        # Create subscription
-        money = Money(amount=Decimal(str(monthly_amount)), currency="EUR")
-        subscription = self.client.create_subscription(
-            customer_id=customer_id,
-            amount=money,
-            interval=interval,
-            description=f"Recurring donation - {donor.donor_name}",
-            webhook_url=self._get_webhook_url(),
-            metadata={"donor_id": donor_id, "subscription_type": "recurring_donation", "interval": interval},
-        )
-
-        # Update donor record
-        self._update_donor_subscription_info(donor, subscription)
-
-        return subscription
 
     def get_subscription_status(self, customer_id: str, subscription_id: str) -> Dict[str, Any]:
         """
@@ -250,140 +161,6 @@ class SubscriptionService:
                 frappe.log_error(f"Failed to get subscription {member.mollie_subscription_id}: {e}")
 
         return subscriptions
-
-    def _ensure_customer_exists(self, member) -> str:
-        """
-        Ensure member has a Mollie customer ID.
-        Uses row locking to prevent duplicate customer creation on concurrent requests.
-        """
-        member_name = member.name
-
-        # Use row lock to prevent race condition
-        frappe.db.begin()
-        try:
-            # Acquire row lock - other requests will wait here
-            locked_row = frappe.db.sql(
-                """
-                SELECT mollie_customer_id, first_name, last_name, email
-                FROM `tabMember` WHERE name = %s FOR UPDATE
-                """,
-                member_name,
-                as_dict=True,
-            )
-
-            if not locked_row:
-                frappe.db.commit()
-                raise ValueError(f"Member {member_name} not found")
-
-            member_data = locked_row[0]
-            existing_customer_id = member_data.get("mollie_customer_id")
-
-            # Check if customer already exists (may have been created by concurrent request)
-            if existing_customer_id:
-                frappe.db.commit()  # Release lock
-                return existing_customer_id
-
-            # Create new customer while holding the lock
-            full_name = f"{member_data.get('first_name', '')} {member_data.get('last_name', '')}".strip()
-            customer = self.client.create_customer(
-                name=full_name,
-                email=member_data.get("email"),
-                metadata={"member_id": member_name},
-            )
-
-            # Update member record while holding lock
-            frappe.db.set_value(
-                "Member", member_name, "mollie_customer_id", customer.id, update_modified=False
-            )
-            frappe.db.commit()  # Commit and release lock
-
-            return customer.id
-
-        except Exception as e:
-            frappe.db.rollback()
-            raise
-
-    def _ensure_donor_customer_exists(self, donor) -> str:
-        """
-        Ensure donor has a Mollie customer ID.
-        Uses row locking to prevent duplicate customer creation on concurrent requests.
-        """
-        donor_name = donor.name
-
-        # Use row lock to prevent race condition
-        frappe.db.begin()
-        try:
-            # Acquire row lock - other requests will wait here
-            locked_row = frappe.db.sql(
-                """
-                SELECT mollie_customer_id, donor_name, donor_email
-                FROM `tabDonor` WHERE name = %s FOR UPDATE
-                """,
-                donor_name,
-                as_dict=True,
-            )
-
-            if not locked_row:
-                frappe.db.commit()
-                raise ValueError(f"Donor {donor_name} not found")
-
-            donor_data = locked_row[0]
-            existing_customer_id = donor_data.get("mollie_customer_id")
-
-            # Check if customer already exists (may have been created by concurrent request)
-            if existing_customer_id:
-                frappe.db.commit()  # Release lock
-                return existing_customer_id
-
-            # Create new customer while holding the lock
-            customer = self.client.create_customer(
-                name=donor_data.get("donor_name") or "",
-                email=donor_data.get("donor_email"),
-                metadata={"donor_id": donor_name},
-            )
-
-            # Update donor record while holding lock
-            frappe.db.set_value("Donor", donor_name, "mollie_customer_id", customer.id, update_modified=False)
-            frappe.db.commit()  # Commit and release lock
-
-            return customer.id
-
-        except Exception as e:
-            frappe.db.rollback()
-            raise
-
-    def _has_valid_mandate(self, member) -> bool:
-        """Check if member has a valid SEPA mandate."""
-        # This would integrate with existing SEPA mandate validation
-        return bool(member.get("sepa_mandate_reference"))
-
-    def _get_webhook_url(self) -> str:
-        """Get webhook URL for subscription notifications."""
-        mollie_settings = frappe.get_single("Mollie Settings")
-        return (
-            mollie_settings.webhook_url
-            or f"{frappe.utils.get_url()}/api/method/verenigingen.verenigingen_payments.mollie.api.webhooks.handle_subscription_webhook"
-        )
-
-    def _update_member_subscription_info(self, member, subscription: Subscription):
-        """Update member record with subscription information.
-
-        Security: ignore_permissions acceptable - called from authenticated webhook or role-restricted sync API.
-        """
-        member.mollie_subscription_id = subscription.id
-        member.subscription_status = subscription.status
-        member.next_payment_date = subscription.next_payment_date
-        member.save(ignore_permissions=True)
-
-    def _update_donor_subscription_info(self, donor, subscription: Subscription):
-        """Update donor record with subscription information.
-
-        Security: ignore_permissions acceptable - called from authenticated webhook or role-restricted sync API.
-        """
-        donor.mollie_subscription_id = subscription.id
-        donor.subscription_status = subscription.status
-        donor.next_payment_date = subscription.next_payment_date
-        donor.save(ignore_permissions=True)
 
     def _update_member_subscription_canceled(self, member_id: str, subscription_id: str, reason: str):
         """Update member record when subscription is canceled.

--- a/verenigingen/verenigingen_payments/utils/payment_gateways.py
+++ b/verenigingen/verenigingen_payments/utils/payment_gateways.py
@@ -14,6 +14,10 @@ from verenigingen.utils.secure_operations import secure_document_operation
 from verenigingen.utils.security.api_security_framework import OperationType, high_security_api, public_api
 from verenigingen.utils.settings_utils import get_payments_settings
 from verenigingen.utils.validation_utilities import DocumentExistenceValidator
+from verenigingen.verenigingen_payments.mollie.core.client import MollieClient
+from verenigingen.verenigingen_payments.mollie.services.complete_payment_service import (
+    CompletePaymentService,
+)
 from verenigingen.verenigingen_payments.mollie.utils.common_helpers import (
     convert_frequency_to_mollie_interval,
     create_error_response,
@@ -570,13 +574,17 @@ class MollieGateway(PaymentGateway):
             if subscription_data.get("start_date"):
                 mollie_subscription_data["startDate"] = subscription_data["start_date"]
 
-            # Create subscription via Mollie Settings
-            result = self.settings.create_subscription(customer_data, mollie_subscription_data)
+            # Create subscription via the consolidated Mollie service layer.
+            result = CompletePaymentService().create_customer_subscription(
+                customer_data, mollie_subscription_data
+            )
 
-            # Update member with subscription details
+            # CompletePaymentService returns the Mollie subscription status
+            # under `subscription_status`; its `status` key is the literal
+            # "success", so the member field maps from `subscription_status`.
             member.db_set("mollie_customer_id", result["customer_id"])
             member.db_set("mollie_subscription_id", result["subscription_id"])
-            member.db_set("subscription_status", result["status"])
+            member.db_set("subscription_status", result["subscription_status"])
             member.db_set("next_payment_date", result.get("next_payment_date"))
 
             frappe.logger().info(
@@ -587,7 +595,7 @@ class MollieGateway(PaymentGateway):
                 "status": "success",
                 "customer_id": result["customer_id"],
                 "subscription_id": result["subscription_id"],
-                "subscription_status": result["status"],
+                "subscription_status": result["subscription_status"],
                 "next_payment_date": result.get("next_payment_date"),
                 "message": _("Subscription created successfully"),
             }
@@ -650,16 +658,16 @@ class MollieGateway(PaymentGateway):
             if not (customer_id and subscription_id):
                 return create_error_response(_("No active subscription found for this member"))
 
-            success = self.settings.cancel_subscription(customer_id, subscription_id)
+            # Cancel via the consolidated Mollie client. It raises on failure,
+            # so the surrounding except block is the error path.
+            MollieClient().cancel_subscription(customer_id, subscription_id)
 
-            if success:
-                # Update member subscription status
-                member.db_set("subscription_status", "cancelled")
-                member.db_set("subscription_cancelled_date", frappe.utils.today())
+            # Update member subscription status. "canceled" (US spelling) is
+            # the only valid Member.subscription_status Select option.
+            member.db_set("subscription_status", "canceled")
+            member.db_set("subscription_cancelled_date", frappe.utils.today())
 
-                return create_success_response(_("Subscription cancelled successfully"))
-            else:
-                return create_error_response(_("Failed to cancel subscription"))
+            return create_success_response(_("Subscription cancelled successfully"))
 
         except Exception as e:
             log_mollie_error("Subscription Cancellation", e, {"member": member.name})


### PR DESCRIPTION
## Phase 1 — collapse the two bottom-level subscription implementations

Phase 1 of the Mollie subscription consolidation. Design:
`docs/plans/2026-05-18-mollie-subscription-consolidation-design.md` (§4).

Mollie subscription create/cancel had **two** bottom-level SDK implementations
(`MollieClient` and the legacy `MollieSettings.create_subscription` /
`cancel_subscription` pair). Phase 1 collapses them onto one: `MollieClient`.

### Changes
- **`MollieClient.create_mandate()`** — new; wraps `customer.mandates.create`
  with the same error-handling shape as `create_subscription`.
- **`CompletePaymentService.create_customer_subscription`** — opt-in SEPA
  mandate provisioning from a `consumerAccount`/IBAN before the subscription
  create, then strips `consumerAccount` from the subscription payload.
- **`CompletePaymentService._validate_subscription_data`** — fixes a latent
  bug: it ran `validate_mollie_amount()` on the `{"value","currency"}` dict
  that Mollie's API requires, so `Decimal(str(dict))` always raised. The
  method was broken for every dict-amount caller (e.g. the live
  `unified_payment_api.create_subscription` endpoint).
- **`MollieGateway.create_subscription` / `cancel_subscription`** — routed
  through `CompletePaymentService` / `MollieClient` instead of the legacy
  `MollieSettings` methods. Maps the Mollie status from
  `result["subscription_status"]` (`result["status"]` is the literal
  `"success"`). Cancel path now writes the valid Select value `"canceled"`
  (was the invalid `"cancelled"`).
- **Deletions** — legacy `MollieSettings.create_subscription` /
  `cancel_subscription` (zero callers after the reroute); dead
  `SubscriptionService.create_membership_subscription` /
  `create_donation_subscription` and their orphaned private helpers.
- Mollie customer metadata is now passed through on customer creation,
  restoring legacy parity.

### Tests
`verenigingen/tests/payment/test_mollie_subscription_consolidation.py` — 9
TDD tests covering the new SDK path against a fake Mollie SDK (the external
boundary). All passing.

### Review
Double-reviewed (code-quality + skeptical). Fixes applied: `"canceled"`
spelling, customer-metadata pass-through, test robustness vs configured
credentials, cancel-error-wrap test, clearer dict-amount validation.

One finding deferred by decision: `CompletePaymentService._create_or_get_customer`
resolves the Mollie customer via a `Donor` email lookup, so a member whose
email matches a `Donor` binds the membership subscription to that Donor's
Mollie customer. Documented as a Phase 2 task (Phase 2 standardises the
mid-level customer/mandate contract).

Net: one bottom-level SDK path. +479 / -336.