### PR TITLE
refactor(mollie): Phase 3 — fold the debug-service paths into the consolidated contract

### DIFF
--- a/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
+++ b/docs/plans/2026-05-18-mollie-subscription-consolidation-design.md
@@ -1,7 +1,7 @@
 # Consolidate Mollie subscription create/cancel logic
 
 **Date:** 2026-05-18
-**Status:** Phases 1 & 2 complete and merged; Phase 3 pending.
+**Status:** Phases 1 & 2 complete and merged; Phase 3 in progress.
 **Context:** Audit T4.4 follow-up. Retiring `MollieConnector` (PR #44) unblocked this.
 
 ## 1. Problem
@@ -240,14 +240,101 @@ payment code.
   `duplicate_subscriptions`) its caller `amendment_events` relies on. These
   are kept *in addition to* the standard keys, not replaced.
 
-### Phase 3 — fold in the debug-service paths ⏳ PENDING
-- Route `MollieDebugService.create_subscription` / `admin_cancel_subscription`
-  through the standardised services so the admin tooling cannot drift.
-- `MollieGateway`-adjacent caller cleanup: `create_member_subscription` in
-  `payment_gateways.py` still calls `MollieDebugService.create_subscription`
-  directly and does its own `db_set`s — once the debug service routes through
-  `CompletePaymentService`, those `db_set`s become redundant (the service owns
-  the owner update) and should be removed, mirroring Phase 2 task 6.
+### Phase 3 — fold in the debug-service paths ⏳ IN PROGRESS
+
+Branch: `refactor/mollie-subscription-consolidation-phase3`. TDD each step —
+payment code.
+
+#### 3.0 Findings from the Phase 3 investigation
+
+- **`MollieDebugService` works at a different abstraction level.** Its
+  `create_subscription`, `create_scheduled_subscription` and
+  `admin_cancel_subscription` are admin debug tooling: every caller (the
+  `mollie_payments_debug`, `mollie_bulk_payment_creation` and
+  `mollie_subscription_recreation` template pages, plus `mollie_payment.py`)
+  passes a **raw Mollie `customer_id`** — often with an explicit `mandate_id` —
+  and consumes the debug-flavoured result dict (`create_success_response` /
+  `create_error_response`). That does **not** fit
+  `CompletePaymentService.create_customer_subscription`, whose contract
+  resolves or creates the Mollie customer from `customer_data["email"]` and
+  has no path for "use this exact existing customer id". `admin_cancel_subscription`
+  also deliberately tolerates an already-cancelled subscription
+  (`status: "warning"`), whereas `CompletePaymentService.cancel_subscription`
+  raises on any failure.
+- **Decision (confirmed with the maintainer):** the debug service routes
+  through **`MollieClient`** — the single standardised bottom-level SDK
+  wrapper — not through `CompletePaymentService`. This removes the real drift
+  (the debug methods currently reach past even `MollieClient` to
+  `self.mollie_client.sdk_client`) without forcing an ill-fitting owner/email
+  create contract onto raw-customer-id admin tooling. The debug result shape
+  and the "already cancelled" tolerance are preserved. `MollieClient`'s
+  subscription methods carry no retry/circuit-breaker decorators, so this
+  changes no runtime behaviour beyond the call path.
+- **`create_member_subscription`** (the whitelisted endpoint in
+  `payment_gateways.py`) has **no JS/HTML caller** — only a
+  `critical_operation_rule.json` fixture entry references it — so its return
+  shape is not consumed by the frontend. It routes through
+  `MollieGateway.create_subscription`, which already goes through
+  `CompletePaymentService` with `owner_doctype`/`owner_name`.
+
+#### 3.1 Task list
+
+1. **`MollieDebugService.create_subscription`** — replace the raw-SDK create
+   (`self.mollie_client.sdk_client` → `customers.get` → `subscriptions.create`)
+   with `self.mollie_client.create_subscription(customer_id, subscription_data)`.
+   `MollieClient.create_subscription` raises `MolliePaymentError` on failure;
+   the method's existing `except Exception` block already sanitises and returns
+   an error response. Result shape unchanged. TDD: the create delegates to
+   `MollieClient` and returns the success shape; a failure returns the
+   sanitised error shape.
+2. **`MollieDebugService.create_scheduled_subscription`** — same replacement.
+   Not named in the original Phase 3 bullet, but it carries the identical
+   raw-SDK create drift; consolidating its sibling while leaving it raw would
+   re-introduce exactly the drift this phase removes.
+3. **`MollieDebugService.admin_cancel_subscription`** — replace the raw-SDK
+   `customers.get(...).subscriptions.delete(...)` with
+   `self.mollie_client.cancel_subscription(customer_id, subscription_id)`.
+   Preserve the "already cancelled → `status: "warning"`" branch:
+   `MollieClient.cancel_subscription` wraps the SDK error as
+   `MolliePaymentError("Failed to cancel subscription <id>: <e>")`, so the
+   original phrases ("not found", "already cancelled", …) remain in the
+   message and the existing `phrase in error_message.lower()` check still
+   matches. TDD: the success path, and an "already cancelled" path that still
+   returns `warning`.
+4. **`payment_gateways.py` `create_member_subscription`** — route through
+   `MollieGateway.create_subscription(member, subscription_data)` instead of
+   `MollieDebugService.create_subscription`. The gateway already routes through
+   `CompletePaymentService` with `owner_doctype`/`owner_name`, so the service
+   owns the Member update.
+   - **Remove** the redundant `member.db_set("mollie_subscription_id", …)` —
+     `CompletePaymentService._update_owner_record` writes it.
+   - **Keep** `member.db_set("payment_method", "Mollie")` — it is *not*
+     redundant: the contract writes `mollie_customer_id`,
+     `mollie_subscription_id`, `subscription_status` and `next_payment_date`,
+     but not `payment_method`. (The original handoff said "remove them";
+     investigation shows only one of the two is redundant.) The `member`
+     object is stale after the service's `frappe.db.set_value` writes, but
+     `db_set` writes straight to the DB so the `payment_method` write is
+     still correct.
+   - Keep the existing early-return guards (already-active subscription,
+     missing `mollie_customer_id`).
+   - **Known behaviour change:** the gateway path passes
+     `consumerAccount = member.iban`, so `CompletePaymentService` *provisions
+     a fresh SEPA mandate from the IBAN* before creating the subscription,
+     whereas the old debug path passed `mandate_id=None` and let Mollie
+     auto-select an existing mandate. This aligns `create_member_subscription`
+     with the Phase-1-blessed `MollieGateway.create_subscription` contract
+     used by the rest of the app. Flagged for review.
+
+#### 3.2 Out of scope
+
+- `MollieDebugService`'s other raw-SDK uses — `update_subscription_webhook`,
+  the bulk "cancel all subscriptions + revoke mandate" helper, and the
+  payment / mandate / customer debug methods. Phase 3 touches only the
+  subscription create/cancel paths named in §4.
+- **Tests:** extend `tests/payment/test_mollie_subscription_consolidation.py`
+  with a `MollieDebugService` test class reusing `FakeSDKClient` / `_patch_sdk`,
+  and a `create_member_subscription` test. TDD each task.
 
 ## 5. Risks & test strategy
 

