### PR TITLE
fix(mollie): repair the broken amendment subscription-sync create call

### DIFF
--- a/verenigingen/tests/payment/test_mollie_amendment_subscription_sync.py
+++ b/verenigingen/tests/payment/test_mollie_amendment_subscription_sync.py
@@ -1,0 +1,130 @@
+"""
+Regression test for the broken Mollie amendment-subscription sync.
+
+``MollieSubscriptionSyncService.sync_subscription_for_amendment`` called
+``MollieClient.create_subscription`` with keyword arguments (``amount=``,
+``interval=``, ``webhook_url=``, ``start_date=`` …) that did not match its
+``(customer_id, subscription_data)`` signature, so every amendment-triggered
+sync raised ``TypeError``. The create call now goes through
+``_create_replacement_subscription``, covered here.
+
+The Mollie SDK is the external boundary; it is replaced by a fake so the test
+never touches the live Mollie API.
+"""
+
+import frappe
+
+from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
+from verenigingen.verenigingen_payments.mollie.core.client import MollieClient
+from verenigingen.verenigingen_payments.mollie.services.mollie_subscription_sync_service import (
+    MollieSubscriptionSyncService,
+)
+
+
+# Mock justified: the Mollie SDK is a third-party HTTP client for an external
+# payment API and cannot run in tests. This fake records the subscription
+# payload so the call shape can be asserted.
+class _FakeSubscription:
+    def __init__(self, subscription_id="sub_FAKE"):
+        self.id = subscription_id
+        self.status = "active"
+        self.next_payment_date = "2026-07-01"
+
+
+class _FakeSubscriptions:
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    def create(self, data=None):
+        self._recorder.append(data)
+        return _FakeSubscription()
+
+
+class _FakeCustomer:
+    def __init__(self, recorder):
+        self.subscriptions = _FakeSubscriptions(recorder)
+
+
+class _FakeCustomers:
+    def __init__(self, recorder):
+        self._recorder = recorder
+        self.fetched = []
+
+    def get(self, customer_id):
+        self.fetched.append(customer_id)
+        return _FakeCustomer(self._recorder)
+
+
+class FakeSDKClient:
+    """Stand-in for ``mollie.api.client.Client``."""
+
+    def __init__(self):
+        self.subscriptions_created = []
+        self.customers = _FakeCustomers(self.subscriptions_created)
+
+
+def _make_mollie_client(sdk):
+    """Build a MollieClient wired to a fake SDK (no live credentials needed)."""
+    client = MollieClient(api_key="test_fake")
+    client._mollie_client = sdk
+    return client
+
+
+class TestAmendmentSubscriptionSync(EnhancedTestCase):
+    """Regression coverage for the amendment-sync subscription-create call."""
+
+    def _make_member(self):
+        token = frappe.generate_hash(length=8)
+        member = self.create_test_member(
+            first_name="Sync",
+            last_name=f"Member{token}",
+            email=f"sync-{token}@example.com",
+            birth_date="1990-01-01",
+        )
+        frappe.db.set_value(
+            "Member", member.name, "mollie_customer_id", "cst_SYNC", update_modified=False
+        )
+        member.reload()
+        return member
+
+    def test_create_replacement_subscription_passes_subscription_data_dict(self):
+        sdk = FakeSDKClient()
+        member = self._make_member()
+        service = MollieSubscriptionSyncService(client=_make_mollie_client(sdk))
+
+        result = service._create_replacement_subscription(
+            member=member,
+            amount=17.5,
+            interval="3 months",
+            start_date="2026-07-01",
+            amendment_name="AMEND-TEST-001",
+            previous_subscription_id="sub_OLD",
+        )
+
+        self.assertEqual(sdk.customers.fetched, ["cst_SYNC"])
+        self.assertEqual(len(sdk.subscriptions_created), 1)
+        payload = sdk.subscriptions_created[0]
+        self.assertEqual(payload["amount"], {"value": "17.50", "currency": "EUR"})
+        self.assertEqual(payload["interval"], "3 months")
+        self.assertEqual(payload["startDate"], "2026-07-01")
+        self.assertEqual(payload["metadata"]["member_id"], member.name)
+        self.assertEqual(payload["metadata"]["amendment_id"], "AMEND-TEST-001")
+        self.assertEqual(payload["metadata"]["previous_subscription_id"], "sub_OLD")
+        self.assertEqual(payload["metadata"]["subscription_type"], "membership_dues")
+        self.assertEqual(result.id, "sub_FAKE")
+
+    def test_create_replacement_subscription_omits_start_date_when_absent(self):
+        sdk = FakeSDKClient()
+        member = self._make_member()
+        service = MollieSubscriptionSyncService(client=_make_mollie_client(sdk))
+
+        service._create_replacement_subscription(
+            member=member,
+            amount=10.0,
+            interval="1 month",
+            start_date=None,
+            amendment_name="AMEND-TEST-002",
+            previous_subscription_id="sub_OLD",
+        )
+
+        self.assertNotIn("startDate", sdk.subscriptions_created[0])

