### PR TITLE
refactor(mollie): standardise the mid-level subscription contract (Phase 2)

### DIFF
--- a/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
+++ b/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
@@ -209,6 +209,15 @@ payment code.
 5. **Mandatory row locking on subscription create.** Port the
    `SELECT … FOR UPDATE` pattern onto the owning Member/Donor row for the
    subscription-create paths, not just customer creation.
+   - **Idempotency (intentional contract decision).** While the owner row is
+     locked, if the owner already has a *live* (`active`/`pending`) Mollie
+     subscription, the create returns that subscription instead of
+     provisioning a second one — mirroring how customer resolution returns an
+     existing customer. The `active`/`pending` gate means a re-subscribe after
+     a cancellation still creates a fresh subscription. A caller that
+     deliberately wants a *second concurrent* live subscription for one owner
+     (e.g. a future amendment "create new before cancelling old" flow) must
+     not route through this path. Confirmed during the Phase 2 review.
 6. **Service owns the DocType update.** `CompletePaymentService` updates the
    owning Member/Donor on create and cancel; remove the duplicated `db_set`s
    from `MollieGateway`. Implement the `_update_subscription_status` no-op.

--- a/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
+++ b/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
@@ -147,29 +147,84 @@ Precise task list:
 - Net: one SDK path (`MollieClient`).
 
 ### Phase 2 — standardise the mid-level contract