--- a/verenigingen/services/mollie_debug_service.py
+++ b/verenigingen/services/mollie_debug_service.py
@@ -293,10 +293,11 @@ class MollieDebugService(StatelessService):
             raise ValueError(_("Cancellation reason is required"))
 
         try:
-            # Use direct Mollie API call to avoid retry/circuit breaker issues
-            client = self.mollie_client.sdk_client
-            customer_obj = client.customers.get(customer_id)
-            cancelled_subscription = customer_obj.subscriptions.delete(subscription_id)
+            # Route through the standardised MollieClient wrapper rather than
+            # the raw SDK, so this admin path cannot drift from the contract.
+            # cancel_subscription raises MolliePaymentError on failure; the
+            # except block below inspects its message for "already cancelled".
+            self.mollie_client.cancel_subscription(customer_id, subscription_id)
 
             # Structured audit trail logging
             self.audit_trail.log_event(
@@ -1604,9 +1605,6 @@ class MollieDebugService(StatelessService):
             raise ValueError(_("Invalid interval - must be one of: {0}").format(", ".join(valid_intervals)))
 
         try:
-            # Get the raw Mollie client
-            client = self.mollie_client.sdk_client
-
             # Build subscription data
             # Note: webhookUrl intentionally omitted to use Mollie dashboard webhook settings
             # This ensures webhooks go to the correct environment (production/test)
@@ -1646,9 +1644,9 @@ class MollieDebugService(StatelessService):
                             f"(interval: {interval}, configured months: {mollie_settings.quarterly_yearly_payment_months})"
                         )
 