--- a/verenigingen/verenigingen_payments/mollie/services/mollie_subscription_sync_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/mollie_subscription_sync_service.py
@@ -5,7 +5,6 @@ Handles synchronization of Mollie subscriptions when membership amendments are a
 Implements event-driven architecture for loose coupling between amendment system and Mollie.
 """
 
-from decimal import Decimal
 from typing import Dict, Optional, Tuple
 
 import frappe
@@ -13,6 +12,7 @@ from frappe import _
 
 from ..core.client import MollieClient
 from ..exceptions import MollieIntegrationError
+from ..utils.common_helpers import format_mollie_amount
 from .subscription_service import SubscriptionService
 
 # Billing interval mapping to Mollie format
@@ -130,23 +130,13 @@ class MollieSubscriptionSyncService:
                     f"✨ Creating new subscription for member {member.name} with amount {new_amount}, interval {new_interval}"
                 )
 
-                from ..core.mollie_models import Money
-
-                money = Money(amount=Decimal(str(new_amount)), currency="EUR")
-
-                new_subscription = self.client.create_subscription(
-                    customer_id=member.mollie_customer_id,
-                    amount=money,
+                new_subscription = self._create_replacement_subscription(
+                    member=member,
+                    amount=new_amount,
                     interval=new_interval,
-                    description=f"Membership dues - {member.first_name} {member.last_name}",
-                    webhook_url=self._get_webhook_url(),
                     start_date=old_subscription.get("next_payment_date"),  # Preserve billing cycle
-                    metadata={
-                        "member_id": member.name,
-                        "subscription_type": "membership_dues",
-                        "amendment_id": amendment_doc.name,
-                        "previous_subscription_id": old_subscription_id,
-                    },
+                    amendment_name=amendment_doc.name,
+                    previous_subscription_id=old_subscription_id,
                 )
 
                 frappe.logger().info(
@@ -329,6 +319,54 @@ class MollieSubscriptionSyncService:
                 "message": f"Unexpected error: {str(e)}",
                 "requires_admin_review": True,
             }
+
+    def _create_replacement_subscription(
+        self,
+        member,
+        amount,
+        interval: str,
+        start_date,
+        amendment_name: str,
+        previous_subscription_id: str,
+    ):
+        """
+        Create the replacement Mollie subscription for an applied amendment.
+
+        Builds the payload in the shape ``MollieClient.create_subscription``
+        expects - a ``(customer_id, subscription_data)`` call where
+        ``subscription_data`` is a dict. ``start_date``, when given, preserves
+        the member's existing billing cycle.
+
+        Args:
+            member: Member document (provides customer id, name, full name)
+            amount: Subscription amount in EUR
+            interval: Mollie interval string (e.g. "1 month", "3 months")
+            start_date: Optional ISO date for the first charge (billing cycle)
+            amendment_name: Contribution Amendment Request name (metadata)
+            previous_subscription_id: The subscription being replaced (metadata)
+
+        Returns:
+            The created Mollie subscription object
+
+        Raises:
+            MolliePaymentError: When the subscription cannot be created
+        """
+        subscription_data = {
+            "amount": format_mollie_amount(amount, "EUR"),
+            "interval": interval,
+            "description": f"Membership dues - {member.first_name} {member.last_name}",
+            "webhookUrl": self._get_webhook_url(),
+            "metadata": {
+                "member_id": member.name,
+                "subscription_type": "membership_dues",
+                "amendment_id": amendment_name,
+                "previous_subscription_id": previous_subscription_id,
+            },
+        }
+        if start_date:
+            subscription_data["startDate"] = start_date
+
+        return self.client.create_subscription(member.mollie_customer_id, subscription_data)
 
     def _get_subscription_parameters(
         self, amendment_doc: "frappe.model.document.Document", membership: "frappe.model.document.Document"


### PR DESCRIPTION
## The bug

`MollieSubscriptionSyncService.sync_subscription_for_amendment` called
`MollieClient.create_subscription` with **keyword arguments**
(`amount=`, `interval=`, `webhook_url=`, `start_date=`, `metadata=`) that do
not match its actual signature `(customer_id, subscription_data: dict)`.
Every call raised `TypeError`.

This is a **live** path: applying a `Contribution Amendment Request` enqueues
`sync_mollie_subscription_on_amendment_applied`, which calls
`sync_subscription_for_amendment`. So a member changing their contribution
amount currently fails the Mollie subscription sync (the `TypeError` is
swallowed into an error result with `requires_admin_review`).

It is the same bug class as the dead `SubscriptionService.create_*` methods
retired in PR #45 — but this one is wired to a live trigger.

## The fix

Extract `_create_replacement_subscription`, which builds a correctly-shaped
`subscription_data` dict — `amount` as `{"value","currency"}`, `interval`,
`description`, `webhookUrl`, `startDate` (only when a billing-cycle date is
known), `metadata` — and calls `MollieClient.create_subscription` positionally.

## Tests

New `verenigingen/tests/payment/test_mollie_amendment_subscription_sync.py` —
2 tests against a fake Mollie SDK: payload shape, and `startDate` omitted when
no billing-cycle date is available. TDD (RED → GREEN); both pass.

## Context

Found while expanding Phase 2 of the Mollie subscription consolidation
(`docs/plans/2026-05-18-mollie-subscription-consolidation-design.md`, §2.0).
Split out as a standalone fix so the live regression is resolved ahead of the
larger Phase 2 standardisation work (which will route this path through the
unified contract).