-- Make row locking mandatory on every create path (port the
-  `SELECT … FOR UPDATE` pattern into `CompletePaymentService` and the sync
-  service create path).
-- Single mandate-validation helper used by all create paths.
-- Service layer always updates the owning Member/Donor record on create and
-  cancel (eliminate the "caller is responsible" gaps).
-- One result dataclass / shape for create and for cancel.
-- **`enable_subscriptions` gate lives only at the caller.** After Phase 1
-  the gate survives because `MollieGateway.create_subscription` checks
-  `settings.enable_subscriptions` itself, but `CompletePaymentService.`
-  `create_customer_subscription` — the consolidation target — has no such
-  check. Any caller wired straight to the service (e.g. the Phase 3 debug
-  service) would bypass the gate. Phase 2 should move the check into the
-  standardised create contract. (Found during Phase 1 review.)
-- **Customer resolution is Donor-only today.** `CompletePaymentService.`
-  `_create_or_get_customer` resolves the Mollie customer by looking up a
-  `Donor` on `donor_email`. After Phase 1, `MollieGateway` (membership dues)
-  routes through this method, so a member whose email matches a `Donor` row
-  binds the membership subscription to that Donor's Mollie customer and
-  writes `mollie_customer_id` back onto the Donor. The legacy path always
-  created a fresh Mollie customer. Phase 2 must make customer resolution
-  owner-aware (Member vs Donor) so each owning DocType resolves against its
-  own record. (Found during Phase 1 review; deferred here by decision.)
+
+Branch: `refactor/mollie-subscription-consolidation-phase2`. TDD each step —
+payment code.
+
+#### 2.0 Findings from the Phase 2 investigation
+
+- **The sync-service create path is broken.**
+  `MollieSubscriptionSyncService.sync_subscription_for_amendment` calls
+  `self.client.create_subscription(customer_id=…, amount=Money(…),
+  interval=…, description=…, webhook_url=…, start_date=…, metadata=…)` —
+  keyword arguments that do not match `MollieClient.create_subscription(
+  customer_id, subscription_data: dict)`. Every call raises `TypeError`.
+  This is the same bug class as the dead `SubscriptionService.create_*`
+  methods retired in Phase 1 — but this one is **live**: applying a
+  `Contribution Amendment Request` enqueues
+  `sync_mollie_subscription_on_amendment_applied`, which calls it. So a
+  member changing their contribution amount currently fails the Mollie
+  sync. Phase 2 must fix this as part of standardising the create path.
+- **Divergences across the create/cancel paths (post-Phase-1):**
+  - *Row locking* — `CompletePaymentService._create_or_get_customer` locks
+    the `Donor` row for *customer* creation, but no path locks the
+    Member/Donor for *subscription* creation (duplicate-subscription race).
+    The sync service takes no lock at all.
+  - *Mandate handling* — `CompletePaymentService` provisions a mandate from
+    an IBAN; the sync service validates an *existing* mandate via the SDK;
+    no shared helper.
+  - *DocType updates* — `CompletePaymentService.create_customer_subscription`
+    does NOT update Member/Donor (its caller `MollieGateway` does the
+    `db_set`s); `cancel_subscription` calls `_update_subscription_status`,
+    which is a TODO no-op; the sync service updates `mollie_subscription_id`
+    itself.
+  - *Return shapes* — `CompletePaymentService` returns dicts;
+    `SubscriptionService.cancel_subscription` returns a `Subscription` SDK
+    object; the sync service returns ad-hoc dicts with bespoke keys
+    (`reason`, `requires_admin_review`, `rollback_successful`, …).
+  - *`enable_subscriptions` gate* — enforced only in `MollieGateway`.
+
+#### 2.1 Task list
+
+1. **Fix the sync-service create call.** Rebuild
+   `sync_subscription_for_amendment` to call
+   `MollieClient.create_subscription(customer_id, subscription_data)` with a
+   correctly-shaped dict (`amount` as `{"value","currency"}`, `interval`,
+   `description`, `webhookUrl`, `startDate`, `metadata`). TDD: a test that
+   currently `TypeError`s, then green.
+2. **Standard result shape.** One documented dict shape for create and one
+   for cancel — a plain `dict` (not a dataclass) so existing
+   `result["status"]` caller access keeps working:
+   - create: `{status, customer_id, subscription_id, subscription_status,
+     next_payment_date, message}` (`status` ∈ `success`/`error`).
+   - cancel: `{status, subscription_id, message}`.
+   Every create/cancel path returns this; `SubscriptionService.`
+   `cancel_subscription` stops returning a raw `Subscription` object.
+3. **`enable_subscriptions` gate in the contract.** Move the check into
+   `CompletePaymentService.create_customer_subscription` (and the sync
+   path) so it cannot be bypassed; keep `MollieGateway`'s early check or
+   let it delegate — no double error.
+4. **Single mandate helper.** One helper used by every create path: provision
+   from IBAN when given, otherwise validate an existing mandate.
+5. **Mandatory row locking on subscription create.** Port the
+   `SELECT … FOR UPDATE` pattern onto the owning Member/Donor row for the
+   subscription-create paths, not just customer creation.
+6. **Service owns the DocType update.** `CompletePaymentService` updates the
+   owning Member/Donor on create and cancel; remove the duplicated `db_set`s
+   from `MollieGateway`. Implement the `_update_subscription_status` no-op.
+7. **Owner-aware customer resolution.** `_create_or_get_customer` must
+   resolve against the owning DocType (Member vs Donor), not always `Donor`,
+   so a member's subscription never binds to a Donor's Mollie customer.
+
+#### 2.2 Open design decisions (confirm before implementing)
+
+- **Result shape** — plain dict (above) vs a dataclass. Dict chosen here to
+  avoid breaking `result["…"]` access in `unified_payment_api`,
+  `MollieGateway` callers, and `amendment_events`. Confirm.
+- **Sync-service return** — `sync_subscription_for_amendment` carries
+  operational keys (`requires_admin_review`, `critical_failure`,
+  `duplicate_subscriptions`) its caller `amendment_events` relies on. These
+  are kept *in addition to* the standard keys, not replaced.
 
 ### Phase 3 — fold in the debug-service paths
 - Route `MollieDebugService.create_subscription` / `admin_cancel_subscription`

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -1,8 +1,9 @@
 """
-Tests for the Mollie subscription create/cancel consolidation (Phase 1).
+Tests for the Mollie subscription create/cancel consolidation (Phases 1 and 2).
 
 Phase 1 collapses the two bottom-level subscription implementations onto a
-single SDK path (``MollieClient``). See
+single SDK path (``MollieClient``); Phase 2 standardises the mid-level
+create/cancel contract. See
 ``docs/plans/2026-05-18-mollie-subscription-consolidation-design.md``.
 
 The Mollie SDK is the external boundary; it is replaced here by ``FakeSDKClient``
@@ -105,10 +106,11 @@ class _FakeCustomer:
 
 
 class _FakeCustomers:
-    def __init__(self, recorder, sub_status, mandate_raises):
+    def __init__(self, recorder, sub_status, mandate_raises, stale_customer_id):
         self._recorder = recorder
         self._sub_status = sub_status
         self._mandate_raises = mandate_raises
+        self._stale_customer_id = stale_customer_id
         self._counter = 0
 
     def create(self, data=None):
@@ -120,15 +122,21 @@ class _FakeCustomers:
 
     def get(self, customer_id):
         self._recorder.customers_fetched.append(customer_id)
+        # Only the designated "stale" id fails to resolve; freshly-created
+        # customers (and every other id) resolve normally.
+        if self._stale_customer_id and customer_id == self._stale_customer_id:
+            raise RuntimeError("simulated stale/unknown Mollie customer")
         return _FakeCustomer(self._recorder, customer_id, self._sub_status, self._mandate_raises)
 
 
 class FakeSDKClient:
     """Stand-in for ``mollie.api.client.Client``."""
 
-    def __init__(self, sub_status="active", mandate_raises=False):
+    def __init__(self, sub_status="active", mandate_raises=False, stale_customer_id=None):
         self.recorder = _Recorder()
-        self.customers = _FakeCustomers(self.recorder, sub_status, mandate_raises)
+        self.customers = _FakeCustomers(
+            self.recorder, sub_status, mandate_raises, stale_customer_id
+        )
 
 
 class _RaisingCustomers:
@@ -692,3 +700,79 @@ class TestMollieSubscriptionContract(EnhancedTestCase):
         self.assertEqual(result["subscription_id"], "sub_EXISTING")
         # No duplicate subscription was provisioned at Mollie.
         self.assertEqual(sdk.recorder.subscriptions_created, [])
+
+    def test_create_subscription_recreates_when_stored_subscription_inactive(self):
+        """An owner whose stored subscription is no longer live (e.g. cancelled)
+        does not get the stale subscription back - a fresh one is provisioned."""
+        sdk = FakeSDKClient(sub_status="canceled")
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+        token = frappe.generate_hash(length=8)
+        member = self.create_test_member(
+            first_name="Stale",
+            last_name=f"Sub{token}",
+            email=f"stale-sub-{token}@example.com",
+            birth_date="1990-01-01",
+        )
+        frappe.db.set_value(
+            "Member",
+            member.name,
+            {"mollie_customer_id": "cst_OLD", "mollie_subscription_id": "sub_OLD"},
+            update_modified=False,
+        )
+
+        with patch("frappe.db.begin"), patch("frappe.db.commit"), patch("frappe.db.rollback"):
+            result = service.create_customer_subscription(
+                {
+                    "name": "Stale Sub",
+                    "email": member.email,
+                    "owner_doctype": "Member",
+                    "owner_name": member.name,
+                },
+                {
+                    "amount": {"value": "15.00", "currency": "EUR"},
+                    "interval": "1 month",
+                    "description": "Membership dues",
+                },
+            )
+
+        self.assertEqual(result["status"], "success")
+        # The cancelled stored subscription is not reused - a fresh one is made.
+        self.assertEqual(len(sdk.recorder.subscriptions_created), 1)
+        self.assertNotEqual(result["subscription_id"], "sub_OLD")
+
+    def test_create_subscription_replaces_stale_customer_id(self):
+        """When the owner's stored Mollie customer id no longer resolves, a
+        fresh customer is created and recorded on the owner."""
+        sdk = FakeSDKClient(stale_customer_id="cst_STALE")
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+        token = frappe.generate_hash(length=8)
+        member = self.create_test_member(
+            first_name="Stale",
+            last_name=f"Cust{token}",
+            email=f"stale-cust-{token}@example.com",
+            birth_date="1990-01-01",
+        )
+        frappe.db.set_value(
+            "Member", member.name, "mollie_customer_id", "cst_STALE", update_modified=False
+        )
+
+        with patch("frappe.db.begin"), patch("frappe.db.commit"), patch("frappe.db.rollback"):
+            result = service.create_customer_subscription(
+                {
+                    "name": "Stale Cust",
+                    "email": member.email,
+                    "owner_doctype": "Member",
+                    "owner_name": member.name,
+                },
+                {
+                    "amount": {"value": "15.00", "currency": "EUR"},
+                    "interval": "1 month",
+                    "description": "Membership dues",
+                },
+            )
+
+        self.assertEqual(result["status"], "success")
+        # A new customer replaced the stale id on the Member.
+        new_customer_id = frappe.db.get_value("Member", member.name, "mollie_customer_id")
+        self.assertTrue(new_customer_id)
+        self.assertNotEqual(new_customer_id, "cst_STALE")

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -519,3 +519,70 @@ class TestMollieSubscriptionContract(EnhancedTestCase):
         # The Mollie customer id is stored on the Member, not the Donor.
         self.assertTrue(frappe.db.get_value("Member", member.name, "mollie_customer_id"))
         self.assertFalse(frappe.db.get_value("Donor", donor.name, "mollie_customer_id"))
+
+    def test_create_customer_subscription_updates_owning_member(self):
+        """On a successful create the service writes the subscription back
+        onto the owning Member - callers no longer do their own db_sets."""
+        sdk = FakeSDKClient()
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+        token = frappe.generate_hash(length=8)
+        member = self.create_test_member(
+            first_name="Update",
+            last_name=f"Owner{token}",
+            email=f"update-owner-{token}@example.com",
+            birth_date="1990-01-01",
+        )
+
+        with patch("frappe.db.begin"), patch("frappe.db.commit"), patch("frappe.db.rollback"):
+            result = service.create_customer_subscription(
+                {
+                    "name": "Update Owner",
+                    "email": member.email,
+                    "owner_doctype": "Member",
+                    "owner_name": member.name,
+                },
+                {
+                    "amount": {"value": "15.00", "currency": "EUR"},
+                    "interval": "1 month",
+                    "description": "Membership dues",
+                },
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "mollie_subscription_id"), "sub_FAKE"
+        )
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "subscription_status"), "active"
+        )
+
+    def test_cancel_subscription_updates_owning_member(self):
+        """cancel_subscription finds the owning Member by mollie_subscription_id
+        and flips subscription_status to the valid 'canceled' value."""
+        sdk = FakeSDKClient()
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+        token = frappe.generate_hash(length=8)
+        member = self.create_test_member(
+            first_name="Cancel",
+            last_name=f"Owner{token}",
+            email=f"cancel-owner-{token}@example.com",
+            birth_date="1990-01-01",
+        )
+        frappe.db.set_value(
+            "Member",
+            member.name,
+            {
+                "mollie_customer_id": "cst_C",
+                "mollie_subscription_id": "sub_C",
+                "subscription_status": "active",
+            },
+            update_modified=False,
+        )
+
+        result = service.cancel_subscription("cst_C", "sub_C")
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "subscription_status"), "canceled"
+        )
+        self.assertTrue(frappe.db.get_value("Member", member.name, "subscription_cancelled_date"))

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -479,3 +479,43 @@ class TestMollieSubscriptionContract(EnhancedTestCase):
         # The gate fires before any Mollie call.
         self.assertEqual(sdk.recorder.subscriptions_created, [])
         self.assertEqual(sdk.recorder.customers_created, [])
+
+    def test_customer_resolution_is_owner_aware_for_member(self):
+        """A membership subscription resolves the Mollie customer against the
+        Member record. Even when a Donor shares the email address, the Donor's
+        mollie_customer_id is left untouched."""
+        sdk = FakeSDKClient()
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        token = frappe.generate_hash(length=8)
+        member = self.create_test_member(
+            first_name="Owner",
+            last_name=f"Aware{token}",
+            email=f"owner-aware-{token}@example.com",
+            birth_date="1990-01-01",
+        )
+        donor = self.create_test_donor()
+        frappe.db.set_value("Donor", donor.name, "donor_email", member.email, update_modified=False)
+
+        # The owner-row lock uses frappe.db.begin/commit; neutralise the
+        # transaction plumbing so the locking logic runs inside the test's
+        # transaction (the pattern used by test_termination_execution_service).
+        with patch("frappe.db.begin"), patch("frappe.db.commit"), patch("frappe.db.rollback"):
+            result = service.create_customer_subscription(
+                {
+                    "name": "Owner Aware",
+                    "email": member.email,
+                    "owner_doctype": "Member",
+                    "owner_name": member.name,
+                },
+                {
+                    "amount": {"value": "15.00", "currency": "EUR"},
+                    "interval": "1 month",
+                    "description": "Membership dues",
+                },
+            )
+
+        self.assertEqual(result["status"], "success")
+        # The Mollie customer id is stored on the Member, not the Donor.
+        self.assertTrue(frappe.db.get_value("Member", member.name, "mollie_customer_id"))
+        self.assertFalse(frappe.db.get_value("Donor", donor.name, "mollie_customer_id"))

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -16,7 +16,10 @@ import frappe
 
 from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
 from verenigingen.verenigingen_payments.mollie.core.client import MollieClient
-from verenigingen.verenigingen_payments.mollie.exceptions import MolliePaymentError
+from verenigingen.verenigingen_payments.mollie.exceptions import (
+    MolliePaymentError,
+    MollieValidationError,
+)
 from verenigingen.verenigingen_payments.mollie.services.complete_payment_service import (
     CompletePaymentService,
 )
@@ -464,8 +467,11 @@ class TestMollieSubscriptionContract(EnhancedTestCase):
         sdk = FakeSDKClient()
         service = CompletePaymentService(client=_make_mollie_client(sdk))
 
+        # The gate raises MollieValidationError - and it must propagate as that
+        # type (not be re-wrapped as MolliePaymentError), so the API layer can
+        # surface the real "not enabled" message.
         with patch("frappe.db.get_single_value", return_value=0):
-            with self.assertRaises(MolliePaymentError) as ctx:
+            with self.assertRaises(MollieValidationError) as ctx:
                 service.create_customer_subscription(
                     {"name": "Jane Doe", "email": _unique_email()},
                     {
@@ -554,6 +560,43 @@ class TestMollieSubscriptionContract(EnhancedTestCase):
         )
         self.assertEqual(
             frappe.db.get_value("Member", member.name, "subscription_status"), "active"
+        )
+        self.assertEqual(
+            str(frappe.db.get_value("Member", member.name, "next_payment_date")), "2026-06-01"
+        )
+
+    def test_update_owner_record_skips_fields_a_doctype_lacks(self):
+        """_update_owner_record writes every applicable field to a Member but
+        silently skips status fields on a Donor (which does not define them)."""
+        service = CompletePaymentService(client=_make_mollie_client(FakeSDKClient()))
+        token = frappe.generate_hash(length=8)
+        member = self.create_test_member(
+            first_name="Record",
+            last_name=f"Owner{token}",
+            email=f"record-owner-{token}@example.com",
+            birth_date="1990-01-01",
+        )
+        donor = self.create_test_donor()
+        values = {
+            "mollie_subscription_id": "sub_REC",
+            "subscription_status": "active",
+            "next_payment_date": "2026-07-01",
+        }
+
+        service._update_owner_record("Member", member.name, values)
+        service._update_owner_record("Donor", donor.name, values)
+
+        # Member defines all three fields.
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "mollie_subscription_id"), "sub_REC"
+        )
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "subscription_status"), "active"
+        )
+        # Donor defines mollie_subscription_id but not the status fields - the
+        # absent fields are skipped without error.
+        self.assertEqual(
+            frappe.db.get_value("Donor", donor.name, "mollie_subscription_id"), "sub_REC"
         )
 
     def test_cancel_subscription_updates_owning_member(self):

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -453,3 +453,29 @@ class TestMollieGatewaySubscription(EnhancedTestCase):
         self.assertEqual(
             frappe.db.get_value("Member", member.name, "subscription_status"), "active"
         )
+
+
+class TestMollieSubscriptionContract(EnhancedTestCase):
+    """Phase 2 - standardised mid-level create/cancel contract."""
+
+    def test_create_customer_subscription_rejected_when_subscriptions_disabled(self):
+        """The enable_subscriptions gate is enforced inside the service, so no
+        caller wired straight to CompletePaymentService can bypass it."""
+        sdk = FakeSDKClient()
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        with patch("frappe.db.get_single_value", return_value=0):
+            with self.assertRaises(MolliePaymentError) as ctx:
+                service.create_customer_subscription(
+                    {"name": "Jane Doe", "email": _unique_email()},
+                    {
+                        "amount": {"value": "15.00", "currency": "EUR"},
+                        "interval": "1 month",
+                        "description": "Membership dues",
+                    },
+                )
+
+        self.assertIn("not enabled", str(ctx.exception))
+        # The gate fires before any Mollie call.
+        self.assertEqual(sdk.recorder.subscriptions_created, [])
+        self.assertEqual(sdk.recorder.customers_created, [])

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -85,6 +85,9 @@ class _FakeSubscriptions:
         self._recorder.subscriptions_created.append(data)
         return _FakeSubscription(status=self._sub_status)
 
+    def get(self, subscription_id):
+        return _FakeSubscription(subscription_id=subscription_id, status=self._sub_status)
+
     def delete(self, subscription_id):
         self._recorder.subscriptions_deleted.append(subscription_id)
         return _FakeSubscription(subscription_id=subscription_id, status="canceled")
@@ -629,3 +632,42 @@ class TestMollieSubscriptionContract(EnhancedTestCase):
             frappe.db.get_value("Member", member.name, "subscription_status"), "canceled"
         )
         self.assertTrue(frappe.db.get_value("Member", member.name, "subscription_cancelled_date"))
+
+    def test_create_customer_subscription_is_idempotent_when_owner_has_subscription(self):
+        """If the owning record already has an active subscription, create
+        returns it rather than provisioning a duplicate at Mollie."""
+        sdk = FakeSDKClient()
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+        token = frappe.generate_hash(length=8)
+        member = self.create_test_member(
+            first_name="Idem",
+            last_name=f"Potent{token}",
+            email=f"idem-{token}@example.com",
+            birth_date="1990-01-01",
+        )
+        frappe.db.set_value(
+            "Member",
+            member.name,
+            {"mollie_customer_id": "cst_EXISTING", "mollie_subscription_id": "sub_EXISTING"},
+            update_modified=False,
+        )
+
+        with patch("frappe.db.begin"), patch("frappe.db.commit"), patch("frappe.db.rollback"):
+            result = service.create_customer_subscription(
+                {
+                    "name": "Idem Potent",
+                    "email": member.email,
+                    "owner_doctype": "Member",
+                    "owner_name": member.name,
+                },
+                {
+                    "amount": {"value": "15.00", "currency": "EUR"},
+                    "interval": "1 month",
+                    "description": "Membership dues",
+                },
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["subscription_id"], "sub_EXISTING")
+        # No duplicate subscription was provisioned at Mollie.
+        self.assertEqual(sdk.recorder.subscriptions_created, [])

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -23,6 +23,9 @@ from verenigingen.verenigingen_payments.mollie.exceptions import (
 from verenigingen.verenigingen_payments.mollie.services.complete_payment_service import (
     CompletePaymentService,
 )
+from verenigingen.verenigingen_payments.mollie.services.subscription_service import (
+    SubscriptionService,
+)
 
 # ---------------------------------------------------------------------------
 # Fake Mollie SDK client
@@ -59,6 +62,7 @@ class _FakeSubscription:
         self.next_payment_date = next_payment_date
         self.canceled_at = None
         self.cancelled_at = None
+        self.metadata = {}
 
 
 class _FakeMandates:
@@ -410,6 +414,7 @@ class TestMollieGatewaySubscription(EnhancedTestCase):
             result = gateway.cancel_subscription(member)
 
         self.assertEqual(result["status"], "success")
+        self.assertEqual(result["subscription_id"], "sub_LIVE")
         self.assertEqual(sdk.recorder.subscriptions_deleted, ["sub_LIVE"])
         self.assertEqual(
             frappe.db.get_value("Member", member.name, "subscription_status"), "canceled"
@@ -628,10 +633,26 @@ class TestMollieSubscriptionContract(EnhancedTestCase):
         result = service.cancel_subscription("cst_C", "sub_C")
 
         self.assertEqual(result["status"], "success")
+        # Standard cancel result shape - exactly these keys.
+        self.assertEqual(set(result), {"status", "subscription_id", "message"})
+        self.assertEqual(result["subscription_id"], "sub_C")
         self.assertEqual(
             frappe.db.get_value("Member", member.name, "subscription_status"), "canceled"
         )
         self.assertTrue(frappe.db.get_value("Member", member.name, "subscription_cancelled_date"))
+
+    def test_subscription_service_cancel_returns_standard_dict(self):
+        """SubscriptionService.cancel_subscription returns the standard cancel
+        result dict, not a raw Mollie subscription object."""
+        sdk = FakeSDKClient()
+        service = SubscriptionService(client=_make_mollie_client(sdk))
+
+        result = service.cancel_subscription("cst_S", "sub_S")
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(set(result), {"status", "subscription_id", "message"})
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["subscription_id"], "sub_S")
 
     def test_create_customer_subscription_is_idempotent_when_owner_has_subscription(self):
         """If the owning record already has an active subscription, create

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -15,6 +15,7 @@ from decimal import Decimal
 from typing import Any, Dict, List, Optional, Union
 
 import frappe