-            # Create subscription
-            customer = client.customers.get(customer_id)
-            subscription = customer.subscriptions.create(subscription_data)
+            # Create the subscription through the standardised MollieClient
+            # wrapper rather than reaching the raw SDK directly.
+            subscription = self.mollie_client.create_subscription(customer_id, subscription_data)
 
             # Structured audit trail logging
             self.audit_trail.log_event(
@@ -1835,8 +1833,6 @@ class MollieDebugService(StatelessService):
         }
 
         try:
-            client = self.mollie_client.sdk_client
-
             subscription_data = {
                 "amount": format_mollie_amount(amount_float),
                 "interval": mollie_interval,
@@ -1859,8 +1855,9 @@ class MollieDebugService(StatelessService):
             if resolved_start:
                 subscription_data["startDate"] = resolved_start
 
-            customer = client.customers.get(customer_id)
-            subscription = customer.subscriptions.create(subscription_data)
+            # Create the subscription through the standardised MollieClient
+            # wrapper rather than reaching the raw SDK directly.
+            subscription = self.mollie_client.create_subscription(customer_id, subscription_data)
 
             result["status"] = "success"
             result["subscription_id"] = subscription.id

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -1,9 +1,10 @@
 """
-Tests for the Mollie subscription create/cancel consolidation (Phases 1 and 2).
+Tests for the Mollie subscription create/cancel consolidation (Phases 1-3).
 
 Phase 1 collapses the two bottom-level subscription implementations onto a
 single SDK path (``MollieClient``); Phase 2 standardises the mid-level
-create/cancel contract. See
+create/cancel contract; Phase 3 routes the ``MollieDebugService`` admin
+tooling through ``MollieClient`` so it can no longer reach the raw SDK. See
 ``docs/plans/2026-05-18-mollie-subscription-consolidation-design.md``.
 
 The Mollie SDK is the external boundary; it is replaced here by ``FakeSDKClient``
@@ -64,6 +65,11 @@ class _FakeSubscription:
         self.canceled_at = None
         self.cancelled_at = None
         self.metadata = {}
+        # The MollieDebugService success responses read these fields directly
+        # (not via getattr), so the fake must carry them.
+        self.amount = {"value": "15.00", "currency": "EUR"}
+        self.interval = "1 month"
+        self.description = "Fake subscription"
 
 
 class _FakeMandates:
@@ -152,6 +158,31 @@ class RaisingSDKClient:
 
     def __init__(self):
         self.customers = _RaisingCustomers()
+
+
+class _AlreadyCancelledSubscriptions:
+    def delete(self, subscription_id):
+        # Mimics Mollie rejecting a delete for a subscription that is already
+        # gone - the message carries a phrase MollieDebugService treats as a
+        # tolerable "already cancelled" outcome.
+        raise RuntimeError("Subscription not found or has been cancelled")
+
+
+class _AlreadyCancelledCustomer:
+    def __init__(self):
+        self.subscriptions = _AlreadyCancelledSubscriptions()
+
+
+class _AlreadyCancelledCustomers:
+    def get(self, customer_id):
+        return _AlreadyCancelledCustomer()
+
+
+class AlreadyCancelledSDKClient:
+    """Fake SDK whose subscription delete fails as 'already cancelled'."""
+
+    def __init__(self):
+        self.customers = _AlreadyCancelledCustomers()
 
 
 def _make_mollie_client(sdk):
@@ -776,3 +807,133 @@ class TestMollieSubscriptionContract(EnhancedTestCase):
         new_customer_id = frappe.db.get_value("Member", member.name, "mollie_customer_id")
         self.assertTrue(new_customer_id)
         self.assertNotEqual(new_customer_id, "cst_STALE")
+
+
+class _DelegationSpy:
+    """Wrap a class method so its calls are recorded while the real method
+    still runs. Used to assert MollieDebugService delegates to MollieClient
+    rather than reaching the raw SDK directly.
+
+    Mock justified: this is a spy, not a stub - the real wrapped method runs,
+    the Mollie SDK stays the only faked boundary. It only records that the
+    standardised MollieClient layer was the path taken, which is precisely
+    the Phase 3 contract under test.
+    """
+
+    def __init__(self, cls, method_name):
+        self._real = getattr(cls, method_name)
+        self.calls = []
+
+        def wrapper(inner_self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return self._real(inner_self, *args, **kwargs)
+
+        self._patch = patch.object(cls, method_name, wrapper)
+
+    def __enter__(self):
+        self._patch.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._patch.stop()
+        return False
+
+
+class TestMollieDebugServiceSubscription(EnhancedTestCase):
+    """Phase 3 - MollieDebugService subscription create/cancel route through
+    MollieClient instead of the raw SDK."""
+
+    def test_create_subscription_delegates_to_mollie_client(self):
+        sdk = FakeSDKClient()
+
+        with _patch_sdk(sdk), _DelegationSpy(MollieClient, "create_subscription") as spy:
+            from verenigingen.services.mollie_debug_service import MollieDebugService
+
+            service = MollieDebugService()
+            result = service.create_subscription(
+                customer_id="cst_DEBUG",
+                amount=15.0,
+                interval="1 month",
+                description="Debug subscription",
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["subscription_id"], "sub_FAKE")
+        # The create went through MollieClient, not the raw sdk_client.
+        self.assertEqual(len(spy.calls), 1)
+        self.assertEqual(spy.calls[0][0][0], "cst_DEBUG")
+        # And the SDK still received exactly one subscription create.
+        self.assertEqual(len(sdk.recorder.subscriptions_created), 1)
+
+    def test_create_subscription_failure_returns_sanitised_error(self):
+        """An SDK failure surfaces as the debug error shape, not an exception."""
+        with _patch_sdk(RaisingSDKClient()):
+            from verenigingen.services.mollie_debug_service import MollieDebugService
+
+            service = MollieDebugService()
+            result = service.create_subscription(
+                customer_id="cst_DEBUG",
+                amount=15.0,
+                interval="1 month",
+                description="Debug subscription",
+            )
+
+        self.assertEqual(result["status"], "error")
+
+    def test_create_scheduled_subscription_delegates_to_mollie_client(self):
+        sdk = FakeSDKClient()
+
+        with _patch_sdk(sdk), _DelegationSpy(MollieClient, "create_subscription") as spy:
+            from verenigingen.services.mollie_debug_service import MollieDebugService
+
+            service = MollieDebugService()
+            result = service.create_scheduled_subscription(
+                customer_id="cst_DEBUG",
+                amount=15.0,
+                interval_count=1,
+                interval_unit="months",
+                description="Debug scheduled subscription",
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["subscription_id"], "sub_FAKE")
+        self.assertEqual(len(spy.calls), 1)
+        self.assertEqual(spy.calls[0][0][0], "cst_DEBUG")
+        self.assertEqual(len(sdk.recorder.subscriptions_created), 1)
+
+    def test_admin_cancel_subscription_delegates_to_mollie_client(self):
+        sdk = FakeSDKClient()
+
+        with _patch_sdk(sdk), _DelegationSpy(MollieClient, "cancel_subscription") as spy:
+            from verenigingen.services.mollie_debug_service import MollieDebugService
+
+            service = MollieDebugService()
+            result = service.admin_cancel_subscription(
+                customer_id="cst_DEBUG",
+                subscription_id="sub_LIVE",
+                reason="Test cancellation",
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(len(spy.calls), 1)
+        self.assertEqual(spy.calls[0][0], ("cst_DEBUG", "sub_LIVE"))
+        self.assertEqual(sdk.recorder.subscriptions_deleted, ["sub_LIVE"])
+
+    def test_admin_cancel_already_cancelled_returns_warning(self):
+        """An already-cancelled subscription is tolerated (status 'warning'),
+        even though MollieClient.cancel_subscription raises - the wrapped
+        MolliePaymentError keeps the SDK's 'not found' phrasing."""
+        with _patch_sdk(AlreadyCancelledSDKClient()), _DelegationSpy(
+            MollieClient, "cancel_subscription"
+        ) as spy:
+            from verenigingen.services.mollie_debug_service import MollieDebugService
+
+            service = MollieDebugService()
+            result = service.admin_cancel_subscription(
+                customer_id="cst_DEBUG",
+                subscription_id="sub_GONE",
+                reason="Test cancellation",
+            )
+
+        self.assertEqual(result["status"], "warning")
+        self.assertEqual(len(spy.calls), 1)

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -504,6 +504,38 @@ class TestMollieGatewaySubscription(EnhancedTestCase):
             frappe.db.get_value("Member", member.name, "subscription_status"), "active"
         )
 
+    def test_create_member_subscription_routes_through_gateway(self):
+        """Phase 3 - the create_member_subscription endpoint delegates to
+        MollieGateway, so CompletePaymentService owns the Member update:
+        subscription_status lands on the Member, which the old
+        MollieDebugService path never set. payment_method is not part of the
+        contract the service owns, so the endpoint still sets it itself."""
+        member = self._make_member()
+        frappe.db.set_value(
+            "Member", member.name, "mollie_customer_id", "cst_MEMBER", update_modified=False
+        )
+        sdk = FakeSDKClient()
+
+        with _patch_sdk(sdk):
+            from verenigingen.verenigingen_payments.utils.payment_gateways import (
+                create_member_subscription,
+            )
+
+            result = create_member_subscription(member.name, 15.0, interval="1 month")
+
+        self.assertEqual(result["status"], "success")
+        # The service owns the Member update - subscription_status is set.
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "subscription_status"), "active"
+        )
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "mollie_subscription_id"), "sub_FAKE"
+        )
+        # payment_method is still set by create_member_subscription itself.
+        self.assertEqual(
+            frappe.db.get_value("Member", member.name, "payment_method"), "Mollie"
+        )
+
 
 class TestMollieSubscriptionContract(EnhancedTestCase):
     """Phase 2 - standardised mid-level create/cancel contract."""

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -536,6 +536,48 @@ class TestMollieGatewaySubscription(EnhancedTestCase):
             frappe.db.get_value("Member", member.name, "payment_method"), "Mollie"
         )
 