+from frappe.query_builder import DocType
 
 from verenigingen.verenigingen_payments.utils.payment_data_extractor import get_payment_data_extractor
 
@@ -456,51 +457,99 @@ class CompletePaymentService:
 
     def _create_or_get_customer(self, customer_data: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Create a new customer or get existing one with race condition protection.
+        Resolve the Mollie customer for a subscription.
 
-        Uses SELECT FOR UPDATE to prevent duplicate customer creation when
-        concurrent requests arrive for the same donor.
+        When `customer_data` names an owning record (`owner_doctype` +
+        `owner_name`) the customer is resolved against that record - a
+        membership subscription against the Member, a donation against the
+        Donor - so a member's subscription never binds to a Donor's Mollie
+        customer just because they happen to share an email address. Without
+        an explicit owner, falls back to Donor-by-email resolution.
+        """
+        owner_doctype = customer_data.get("owner_doctype")
+        owner_name = customer_data.get("owner_name")
+        if owner_doctype and owner_name:
+            return self._resolve_customer_for_owner(owner_doctype, owner_name, customer_data)
+        return self._resolve_customer_by_email(customer_data)
+
+    def _resolve_customer_for_owner(
+        self, owner_doctype: str, owner_name: str, customer_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Reuse or create the Mollie customer recorded on a specific Member or
+        Donor, locking that row (SELECT ... FOR UPDATE) so concurrent requests
+        for the same owner cannot create duplicate Mollie customers.
+        """
+        if owner_doctype not in ("Member", "Donor"):
+            raise MollieValidationError(f"Unsupported subscription owner doctype: {owner_doctype}")
+
+        # begin()/commit() bracket the row lock: commit() persists the customer
+        # id and releases the lock; every exit path must commit() or rollback().
+        frappe.db.begin()
+        try:
+            owner = DocType(owner_doctype)
+            locked_row = (
+                frappe.qb.from_(owner)
+                .select(owner.mollie_customer_id)
+                .where(owner.name == owner_name)
+                .for_update()
+                .run(as_dict=True)
+            )
+
+            if not locked_row:
+                frappe.db.commit()
+                return create_error_response(f"{owner_doctype} {owner_name} not found")
+
+            existing_customer_id = locked_row[0].get("mollie_customer_id")
+            if existing_customer_id:
+                try:
+                    customer = self.client.get_customer(existing_customer_id)
+                    frappe.db.commit()  # Release lock
+                    return {"status": "found", "customer_id": customer.id}
+                except Exception as e:
+                    frappe.logger().warning(
+                        f"Existing customer ID {existing_customer_id} not found in Mollie: {e}"
+                    )
+                    # Stale id - fall through and create a fresh customer.
+
+            customer = self.client.create_customer(self._mollie_customer_payload(customer_data))
+            frappe.db.set_value(
+                owner_doctype, owner_name, "mollie_customer_id", customer.id, update_modified=False
+            )
+            frappe.db.commit()  # Commit and release lock
+            frappe.logger().info(f"Saved Mollie customer {customer.id} to {owner_doctype} {owner_name}")
+            return {"status": "created", "customer_id": customer.id}
+
+        except Exception as e:
+            frappe.db.rollback()
+            error_msg = f"Failed to create or get Mollie customer: {e}"
+            frappe.log_error(error_msg, "Mollie Customer Error")
+            return create_error_response(error_msg)
+
+    def _resolve_customer_by_email(self, customer_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Resolve the Mollie customer by Donor email - the fallback for donation
+        flows that do not name an explicit owner record.
+
+        Uses SELECT ... FOR UPDATE on the Donor row so concurrent requests for
+        the same donor cannot create duplicate Mollie customers.
         """
         email = customer_data["email"]
 
-        # First check without lock for quick path (most common case)
+        # Quick path: no Donor with this email -> no race, create without a lock.
         existing_donors = frappe.get_all(
             "Donor", filters={"donor_email": email}, fields=["name", "mollie_customer_id"]
         )
-
         if not existing_donors:
-            # No donor exists, create customer without lock (no race condition risk)
-            # This is safe because we can't have a race condition for a non-existent donor
             return self._create_mollie_customer_only(customer_data)
 
         donor_name = existing_donors[0]["name"]
 
-        # ===== ROW LOCKING FOR RACE CONDITION PREVENTION =====
-        #
-        # PROBLEM: Without locking, two concurrent requests for the same donor could both:
-        #   1. Check mollie_customer_id (both see None)
-        #   2. Create new Mollie customers (duplicate!)
-        #   3. Save their customer ID (one gets overwritten)
-        #
-        # SOLUTION: Use SELECT ... FOR UPDATE to acquire an exclusive row lock
-        #   - First request acquires lock, second request WAITS
-        #   - After first request commits, second request sees the updated value
-        #   - No duplicate Mollie customers created
-        #
-        # TRANSACTION SEMANTICS:
-        #   - begin() starts transaction and creates savepoint
-        #   - commit() persists changes AND releases the row lock
-        #   - rollback() undoes changes AND releases the row lock
-        #   - ALL exit paths must either commit() or rollback() to release the lock
-        #
+        # begin()/commit() bracket the row lock: commit()/rollback() release it.
         frappe.db.begin()
         try:
-            # Acquire row lock - other requests will wait here
             locked_row = frappe.db.sql(
-                """
-                SELECT mollie_customer_id FROM `tabDonor`
-                WHERE name = %s FOR UPDATE
-                """,
+                "SELECT mollie_customer_id FROM `tabDonor` WHERE name = %s FOR UPDATE",
                 donor_name,
                 as_dict=True,
             )
@@ -510,8 +559,6 @@ class CompletePaymentService:
                 return self._create_mollie_customer_only(customer_data)
 
             existing_customer_id = locked_row[0].get("mollie_customer_id")
-
-            # Check if customer already exists (may have been created by concurrent request)
             if existing_customer_id:
                 try:
                     customer = self.client.get_customer(existing_customer_id)
@@ -524,23 +571,12 @@ class CompletePaymentService:
                     frappe.logger().warning(
                         f"Existing customer ID {existing_customer_id} not found in Mollie: {e}"
                     )
-                    # Continue to create new customer (stale ID case)
+                    # Stale id - fall through and create a fresh customer.
 
-            # Create new customer in Mollie while holding the lock
-            mollie_customer_data = {"name": customer_data.get("name", ""), "email": email}
-            if customer_data.get("locale"):
-                mollie_customer_data["locale"] = customer_data["locale"]
-            if customer_data.get("metadata"):
-                mollie_customer_data["metadata"] = customer_data["metadata"]
-
-            customer = self.client.create_customer(mollie_customer_data)
-            frappe.logger().info(f"Created new Mollie customer {customer.id}")
-
-            # Update donor with new customer ID (still holding lock)
+            customer = self.client.create_customer(self._mollie_customer_payload(customer_data))
             frappe.db.set_value("Donor", donor_name, "mollie_customer_id", customer.id, update_modified=False)
             frappe.db.commit()  # Commit and release lock
             frappe.logger().info(f"Saved customer ID {customer.id} to donor {donor_name}")
-
             return {"status": "created", "customer_id": customer.id}
 
         except Exception as e:
@@ -550,25 +586,27 @@ class CompletePaymentService:
             return create_error_response(error_msg)
 
     def _create_mollie_customer_only(self, customer_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Create Mollie customer without updating any Frappe document."""
+        """Create a Mollie customer without recording it on any Frappe document."""
         try:
-            mollie_customer_data = {
-                "name": customer_data.get("name", ""),
-                "email": customer_data["email"],
-            }
-            if customer_data.get("locale"):
-                mollie_customer_data["locale"] = customer_data["locale"]
-            if customer_data.get("metadata"):
-                mollie_customer_data["metadata"] = customer_data["metadata"]
-
-            customer = self.client.create_customer(mollie_customer_data)
-            frappe.logger().info(f"Created new Mollie customer {customer.id} (no donor)")
+            customer = self.client.create_customer(self._mollie_customer_payload(customer_data))
+            frappe.logger().info(f"Created new Mollie customer {customer.id} (no owner record)")
             return {"status": "created", "customer_id": customer.id}
-
         except Exception as e:
             error_msg = f"Failed to create Mollie customer: {e}"
             frappe.log_error(error_msg, "Mollie Customer Error")
             return create_error_response(error_msg)
+
+    def _mollie_customer_payload(self, customer_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Build the customer dict passed to the Mollie SDK (name/email/locale/metadata)."""
+        payload = {
+            "name": customer_data.get("name", ""),
+            "email": customer_data["email"],
+        }
+        if customer_data.get("locale"):
+            payload["locale"] = customer_data["locale"]
+        if customer_data.get("metadata"):
+            payload["metadata"] = customer_data["metadata"]
+        return payload
 
     def _update_donation_with_payment(self, donation_doc: Any, mollie_payment: Any) -> None:
         """Update donation document with Mollie payment details."""

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -195,6 +195,12 @@ class CompletePaymentService:
         try:
             frappe.logger().info(f"🔄 Creating customer subscription for {customer_data.get('email')}")
 
+            # Subscriptions must be enabled in Mollie Settings. Enforced here -
+            # inside the standardised create contract - so that no caller wired
+            # straight to this service can bypass the gate.
+            if not frappe.db.get_single_value("Mollie Settings", "enable_subscriptions"):
+                raise MollieValidationError("Subscriptions are not enabled in Mollie Settings")
+
             # Validate input data
             self._validate_subscription_data(customer_data, subscription_data)
 

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -255,6 +255,23 @@ class CompletePaymentService:
 
             frappe.logger().info(f"✅ Subscription created: {mollie_subscription.id}")
 
+            # The service owns the owning-DocType update: write the new
+            # subscription back onto the Member/Donor so callers do not have
+            # to do their own db_sets.
+            owner_doctype = customer_data.get("owner_doctype")
+            owner_name = customer_data.get("owner_name")
+            if owner_doctype and owner_name:
+                self._update_owner_record(
+                    owner_doctype,
+                    owner_name,
+                    {
+                        "mollie_customer_id": customer_id,
+                        "mollie_subscription_id": mollie_subscription.id,
+                        "subscription_status": mollie_subscription.status,
+                        "next_payment_date": getattr(mollie_subscription, "next_payment_date", None),
+                    },
+                )
+
             return {
                 "status": "success",
                 "customer_id": customer_result["customer_id"],
@@ -307,8 +324,8 @@ class CompletePaymentService:
             # Cancel in Mollie
             cancelled_subscription = self.client.cancel_subscription(customer_id, subscription_id)
 
-            # Update related documents
-            self._update_subscription_status(subscription_id, "cancelled", reason)
+            # Flip the owning Member/Donor onto the cancelled status.
+            self._update_subscription_status(subscription_id, "canceled", reason)
 
             frappe.logger().info(f"✅ Subscription cancelled: {subscription_id}")
 
@@ -626,10 +643,45 @@ class CompletePaymentService:
             )
 
     def _update_subscription_status(self, subscription_id: str, status: str, reason: str = "") -> None:
-        """Update subscription status in related documents."""
-        # TODO: Implement updating Member, Donor, or other relevant documents
-        # that track subscription status
-        frappe.logger().info(f"Subscription {subscription_id} status updated to {status}: {reason}")
+        """
+        Flip the owning Member/Donor's subscription status after a cancel.
+
+        The owner is located by `mollie_subscription_id`; Member is checked
+        before Donor.
+        """
+        for owner_doctype in ("Member", "Donor"):
+            owner_name = frappe.db.get_value(
+                owner_doctype, {"mollie_subscription_id": subscription_id}, "name"
+            )
+            if owner_name:
+                self._update_owner_record(
+                    owner_doctype,
+                    owner_name,
+                    {
+                        "subscription_status": status,
+                        "subscription_cancelled_date": frappe.utils.today(),
+                    },
+                )
+                frappe.logger().info(
+                    f"{owner_doctype} {owner_name}: subscription {subscription_id} -> {status} ({reason})"
+                )
+                return
+
+        frappe.logger().info(
+            f"No owning record found for subscription {subscription_id}; status update skipped"
+        )
+
+    def _update_owner_record(self, owner_doctype: str, owner_name: str, values: Dict[str, Any]) -> None:
+        """
+        Write subscription fields onto a Member/Donor record.
+
+        Any field the DocType does not define is skipped - Donor, unlike
+        Member, has no subscription_status / next_payment_date fields.
+        """
+        meta = frappe.get_meta(owner_doctype)
+        payload = {key: value for key, value in values.items() if meta.has_field(key)}
+        if payload:
+            frappe.db.set_value(owner_doctype, owner_name, payload, update_modified=False)
 
     def get_client_info(self) -> Dict[str, Any]:
         """Get information about the Mollie client configuration."""

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -281,10 +281,12 @@ class CompletePaymentService:
                 "message": "Subscription created successfully",
             }
 
-        except MolliePaymentError:
-            # Already a specific Mollie error (e.g. mandate provisioning or the
-            # subscription create itself) - propagate it without relabelling it
-            # as a generic "Failed to create subscription".
+        except (MolliePaymentError, MollieValidationError):
+            # Already a specific, well-typed Mollie error (mandate provisioning,
+            # the subscription create itself, the enable_subscriptions gate, or
+            # input validation) - propagate it with its own type and message so
+            # callers like unified_payment_api can distinguish a validation
+            # failure from a payment failure. Do not relabel or re-log it.
             raise
         except Exception as e:
             error_msg = f"Failed to create subscription: {e}"
@@ -305,7 +307,12 @@ class CompletePaymentService:
         return self.webhook_service.process_webhook(payment_id, payment_data)
 
     def cancel_subscription(
-        self, customer_id: str, subscription_id: str, reason: str = "Customer request"
+        self,
+        customer_id: str,
+        subscription_id: str,
+        reason: str = "Customer request",
+        owner_doctype: Optional[str] = None,
+        owner_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Cancel a subscription.
@@ -314,6 +321,10 @@ class CompletePaymentService:
             customer_id: Mollie customer ID
             subscription_id: Subscription to cancel
             reason: Cancellation reason
+            owner_doctype: Owning DocType ("Member"/"Donor"). When given with
+                owner_name, the owning record is updated directly instead of
+                being reverse-resolved from the (non-unique) subscription id.
+            owner_name: Owning record name
 
         Returns:
             Dict with cancellation results
@@ -325,7 +336,7 @@ class CompletePaymentService:
             cancelled_subscription = self.client.cancel_subscription(customer_id, subscription_id)
 
             # Flip the owning Member/Donor onto the cancelled status.
-            self._update_subscription_status(subscription_id, "canceled", reason)
+            self._update_subscription_status(subscription_id, "canceled", reason, owner_doctype, owner_name)
 
             frappe.logger().info(f"✅ Subscription cancelled: {subscription_id}")
 
@@ -565,10 +576,13 @@ class CompletePaymentService:
         # begin()/commit() bracket the row lock: commit()/rollback() release it.
         frappe.db.begin()
         try:
-            locked_row = frappe.db.sql(
-                "SELECT mollie_customer_id FROM `tabDonor` WHERE name = %s FOR UPDATE",
-                donor_name,
-                as_dict=True,
+            donor = DocType("Donor")
+            locked_row = (
+                frappe.qb.from_(donor)
+                .select(donor.mollie_customer_id)
+                .where(donor.name == donor_name)
+                .for_update()
+                .run(as_dict=True)
             )
 
             if not locked_row:
@@ -642,33 +656,53 @@ class CompletePaymentService:
                 f"Payment amount {payment_amount} differs from donation amount {donation_doc.amount}"
             )
 
-    def _update_subscription_status(self, subscription_id: str, status: str, reason: str = "") -> None:
+    def _update_subscription_status(
+        self,
+        subscription_id: str,
+        status: str,
+        reason: str = "",
+        owner_doctype: Optional[str] = None,
+        owner_name: Optional[str] = None,
+    ) -> None:
         """
         Flip the owning Member/Donor's subscription status after a cancel.
 
-        The owner is located by `mollie_subscription_id`; Member is checked
-        before Donor.
+        When the owner is known (the caller had the record in hand) it is used
+        directly. Otherwise the owner is reverse-resolved by
+        `mollie_subscription_id` - Member before Donor - which is best-effort:
+        `mollie_subscription_id` carries no uniqueness constraint, so a missing
+        match is logged as an error rather than passing silently.
         """
-        for owner_doctype in ("Member", "Donor"):
-            owner_name = frappe.db.get_value(
-                owner_doctype, {"mollie_subscription_id": subscription_id}, "name"
+        cancel_values = {
+            "subscription_status": status,
+            "subscription_cancelled_date": frappe.utils.today(),
+        }
+
+        if owner_doctype and owner_name:
+            self._update_owner_record(owner_doctype, owner_name, cancel_values)
+            frappe.logger().info(
+                f"{owner_doctype} {owner_name}: subscription {subscription_id} -> {status} ({reason})"
             )
-            if owner_name:
-                self._update_owner_record(
-                    owner_doctype,
-                    owner_name,
-                    {
-                        "subscription_status": status,
-                        "subscription_cancelled_date": frappe.utils.today(),
-                    },
-                )
+            return
+
+        for candidate_doctype in ("Member", "Donor"):
+            candidate_name = frappe.db.get_value(
+                candidate_doctype, {"mollie_subscription_id": subscription_id}, "name"
+            )
+            if candidate_name:
+                self._update_owner_record(candidate_doctype, candidate_name, cancel_values)
                 frappe.logger().info(
-                    f"{owner_doctype} {owner_name}: subscription {subscription_id} -> {status} ({reason})"
+                    f"{candidate_doctype} {candidate_name}: subscription "
+                    f"{subscription_id} -> {status} ({reason})"
                 )
                 return
 
-        frappe.logger().info(
-            f"No owning record found for subscription {subscription_id}; status update skipped"
+        # The Mollie-side cancel succeeded but no local record was updated -
+        # surface it so the inconsistency can be reconciled.
+        frappe.log_error(
+            f"Cancelled Mollie subscription {subscription_id} but found no owning "
+            f"Member/Donor to update (reason: {reason})",
+            "Mollie Subscription Cancel",
         )
 
     def _update_owner_record(self, owner_doctype: str, owner_name: str, values: Dict[str, Any]) -> None:

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -451,17 +451,17 @@ class CompletePaymentService:
             frappe.logger().info(f"❌ Cancelling subscription {subscription_id}")
 
             # Cancel in Mollie
-            cancelled_subscription = self.client.cancel_subscription(customer_id, subscription_id)
+            self.client.cancel_subscription(customer_id, subscription_id)
 
             # Flip the owning Member/Donor onto the cancelled status.
             self._update_subscription_status(subscription_id, "canceled", reason, owner_doctype, owner_name)
 
             frappe.logger().info(f"✅ Subscription cancelled: {subscription_id}")
 
+            # Standard cancel result shape.
             return {
                 "status": "success",
                 "subscription_id": subscription_id,
-                "cancelled_at": getattr(cancelled_subscription, "cancelled_at", None),
                 "message": "Subscription cancelled successfully",
             }
 

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -244,8 +244,16 @@ class CompletePaymentService:
         if owner_doctype not in ("Member", "Donor"):
             raise MollieValidationError(f"Unsupported subscription owner doctype: {owner_doctype}")
 
+        # Existence is checked before begin() so a "not found" raises cleanly
+        # without a transaction having to be opened and torn down.
+        if not frappe.db.exists(owner_doctype, owner_name):
+            raise MollieValidationError(f"{owner_doctype} {owner_name} not found")
+
         # begin()/commit() bracket the row lock; every exit path commits or
-        # rolls back so the lock is always released.
+        # rolls back so the lock is always released. The lock is held across
+        # the Mollie API calls below - that is intentional: it only ever
+        # blocks a concurrent create for the *same* owner, which is exactly
+        # the duplicate this prevents.
         frappe.db.begin()
         try:
             owner = DocType(owner_doctype)
@@ -257,15 +265,17 @@ class CompletePaymentService:
                 .run(as_dict=True)
             )
             if not locked_row:
-                frappe.db.commit()
+                # Raced with a delete between the exists-check and the lock.
                 raise MollieValidationError(f"{owner_doctype} {owner_name} not found")
 
             stored_customer_id = locked_row[0].get("mollie_customer_id")
             stored_subscription_id = locked_row[0].get("mollie_subscription_id")
 
-            # Idempotent: an owner that already has a live subscription gets
-            # that subscription back - no duplicate is provisioned.
-            if stored_subscription_id:
+            # Idempotent: an owner that already has a live (active/pending)
+            # subscription gets that subscription back - no duplicate is
+            # provisioned. Both ids must be present: a subscription id is only
+            # usable together with its customer id.
+            if stored_subscription_id and stored_customer_id:
                 existing = self._get_active_subscription(stored_customer_id, stored_subscription_id)
                 if existing is not None:
                     frappe.db.commit()
@@ -275,6 +285,16 @@ class CompletePaymentService:
                     return self._subscription_result(
                         stored_customer_id, existing, message="Subscription already exists"
                     )
+            elif stored_subscription_id:
+                # Subscription id without a customer id - the stored
+                # subscription cannot be looked up. Surface it and provision
+                # a fresh one rather than billing against an unknown customer.
+                frappe.log_error(
+                    f"{owner_doctype} {owner_name} has mollie_subscription_id "
+                    f"{stored_subscription_id} but no mollie_customer_id; "
+                    f"provisioning a fresh subscription.",
+                    "Mollie Subscription Create",
+                )
 
             customer_id = self._resolve_customer_id_locked(stored_customer_id, customer_data)
             mollie_subscription = self._provision_and_create_subscription(

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -125,7 +125,7 @@ class CompletePaymentService:
                 "locale": form_data.get("locale", "nl_NL"),
             }
 
-            customer_result = self._create_or_get_customer(customer_data)
+            customer_result = self._resolve_customer_by_email(customer_data)
 
             if not customer_result.get("customer_id"):
                 raise MolliePaymentError(
@@ -205,81 +205,13 @@ class CompletePaymentService:
             # Validate input data
             self._validate_subscription_data(customer_data, subscription_data)
 
-            # Create or get customer
-            customer_result = self._create_or_get_customer(customer_data)
-
-            if not customer_result.get("customer_id"):
-                raise MolliePaymentError(
-                    f"Failed to create customer for subscription: {customer_result.get('error')}"
-                )
-
-            customer_id = customer_result["customer_id"]
-
-            # Opt-in mandate provisioning: when an IBAN is supplied via
-            # `consumerAccount`, provision a SEPA direct-debit mandate before
-            # creating the subscription. This replaces the legacy
-            # MollieSettings.create_subscription path (which always did this)
-            # and keeps mandate provisioning an explicit, requested step
-            # rather than a hidden side effect of "create subscription".
-            consumer_account = subscription_data.get("consumerAccount")
-            if consumer_account:
-                mandate_data = {
-                    "method": "directdebit",
-                    "consumerName": customer_data.get("name", ""),
-                    "consumerAccount": consumer_account,
-                    "signatureDate": frappe.utils.today(),
-                    "mandateReference": f"MANDATE-{frappe.utils.random_string(8)}",
-                }
-                self.client.create_mandate(customer_id, mandate_data)
-
-            # consumerAccount is mandate-only input; Mollie's subscription API
-            # does not accept it, so strip it before creating the subscription
-            # (always - including the falsy "no IBAN" case).
-            if "consumerAccount" in subscription_data:
-                subscription_data = {k: v for k, v in subscription_data.items() if k != "consumerAccount"}
-
-            # Create subscription. Without a mandate (no consumerAccount and
-            # none established via a sequenceType="first" payment) Mollie
-            # rejects this with "No suitable mandates found".
-            try:
-                mollie_subscription = self.client.create_subscription(customer_id, subscription_data)
-            except Exception as e:
-                if "No suitable mandates found" in str(e):
-                    raise MolliePaymentError(
-                        "Cannot create subscription: No mandate exists for customer. "
-                        "For recurring donations, use create_recurring_donation_payment() "
-                        "to establish mandate first with sequenceType='first' payment.",
-                        original_error=e,
-                    )
-                raise
-
-            frappe.logger().info(f"✅ Subscription created: {mollie_subscription.id}")
-
-            # The service owns the owning-DocType update: write the new
-            # subscription back onto the Member/Donor so callers do not have
-            # to do their own db_sets.
             owner_doctype = customer_data.get("owner_doctype")
             owner_name = customer_data.get("owner_name")
             if owner_doctype and owner_name:
-                self._update_owner_record(
-                    owner_doctype,
-                    owner_name,
-                    {
-                        "mollie_customer_id": customer_id,
-                        "mollie_subscription_id": mollie_subscription.id,
-                        "subscription_status": mollie_subscription.status,
-                        "next_payment_date": getattr(mollie_subscription, "next_payment_date", None),
-                    },
+                return self._create_owner_subscription(
+                    owner_doctype, owner_name, customer_data, subscription_data
                 )
-
-            return {
-                "status": "success",
-                "customer_id": customer_result["customer_id"],
-                "subscription_id": mollie_subscription.id,
-                "subscription_status": mollie_subscription.status,
-                "next_payment_date": getattr(mollie_subscription, "next_payment_date", None),
-                "message": "Subscription created successfully",
-            }
+            return self._create_unowned_subscription(customer_data, subscription_data)
 
         except (MolliePaymentError, MollieValidationError):
             # Already a specific, well-typed Mollie error (mandate provisioning,
@@ -292,6 +224,192 @@ class CompletePaymentService:
             error_msg = f"Failed to create subscription: {e}"
             frappe.log_error(error_msg, "Subscription Creation Error")
             raise MolliePaymentError(error_msg, original_error=e)
+
+    def _create_owner_subscription(
+        self,
+        owner_doctype: str,
+        owner_name: str,
+        customer_data: Dict[str, Any],
+        subscription_data: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Create a subscription owned by a Member/Donor, holding a FOR UPDATE
+        lock on the owner row for the whole operation.
+
+        The lock blocks a concurrent create for the same owner: the second
+        request waits, then sees the subscription the first one wrote and
+        returns it instead of provisioning a duplicate at Mollie. An owner
+        that already has a live subscription is likewise returned as-is.
+        """
+        if owner_doctype not in ("Member", "Donor"):
+            raise MollieValidationError(f"Unsupported subscription owner doctype: {owner_doctype}")
+
+        # begin()/commit() bracket the row lock; every exit path commits or
+        # rolls back so the lock is always released.
+        frappe.db.begin()
+        try:
+            owner = DocType(owner_doctype)
+            locked_row = (
+                frappe.qb.from_(owner)
+                .select(owner.mollie_customer_id, owner.mollie_subscription_id)
+                .where(owner.name == owner_name)
+                .for_update()
+                .run(as_dict=True)
+            )
+            if not locked_row:
+                frappe.db.commit()
+                raise MollieValidationError(f"{owner_doctype} {owner_name} not found")
+
+            stored_customer_id = locked_row[0].get("mollie_customer_id")
+            stored_subscription_id = locked_row[0].get("mollie_subscription_id")
+
+            # Idempotent: an owner that already has a live subscription gets
+            # that subscription back - no duplicate is provisioned.
+            if stored_subscription_id:
+                existing = self._get_active_subscription(stored_customer_id, stored_subscription_id)
+                if existing is not None:
+                    frappe.db.commit()
+                    frappe.logger().info(
+                        f"{owner_doctype} {owner_name} already has subscription {existing.id}"
+                    )
+                    return self._subscription_result(
+                        stored_customer_id, existing, message="Subscription already exists"
+                    )
+
+            customer_id = self._resolve_customer_id_locked(stored_customer_id, customer_data)
+            mollie_subscription = self._provision_and_create_subscription(
+                customer_id, customer_data, subscription_data
+            )
+
+            # The service owns the owning-DocType update.
+            self._update_owner_record(
+                owner_doctype,
+                owner_name,
+                {
+                    "mollie_customer_id": customer_id,
+                    "mollie_subscription_id": mollie_subscription.id,
+                    "subscription_status": mollie_subscription.status,
+                    "next_payment_date": getattr(mollie_subscription, "next_payment_date", None),
+                },
+            )
+            frappe.db.commit()
+            frappe.logger().info(f"✅ Subscription created: {mollie_subscription.id}")
+            return self._subscription_result(customer_id, mollie_subscription)
+
+        except (MolliePaymentError, MollieValidationError):
+            frappe.db.rollback()
+            raise
+        except Exception as e:
+            frappe.db.rollback()
+            error_msg = f"Failed to create subscription: {e}"
+            frappe.log_error(error_msg, "Subscription Creation Error")
+            raise MolliePaymentError(error_msg, original_error=e)
+
+    def _create_unowned_subscription(
+        self, customer_data: Dict[str, Any], subscription_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Create a subscription with no explicit owner record (donation flow).
+
+        The Mollie customer is resolved by Donor email; nothing is written
+        back to a Frappe record here.
+        """
+        customer_result = self._resolve_customer_by_email(customer_data)
+        if not customer_result.get("customer_id"):
+            raise MolliePaymentError(
+                f"Failed to create customer for subscription: {customer_result.get('error')}"
+            )
+        customer_id = customer_result["customer_id"]
+        mollie_subscription = self._provision_and_create_subscription(
+            customer_id, customer_data, subscription_data
+        )
+        frappe.logger().info(f"✅ Subscription created: {mollie_subscription.id}")
+        return self._subscription_result(customer_id, mollie_subscription)
+
+    def _provision_and_create_subscription(
+        self, customer_id: str, customer_data: Dict[str, Any], subscription_data: Dict[str, Any]
+    ) -> Any:
+        """
+        Provision a SEPA mandate from an IBAN (when `consumerAccount` is given)
+        and create the Mollie subscription.
+
+        `consumerAccount` is mandate-only input - Mollie's subscription API
+        does not accept it - so it is always stripped before the create.
+        """
+        consumer_account = subscription_data.get("consumerAccount")
+        if consumer_account:
+            self.client.create_mandate(
+                customer_id,
+                {
+                    "method": "directdebit",
+                    "consumerName": customer_data.get("name", ""),
+                    "consumerAccount": consumer_account,
+                    "signatureDate": frappe.utils.today(),
+                    "mandateReference": f"MANDATE-{frappe.utils.random_string(8)}",
+                },
+            )
+        if "consumerAccount" in subscription_data:
+            subscription_data = {k: v for k, v in subscription_data.items() if k != "consumerAccount"}
+
+        # Without a mandate (no consumerAccount and none established via a
+        # sequenceType="first" payment) Mollie rejects the create.
+        try:
+            return self.client.create_subscription(customer_id, subscription_data)
+        except Exception as e:
+            if "No suitable mandates found" in str(e):
+                raise MolliePaymentError(
+                    "Cannot create subscription: No mandate exists for customer. "
+                    "For recurring donations, use create_recurring_donation_payment() "
+                    "to establish mandate first with sequenceType='first' payment.",
+                    original_error=e,
+                )
+            raise
+
+    def _resolve_customer_id_locked(
+        self, stored_customer_id: Optional[str], customer_data: Dict[str, Any]
+    ) -> str:
+        """
+        Resolve the Mollie customer id while the owner row is already locked:
+        reuse the stored id if it still resolves at Mollie, otherwise create a
+        fresh customer. No transaction control - the caller owns the lock.
+        """
+        if stored_customer_id:
+            try:
+                return self.client.get_customer(stored_customer_id).id
+            except Exception as e:
+                frappe.logger().warning(f"Stored Mollie customer {stored_customer_id} not retrievable: {e}")
+                # Stale id - fall through and create a fresh customer.
+        return self.client.create_customer(self._mollie_customer_payload(customer_data)).id
+
+    def _get_active_subscription(self, customer_id: Optional[str], subscription_id: str) -> Optional[Any]:
+        """
+        Return the Mollie subscription if it still exists and is active or
+        pending; otherwise None (so the caller provisions a fresh one).
+        """
+        try:
+            subscription = self.client.get_subscription(customer_id, subscription_id)
+        except Exception as e:
+            frappe.logger().warning(f"Stored subscription {subscription_id} not retrievable: {e}")
+            return None
+        if getattr(subscription, "status", None) in ("active", "pending"):
+            return subscription
+        return None
+
+    def _subscription_result(
+        self,
+        customer_id: Optional[str],
+        mollie_subscription: Any,
+        message: str = "Subscription created successfully",
+    ) -> Dict[str, Any]:
+        """Build the standard create-subscription result dict."""
+        return {
+            "status": "success",
+            "customer_id": customer_id,
+            "subscription_id": mollie_subscription.id,
+            "subscription_status": mollie_subscription.status,
+            "next_payment_date": getattr(mollie_subscription, "next_payment_date", None),
+            "message": message,
+        }
 
     def process_webhook(self, payment_id: str, payment_data: Optional[Any] = None) -> Dict[str, Any]:
         """
@@ -482,77 +600,6 @@ class CompletePaymentService:
             payment_data["sequenceType"] = form_data["sequenceType"]
 
         return payment_data
-
-    def _create_or_get_customer(self, customer_data: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Resolve the Mollie customer for a subscription.
-
-        When `customer_data` names an owning record (`owner_doctype` +
-        `owner_name`) the customer is resolved against that record - a
-        membership subscription against the Member, a donation against the
-        Donor - so a member's subscription never binds to a Donor's Mollie
-        customer just because they happen to share an email address. Without
-        an explicit owner, falls back to Donor-by-email resolution.
-        """
-        owner_doctype = customer_data.get("owner_doctype")
-        owner_name = customer_data.get("owner_name")
-        if owner_doctype and owner_name:
-            return self._resolve_customer_for_owner(owner_doctype, owner_name, customer_data)
-        return self._resolve_customer_by_email(customer_data)
-
-    def _resolve_customer_for_owner(
-        self, owner_doctype: str, owner_name: str, customer_data: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """
-        Reuse or create the Mollie customer recorded on a specific Member or
-        Donor, locking that row (SELECT ... FOR UPDATE) so concurrent requests
-        for the same owner cannot create duplicate Mollie customers.
-        """
-        if owner_doctype not in ("Member", "Donor"):
-            raise MollieValidationError(f"Unsupported subscription owner doctype: {owner_doctype}")
-
-        # begin()/commit() bracket the row lock: commit() persists the customer
-        # id and releases the lock; every exit path must commit() or rollback().
-        frappe.db.begin()
-        try:
-            owner = DocType(owner_doctype)
-            locked_row = (
-                frappe.qb.from_(owner)
-                .select(owner.mollie_customer_id)
-                .where(owner.name == owner_name)
-                .for_update()
-                .run(as_dict=True)
-            )
-
-            if not locked_row:
-                frappe.db.commit()
-                return create_error_response(f"{owner_doctype} {owner_name} not found")
-
-            existing_customer_id = locked_row[0].get("mollie_customer_id")
-            if existing_customer_id:
-                try:
-                    customer = self.client.get_customer(existing_customer_id)
-                    frappe.db.commit()  # Release lock
-                    return {"status": "found", "customer_id": customer.id}
-                except Exception as e:
-                    frappe.logger().warning(
-                        f"Existing customer ID {existing_customer_id} not found in Mollie: {e}"
-                    )
-                    # Stale id - fall through and create a fresh customer.
-
-            customer = self.client.create_customer(self._mollie_customer_payload(customer_data))
-            frappe.db.set_value(
-                owner_doctype, owner_name, "mollie_customer_id", customer.id, update_modified=False
-            )
-            frappe.db.commit()  # Commit and release lock
-            frappe.logger().info(f"Saved Mollie customer {customer.id} to {owner_doctype} {owner_name}")
-            return {"status": "created", "customer_id": customer.id}
-
-        except Exception as e:
-            frappe.db.rollback()
-            error_msg = f"Failed to create or get Mollie customer: {e}"
-            frappe.log_error(error_msg, "Mollie Customer Error")
-            return create_error_response(error_msg)
 
     def _resolve_customer_by_email(self, customer_data: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/verenigingen/verenigingen_payments/mollie/services/subscription_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/subscription_service.py
@@ -11,7 +11,6 @@ from frappe import _
 from frappe.utils import now_datetime
 
 from ..core.client import MollieClient
-from ..core.mollie_models import Subscription
 from ..exceptions import MollieIntegrationError
 from ..utils.amount_helpers import extract_amount_currency, extract_amount_float
 from ..utils.validators import PaymentDataValidator
@@ -65,7 +64,7 @@ class SubscriptionService:
             "metadata": subscription.metadata,
         }
 
-    def cancel_subscription(self, customer_id: str, subscription_id: str, reason: str = "") -> Subscription:
+    def cancel_subscription(self, customer_id: str, subscription_id: str, reason: str = "") -> Dict[str, Any]:
         """
         Cancel a subscription.
 
@@ -75,7 +74,7 @@ class SubscriptionService:
             reason: Optional cancellation reason
 
         Returns:
-            Canceled subscription object
+            Standard cancel result dict: {status, subscription_id, message}
         """
         subscription = self.client.cancel_subscription(customer_id, subscription_id)
 
@@ -92,7 +91,11 @@ class SubscriptionService:
             if donor_id:
                 self._update_donor_subscription_canceled(donor_id, subscription_id, reason)
 
-        return subscription
+        return {
+            "status": "success",
+            "subscription_id": subscription_id,
+            "message": "Subscription cancelled successfully",
+        }
 
     def process_subscription_payment(self, payment_id: str) -> Dict[str, Any]:
         """

--- a/verenigingen/verenigingen_payments/utils/payment_gateways.py
+++ b/verenigingen/verenigingen_payments/utils/payment_gateways.py
@@ -14,7 +14,6 @@ from verenigingen.utils.secure_operations import secure_document_operation
 from verenigingen.utils.security.api_security_framework import OperationType, high_security_api, public_api
 from verenigingen.utils.settings_utils import get_payments_settings
 from verenigingen.utils.validation_utilities import DocumentExistenceValidator
-from verenigingen.verenigingen_payments.mollie.core.client import MollieClient
 from verenigingen.verenigingen_payments.mollie.services.complete_payment_service import (
     CompletePaymentService,
 )
@@ -579,17 +578,12 @@ class MollieGateway(PaymentGateway):
                 mollie_subscription_data["startDate"] = subscription_data["start_date"]
 
             # Create subscription via the consolidated Mollie service layer.
+            # The service owns the Member update (mollie_customer_id,
+            # mollie_subscription_id, subscription_status, next_payment_date)
+            # via the owner_doctype/owner_name passed in customer_data.
             result = CompletePaymentService().create_customer_subscription(
                 customer_data, mollie_subscription_data
             )
-
-            # CompletePaymentService returns the Mollie subscription status
-            # under `subscription_status`; its `status` key is the literal
-            # "success", so the member field maps from `subscription_status`.
-            member.db_set("mollie_customer_id", result["customer_id"])
-            member.db_set("mollie_subscription_id", result["subscription_id"])
-            member.db_set("subscription_status", result["subscription_status"])
-            member.db_set("next_payment_date", result.get("next_payment_date"))
 
             frappe.logger().info(
                 f"Created Mollie subscription {result['subscription_id']} for member {member.name}"
@@ -662,14 +656,10 @@ class MollieGateway(PaymentGateway):
             if not (customer_id and subscription_id):
                 return create_error_response(_("No active subscription found for this member"))
 
-            # Cancel via the consolidated Mollie client. It raises on failure,
+            # Cancel via the consolidated service. It performs the Mollie
+            # cancel and owns the Member status update; it raises on failure,
             # so the surrounding except block is the error path.
-            MollieClient().cancel_subscription(customer_id, subscription_id)
-
-            # Update member subscription status. "canceled" (US spelling) is
-            # the only valid Member.subscription_status Select option.
-            member.db_set("subscription_status", "canceled")
-            member.db_set("subscription_cancelled_date", frappe.utils.today())
+            CompletePaymentService().cancel_subscription(customer_id, subscription_id)
 
             return create_success_response(_("Subscription cancelled successfully"))
 

--- a/verenigingen/verenigingen_payments/utils/payment_gateways.py
+++ b/verenigingen/verenigingen_payments/utils/payment_gateways.py
@@ -528,10 +528,14 @@ class MollieGateway(PaymentGateway):
                     "message": _("Subscriptions are not enabled for this Mollie gateway"),
                 }
 
-            # Prepare customer data
+            # Prepare customer data. owner_doctype/owner_name make the service
+            # resolve the Mollie customer against this Member - not against a
+            # Donor that happens to share the email address.
             customer_data = {
                 "name": f"{member.first_name} {member.last_name}".strip(),
                 "email": member.email,
+                "owner_doctype": "Member",
+                "owner_name": member.name,
                 "metadata": {
                     "member_id": member.name,
                     "member_number": getattr(member, "member_id", ""),

--- a/verenigingen/verenigingen_payments/utils/payment_gateways.py
+++ b/verenigingen/verenigingen_payments/utils/payment_gateways.py
@@ -513,6 +513,11 @@ class MollieGateway(PaymentGateway):
         """
         Create Mollie subscription for recurring membership dues
 
+        CompletePaymentService owns the Member update (mollie_customer_id,
+        mollie_subscription_id, subscription_status, next_payment_date) and
+        writes it via frappe.db.set_value - so the passed-in `member` document
+        object is stale after this call; reload() it if you need the new values.
+
         Args:
             member: Member document
             subscription_data (dict): Subscription configuration
@@ -643,6 +648,10 @@ class MollieGateway(PaymentGateway):
         """
         Cancel Mollie subscription for member
 
+        CompletePaymentService owns the Member status update, so the passed-in
+        `member` document object is stale after this call; reload() it if you
+        need the new values.
+
         Args:
             member: Member document with subscription details
 
@@ -658,8 +667,12 @@ class MollieGateway(PaymentGateway):
 
             # Cancel via the consolidated service. It performs the Mollie
             # cancel and owns the Member status update; it raises on failure,
-            # so the surrounding except block is the error path.
-            CompletePaymentService().cancel_subscription(customer_id, subscription_id)
+            # so the surrounding except block is the error path. The owner is
+            # passed explicitly so the service updates this Member directly
+            # rather than reverse-resolving by the non-unique subscription id.
+            CompletePaymentService().cancel_subscription(
+                customer_id, subscription_id, owner_doctype="Member", owner_name=member.name
+            )
 
             return create_success_response(_("Subscription cancelled successfully"))
 
@@ -1078,10 +1091,9 @@ def _activate_subscription_after_first_payment(gateway, member_name, member_cust
                 f"Successfully activated subscription {result['subscription_id']} for member {member_name}"
             )
 
-            # Update member with subscription details
-            member.db_set("mollie_subscription_id", result["subscription_id"])
-            member.db_set("subscription_status", "Active")
-            member.db_set("next_payment_date", subscription_data["startDate"])
+            # The subscription fields (mollie_subscription_id, subscription_status,
+            # next_payment_date) are written onto the member by
+            # CompletePaymentService - the gateway no longer does its own db_sets.
 
             return {
                 "status": "success",

--- a/verenigingen/verenigingen_payments/utils/payment_gateways.py
+++ b/verenigingen/verenigingen_payments/utils/payment_gateways.py
@@ -20,7 +20,6 @@ from verenigingen.verenigingen_payments.mollie.services.complete_payment_service
 from verenigingen.verenigingen_payments.mollie.utils.common_helpers import (
     convert_frequency_to_mollie_interval,
     create_error_response,
-    create_success_response,
     format_mollie_amount,
     format_mollie_amount_string,
     get_member_by_customer_id,
@@ -670,11 +669,10 @@ class MollieGateway(PaymentGateway):
             # so the surrounding except block is the error path. The owner is
             # passed explicitly so the service updates this Member directly
             # rather than reverse-resolving by the non-unique subscription id.
-            CompletePaymentService().cancel_subscription(
+            # Its return value is the standard cancel result shape.
+            return CompletePaymentService().cancel_subscription(
                 customer_id, subscription_id, owner_doctype="Member", owner_name=member.name
             )
-
-            return create_success_response(_("Subscription cancelled successfully"))
 
         except Exception as e:
             log_mollie_error("Subscription Cancellation", e, {"member": member.name})


### PR DESCRIPTION
## Phase 2 — standardise the mid-level create/cancel contract

Phase 2 of the Mollie subscription consolidation. Design:
`docs/plans/2026-05-18-mollie-subscription-consolidation-design.md` §2.

Phase 1 (PR #45) collapsed the two bottom-level SDK implementations onto one
(`MollieClient`). Phase 2 makes every mid-level create/cancel path obey one
standard contract.

### Tasks (all 6 complete)

1. **Spec** — expanded §2 into a precise task list (`89cb4b5c`).
2. **Standard result shape** (`bbaf6e6e`) — every cancel path returns
   `{status, subscription_id, message}`; `SubscriptionService.cancel_subscription`
   stopped returning a raw Mollie SDK object. Create shape unified via
   `_subscription_result`.
3. **`enable_subscriptions` gate in the contract** (`bb6dd101`) — moved into
   `CompletePaymentService` so no caller can bypass it.
4. **Single mandate helper** (`999e61d0`) — `_provision_and_create_subscription`
   provisions a SEPA mandate from an IBAN, strips `consumerAccount`, creates the
   subscription; used by every create path.
5. **Mandatory row locking on subscription create** (`999e61d0`) —
   `_create_owner_subscription` holds a `FOR UPDATE` lock on the owning
   Member/Donor row across the whole create. A concurrent create for the same
   owner waits; an owner that already has a live subscription gets it back
   (idempotent) instead of a duplicate being provisioned.
6. **Service owns the Member/Donor update** (`f02b131e`) — `CompletePaymentService`
   writes the subscription back onto the owner on create and cancel via
   `_update_owner_record` / `_update_subscription_status`; `MollieGateway`
   dropped its `db_set`s.
7. **Owner-aware customer resolution** (`ff40793c`) — customer resolution
   dispatches on an explicit `owner_doctype`/`owner_name`, so a membership
   subscription never binds to a Donor that shares the member's email.

`66e24b66` applies the first round of double-review feedback (tasks 3/6/7):
the `enable_subscriptions` gate exception type, explicit owner pass-through on
cancel, removal of an invalid `subscription_status="Active"` write, and more.

### Tests

`tests/payment/test_mollie_subscription_consolidation.py` — 19 tests against a
fake Mollie SDK (the external boundary), covering the gate, owner-aware
resolution, service-owned updates, the locked idempotent create, and the
standard result shapes. All green; ruff clean.

### Review status

Tasks 3/6/7 had a double review (fixes in `66e24b66`). **Tasks 4/5/2 — the
locked-create restructure and the result-shape standardisation — have not been
reviewed yet** and should get a double review before merge.

### Not in scope

Phase 3 (route `MollieDebugService` through the standardised services) is a
separate follow-up PR.