+    def test_create_member_subscription_blocks_existing_active_subscription(self):
+        """The early guard must fire for a member who already has a live
+        subscription. subscription_status is stored lowercase, so the guard
+        compares against 'active'."""
+        member = self._make_member()
+        frappe.db.set_value(
+            "Member",
+            member.name,
+            {
+                "mollie_customer_id": "cst_MEMBER",
+                "mollie_subscription_id": "sub_EXISTING",
+                "subscription_status": "active",
+            },
+            update_modified=False,
+        )
+
+        from verenigingen.verenigingen_payments.utils.payment_gateways import (
+            create_member_subscription,
+        )
+
+        result = create_member_subscription(member.name, 15.0, interval="1 month")
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["existing_subscription_id"], "sub_EXISTING")
+
+    def test_create_member_subscription_rejects_unsupported_interval(self):
+        """An interval the gateway does not support is rejected outright,
+        rather than being silently coerced to monthly billing."""
+        member = self._make_member()
+        frappe.db.set_value(
+            "Member", member.name, "mollie_customer_id", "cst_MEMBER", update_modified=False
+        )
+
+        from verenigingen.verenigingen_payments.utils.payment_gateways import (
+            create_member_subscription,
+        )
+
+        result = create_member_subscription(member.name, 15.0, interval="12 months")
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Unsupported", result["message"])
+
 
 class TestMollieSubscriptionContract(EnhancedTestCase):
     """Phase 2 - standardised mid-level create/cancel contract."""

--- a/verenigingen/verenigingen_payments/utils/payment_gateways.py
+++ b/verenigingen/verenigingen_payments/utils/payment_gateways.py
@@ -2007,25 +2007,26 @@ def create_member_subscription(member_id, amount, interval="1 month", descriptio
                 "message": _("No Mollie customer ID found. Please set up payment details first."),
             }
 
-        # Use existing MollieDebugService for subscription creation
-        # This handles mandate auto-selection and all the edge cases
-        from verenigingen.services.mollie_debug_service import MollieDebugService
-
-        debug_service = MollieDebugService()
-
-        # Create subscription using the existing service method
-        result = debug_service.create_subscription(
-            customer_id=member.mollie_customer_id,
-            amount=float(amount),
-            interval=interval,
-            description=description or f"Membership dues for {member.first_name} {member.last_name}",
-            mandate_id=None,  # Let Mollie auto-select active mandate
-            start_date=start_date,
+        # Create the subscription via the consolidated Mollie gateway, which
+        # routes through CompletePaymentService with owner_doctype/owner_name -
+        # so the service owns the Member update (mollie_customer_id,
+        # mollie_subscription_id, subscription_status, next_payment_date).
+        gateway = PaymentGatewayFactory.get_gateway("Mollie", "Default")
+        result = gateway.create_subscription(
+            member,
+            {
+                "amount": float(amount),
+                "interval": interval,
+                "description": description or f"Membership dues for {member.first_name} {member.last_name}",
+                "start_date": start_date,
+            },
         )
 
-        # If successful, update member record
-        if result.get("status") == "success" and result.get("subscription_id"):
-            member.db_set("mollie_subscription_id", result["subscription_id"])
+        # payment_method is not part of the subscription contract the service
+        # owns, so it is still set here. db_set writes straight to the DB,
+        # which is correct even though `member` is stale after the service's
+        # set_value writes.
+        if result.get("status") == "success":
             member.db_set("payment_method", "Mollie")
 
         return result

--- a/verenigingen/verenigingen_payments/utils/payment_gateways.py
+++ b/verenigingen/verenigingen_payments/utils/payment_gateways.py
@@ -1990,8 +1990,10 @@ def create_member_subscription(member_id, amount, interval="1 month", descriptio
     try:
         member = frappe.get_doc("Member", member_id)
 
-        # Check if member already has an active subscription
-        if member.mollie_subscription_id and member.subscription_status == "Active":
+        # Check if member already has an active subscription. The
+        # subscription_status Select field stores lowercase values
+        # ("active"/"pending"/...), so the comparison must be lowercase too.
+        if member.mollie_subscription_id and member.subscription_status == "active":
             return {
                 "status": "error",
                 "message": _(
@@ -2005,6 +2007,19 @@ def create_member_subscription(member_id, amount, interval="1 month", descriptio
             return {
                 "status": "error",
                 "message": _("No Mollie customer ID found. Please set up payment details first."),
+            }
+
+        # Validate the interval against what the gateway actually supports.
+        # The gateway maps unknown intervals to "1 month", which would
+        # silently bill a member monthly when they asked for quarterly or
+        # annual - so reject unsupported values explicitly instead.
+        supported_intervals = ("1 month", "3 months", "6 months", "1 year")
+        if interval not in supported_intervals:
+            return {
+                "status": "error",
+                "message": _("Unsupported subscription interval: {0}. Use one of: {1}.").format(
+                    interval, ", ".join(supported_intervals)
+                ),
             }
 
         # Create the subscription via the consolidated Mollie gateway, which


### PR DESCRIPTION
## Phase 3 of the Mollie subscription consolidation

Final phase. Routes the remaining ad-hoc subscription create/cancel paths onto the consolidated contract. Design: `docs/plans/2026-05-18-mollie-subscription-consolidation-design.md` §4 Phase 3 (§3.0 findings, §3.1 task list).

Phases 1 & 2: PRs #45, #46, #47.

### What changed

- **`MollieDebugService`** — `create_subscription`, `create_scheduled_subscription` and `admin_cancel_subscription` reached past the standardised `MollieClient` wrapper to `self.mollie_client.sdk_client` (the raw SDK). All three now route through `MollieClient.create_subscription` / `cancel_subscription`, so the admin debug tooling can no longer drift from the consolidated SDK contract. Result shapes and the `admin_cancel` "already cancelled → `warning`" tolerance are unchanged.
- **`create_member_subscription`** (whitelisted endpoint in `payment_gateways.py`) — routed through `MollieGateway.create_subscription` instead of `MollieDebugService.create_subscription`. The gateway already goes through `CompletePaymentService` with `owner_doctype`/`owner_name`, so the service owns the Member update; the redundant `member.db_set("mollie_subscription_id", …)` is dropped. `payment_method` is kept (not part of the contract the service owns).

### Design decisions

- The debug service routes through **`MollieClient`**, not `CompletePaymentService` — its methods operate on raw Mollie customer ids, which don't fit the service's email/owner-record create contract. Confirmed with the maintainer.
- `MollieClient`'s subscription methods carry no retry/circuit-breaker decorators, so the routing change alters no runtime behaviour beyond the call path.

### Behaviour changes (review these)

1. **Mandate provisioning** — via the gateway, `create_member_subscription` passes `consumerAccount = member.iban`, so `CompletePaymentService` provisions a *fresh* SEPA mandate rather than letting Mollie auto-select an existing one. This aligns the endpoint with `MollieGateway.create_subscription`, which is already the app's modern path. A possible duplicate-mandate-on-resubscribe risk lives in `_provision_and_create_subscription` (Phase 1/2 code) — **pre-existing, out of scope here**, see follow-up below.
2. **Interval validation** — the gateway silently maps unknown intervals to `1 month`. To avoid silently billing monthly when an unsupported value is passed, `create_member_subscription` now rejects intervals outside `1 month / 3 months / 6 months / 1 year`. (The old debug path's vocabulary differed: `2 months` / `12 months` were accepted, `1 year` was not.)
3. **Guard casing fix** — the "already has an active subscription" guard compared `subscription_status` against `"Active"`; the Select field stores lowercase. Fixed to `"active"` (Phase 3 is what now populates that field via the service).
4. **Minor:** an already-cancelled `admin_cancel_subscription` now also writes a "Mollie Client" Error Log entry, because `MollieClient.cancel_subscription` logs all failures before raising. Cosmetic noise inherent to routing through the standardised wrapper.
5. **Minor:** `create_member_subscription`'s response has fewer keys (gateway result shape). No JS/HTML/Python callers — only a `critical_operation_rule.json` fixture entry.

### Suggested follow-up (not in this PR)

`CompletePaymentService._provision_and_create_subscription` always creates a fresh `directdebit` mandate when `consumerAccount` is given, with no `list_mandates` de-dup. On a re-subscribe after cancellation an old valid mandate may still exist at Mollie. Pre-existing Phase 1/2 behaviour; worth a ticket to reuse an existing valid mandate.

### Tests

`verenigingen/tests/payment/test_mollie_subscription_consolidation.py` — 29 tests, all passing. New: 5 `MollieDebugService` routing tests (delegation via a `_DelegationSpy` helper + already-cancelled tolerance), 3 `create_member_subscription` tests (gateway routing, existing-subscription guard, interval rejection). TDD'd: each is red on `develop`, green here.

### Review

Double-reviewed: code-quality + skeptical. The skeptical review verdict was "safe to merge as-is"; its two in-scope findings (guard casing, interval coercion) are fixed in this PR; the duplicate-mandate finding is the documented follow-up above.