### PR TITLE
fix(mollie): reuse an existing SEPA mandate instead of provisioning a duplicate

### DIFF
--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -51,9 +51,13 @@ class _Recorder:
 
 
 class _FakeMandate:
-    def __init__(self, mandate_id="mdt_FAKE", status="valid"):
+    def __init__(self, mandate_id="mdt_FAKE", status="valid", method="directdebit",
+                 consumer_account=None):
         self.id = mandate_id
         self.status = status
+        self.method = method
+        # Mollie returns directdebit mandate bank details under `details`.
+        self.details = {"consumerAccount": consumer_account} if consumer_account else {}
 
 
 class _FakeSubscription:
@@ -73,9 +77,11 @@ class _FakeSubscription:
 
 
 class _FakeMandates:
-    def __init__(self, recorder, raises=False):
+    def __init__(self, recorder, raises=False, existing=None, list_raises=False):
         self._recorder = recorder
         self._raises = raises
+        self._existing = existing or []
+        self._list_raises = list_raises
 
     def create(self, data=None):
         if self._raises:
@@ -84,7 +90,9 @@ class _FakeMandates:
         return _FakeMandate()
 
     def list(self):
-        return []
+        if self._list_raises:
+            raise RuntimeError("simulated Mollie mandate list failure")
+        return list(self._existing)
 
 
 class _FakeSubscriptions:
@@ -105,26 +113,37 @@ class _FakeSubscriptions:
 
 
 class _FakeCustomer:
-    def __init__(self, recorder, customer_id, sub_status, mandate_raises):
+    def __init__(self, recorder, customer_id, sub_status, mandate_raises,
+                 existing_mandates, mandate_list_raises):
         self.id = customer_id
-        self.mandates = _FakeMandates(recorder, raises=mandate_raises)
+        self.mandates = _FakeMandates(
+            recorder, raises=mandate_raises, existing=existing_mandates,
+            list_raises=mandate_list_raises,
+        )
         self.subscriptions = _FakeSubscriptions(recorder, sub_status)
 
 
 class _FakeCustomers:
-    def __init__(self, recorder, sub_status, mandate_raises, stale_customer_id):
+    def __init__(self, recorder, sub_status, mandate_raises, stale_customer_id,
+                 existing_mandates, mandate_list_raises):
         self._recorder = recorder
         self._sub_status = sub_status
         self._mandate_raises = mandate_raises
         self._stale_customer_id = stale_customer_id
+        self._existing_mandates = existing_mandates
+        self._mandate_list_raises = mandate_list_raises
         self._counter = 0
+
+    def _build(self, customer_id):
+        return _FakeCustomer(
+            self._recorder, customer_id, self._sub_status, self._mandate_raises,
+            self._existing_mandates, self._mandate_list_raises,
+        )
 
     def create(self, data=None):
         self._recorder.customers_created.append(data)
         self._counter += 1
-        return _FakeCustomer(
-            self._recorder, f"cst_FAKE{self._counter}", self._sub_status, self._mandate_raises
-        )
+        return self._build(f"cst_FAKE{self._counter}")
 
     def get(self, customer_id):
         self._recorder.customers_fetched.append(customer_id)
@@ -132,16 +151,18 @@ class _FakeCustomers:
         # customers (and every other id) resolve normally.
         if self._stale_customer_id and customer_id == self._stale_customer_id:
             raise RuntimeError("simulated stale/unknown Mollie customer")
-        return _FakeCustomer(self._recorder, customer_id, self._sub_status, self._mandate_raises)
+        return self._build(customer_id)
 
 
 class FakeSDKClient:
     """Stand-in for ``mollie.api.client.Client``."""
 
-    def __init__(self, sub_status="active", mandate_raises=False, stale_customer_id=None):
+    def __init__(self, sub_status="active", mandate_raises=False, stale_customer_id=None,
+                 existing_mandates=None, mandate_list_raises=False):
         self.recorder = _Recorder()
         self.customers = _FakeCustomers(
-            self.recorder, sub_status, mandate_raises, stale_customer_id
+            self.recorder, sub_status, mandate_raises, stale_customer_id,
+            existing_mandates, mandate_list_raises,
         )
 
 
@@ -228,6 +249,21 @@ class TestMollieClient(EnhancedTestCase):
         with self.assertRaises(MolliePaymentError):
             client.cancel_subscription("cst_123", "sub_123")
 
+    def test_list_mandates_wraps_sdk_customer_mandates_list(self):
+        sdk = FakeSDKClient(existing_mandates=[_FakeMandate(mandate_id="mdt_X")])
+        client = _make_mollie_client(sdk)
+
+        mandates = client.list_mandates("cst_123")
+
+        self.assertEqual([m.id for m in mandates], ["mdt_X"])
+        self.assertEqual(sdk.recorder.customers_fetched, ["cst_123"])
+
+    def test_list_mandates_wraps_sdk_errors_in_mollie_payment_error(self):
+        client = _make_mollie_client(RaisingSDKClient())
+
+        with self.assertRaises(MolliePaymentError):
+            client.list_mandates("cst_123")
+
 
 class TestCompletePaymentServiceSubscription(EnhancedTestCase):
     """Phase 1, step 2 - CompletePaymentService.create_customer_subscription."""
@@ -303,6 +339,125 @@ class TestCompletePaymentServiceSubscription(EnhancedTestCase):
         # subscription create payload (Mollie's API rejects it there).
         self.assertEqual(len(sdk.recorder.subscriptions_created), 1)
         self.assertNotIn("consumerAccount", sdk.recorder.subscriptions_created[0])
+
+    def test_create_subscription_reuses_existing_mandate_for_same_iban(self):
+        """A customer that already has a valid SEPA mandate for the same IBAN
+        gets no second mandate provisioned - the subscription reuses it."""
+        iban = "NL39RABO0300065264"
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(status="valid", method="directdebit", consumer_account=iban)
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        result = service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": iban,
+            },
+        )
+
+        self.assertEqual(result["status"], "success")
+        # No duplicate mandate - the existing valid one is reused.
+        self.assertEqual(sdk.recorder.mandates_created, [])
+        self.assertEqual(len(sdk.recorder.subscriptions_created), 1)
+
+    def test_create_subscription_reuses_existing_mandate_ignoring_iban_spacing(self):
+        """IBAN comparison ignores spacing/case, so a spaced IBAN still
+        matches an existing mandate stored without spaces."""
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(
+                    status="valid", method="directdebit",
+                    consumer_account="NL39RABO0300065264",
+                )
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": "nl39 rabo 0300 0652 64",
+            },
+        )
+
+        self.assertEqual(sdk.recorder.mandates_created, [])
+
+    def test_create_subscription_provisions_mandate_when_iban_differs(self):
+        """An existing mandate for a *different* IBAN does not block
+        provisioning - the member may have changed banks."""
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(
+                    status="valid", method="directdebit",
+                    consumer_account="NL11INGB0001111111",
+                )
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": "NL39RABO0300065264",
+            },
+        )
+
+        self.assertEqual(len(sdk.recorder.mandates_created), 1)
+
+    def test_create_subscription_provisions_mandate_when_existing_is_invalid(self):
+        """An existing mandate that is not valid/pending (e.g. invalid) does
+        not count - a fresh mandate is provisioned."""
+        iban = "NL39RABO0300065264"
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(status="invalid", method="directdebit", consumer_account=iban)
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": iban,
+            },
+        )
+
+        self.assertEqual(len(sdk.recorder.mandates_created), 1)
+
+    def test_create_subscription_provisions_mandate_when_mandate_listing_fails(self):
+        """If the mandate lookup itself errors, provisioning falls back to
+        creating a mandate (fail open) so the subscription still succeeds."""
+        iban = "NL39RABO0300065264"
+        sdk = FakeSDKClient(mandate_list_raises=True)
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        result = service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": iban,
+            },
+        )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(len(sdk.recorder.mandates_created), 1)
 
     def test_create_customer_subscription_propagates_mandate_failure(self):
         """If mandate provisioning fails, the original mandate error must

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -60,6 +60,32 @@ class _FakeMandate:
         self.details = {"consumerAccount": consumer_account} if consumer_account else {}
 
 
+# Mollie paginates list endpoints at 50/page; a small page size here keeps
+# the pagination tests legible (3 mandates already span two pages).
+_FAKE_MANDATE_PAGE_SIZE = 2
+
+
+class _FakePaginationList:
+    """Stand-in for Mollie's ``PaginationList``: iterating yields only the
+    *current* page, and ``get_next()`` returns the following page (or None).
+
+    This deliberately mirrors the real SDK's non-auto-paginating behaviour so
+    ``MollieClient.list_mandates`` is exercised against it - a plain list
+    would silently hide the need to walk pages.
+    """
+
+    def __init__(self, items, page_size=_FAKE_MANDATE_PAGE_SIZE):
+        self._items = list(items)
+        self._page_size = page_size
+
+    def __iter__(self):
+        return iter(self._items[: self._page_size])
+
+    def get_next(self):
+        rest = self._items[self._page_size:]
+        return _FakePaginationList(rest, self._page_size) if rest else None
+
+
 class _FakeSubscription:
     def __init__(self, subscription_id="sub_FAKE", status="active",
                  next_payment_date="2026-06-01"):
@@ -92,7 +118,9 @@ class _FakeMandates:
     def list(self):
         if self._list_raises:
             raise RuntimeError("simulated Mollie mandate list failure")
-        return list(self._existing)
+        # Return a paginating list, as the real SDK does, so list_mandates
+        # has to walk pages rather than trust the first one.
+        return _FakePaginationList(self._existing)
 
 
 class _FakeSubscriptions:
@@ -135,6 +163,11 @@ class _FakeCustomers:
         self._counter = 0
 
     def _build(self, customer_id):
+        # Caveat: every customer this fake builds - including freshly
+        # created()d ones - carries the same existing_mandates. A real new
+        # Mollie customer has none. Tests here only ever resolve one
+        # customer, so this is harmless; a future multi-customer test must
+        # not rely on a created customer starting mandate-free.
         return _FakeCustomer(
             self._recorder, customer_id, self._sub_status, self._mandate_raises,
             self._existing_mandates, self._mandate_list_raises,
@@ -458,6 +491,80 @@ class TestCompletePaymentServiceSubscription(EnhancedTestCase):
 
         self.assertEqual(result["status"], "success")
         self.assertEqual(len(sdk.recorder.mandates_created), 1)
+
+    def test_create_subscription_reuses_pending_mandate(self):
+        """A directdebit mandate still being established (status 'pending')
+        counts as usable - provisioning a second one would duplicate it."""
+        iban = "NL39RABO0300065264"
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(status="pending", method="directdebit", consumer_account=iban)
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": iban,
+            },
+        )
+
+        self.assertEqual(sdk.recorder.mandates_created, [])
+
+    def test_create_subscription_provisions_when_only_creditcard_mandate(self):
+        """A non-directdebit mandate (e.g. creditcard) for the IBAN does not
+        count - a SEPA directdebit mandate is still provisioned."""
+        iban = "NL39RABO0300065264"
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(status="valid", method="creditcard", consumer_account=iban)
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": iban,
+            },
+        )
+
+        self.assertEqual(len(sdk.recorder.mandates_created), 1)
+
+    def test_create_subscription_finds_matching_mandate_on_a_later_page(self):
+        """Mollie paginates the mandate list; the match must be found even
+        when it sits beyond the first page."""
+        iban = "NL39RABO0300065264"
+        # Page size is 2, so a valid match in position 3 is on page 2.
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(mandate_id="mdt_1", status="invalid", method="directdebit"),
+                _FakeMandate(mandate_id="mdt_2", status="valid", method="directdebit",
+                             consumer_account="NL11INGB0001111111"),
+                _FakeMandate(mandate_id="mdt_3", status="valid", method="directdebit",
+                             consumer_account=iban),
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": iban,
+            },
+        )
+
+        self.assertEqual(sdk.recorder.mandates_created, [])
 
     def test_create_customer_subscription_propagates_mandate_failure(self):
         """If mandate provisioning fails, the original mandate error must

--- a/verenigingen/verenigingen_payments/mollie/core/client.py
+++ b/verenigingen/verenigingen_payments/mollie/core/client.py
@@ -283,6 +283,28 @@ class MollieClient:
             frappe.log_error(error_msg, "Mollie Client")
             raise MolliePaymentError(error_msg, original_error=e)
 
+    def list_mandates(self, customer_id: str) -> Any:
+        """
+        List the payment mandates for a customer.
+
+        Args:
+            customer_id: The Mollie customer ID
+
+        Returns:
+            Iterable of Mollie mandate objects
+
+        Raises:
+            MolliePaymentError: When the mandates cannot be listed
+        """
+        try:
+            client = self._get_mollie_client()
+            customer = client.customers.get(customer_id)
+            return customer.mandates.list()
+        except Exception as e:
+            error_msg = f"Failed to list mandates for customer {customer_id}: {e}"
+            frappe.log_error(error_msg, "Mollie Client")
+            raise MolliePaymentError(error_msg, original_error=e)
+
     def list_customer_payments(self, customer_id: str, limit: int = 50) -> Any:
         """
         List payments for a customer.

--- a/verenigingen/verenigingen_payments/mollie/core/client.py
+++ b/verenigingen/verenigingen_payments/mollie/core/client.py
@@ -283,15 +283,19 @@ class MollieClient:
             frappe.log_error(error_msg, "Mollie Client")
             raise MolliePaymentError(error_msg, original_error=e)
 
-    def list_mandates(self, customer_id: str) -> Any:
+    def list_mandates(self, customer_id: str) -> list:
         """
-        List the payment mandates for a customer.
+        List all payment mandates for a customer, across every page.
+
+        Mollie's SDK returns a ``PaginationList`` whose iterator only yields
+        the first page (50 results). Callers need the complete set, so this
+        walks ``get_next()`` and returns a flat list.
 
         Args:
             customer_id: The Mollie customer ID
 
         Returns:
-            Iterable of Mollie mandate objects
+            List of Mollie mandate objects
 
         Raises:
             MolliePaymentError: When the mandates cannot be listed
@@ -299,7 +303,12 @@ class MollieClient:
         try:
             client = self._get_mollie_client()
             customer = client.customers.get(customer_id)
-            return customer.mandates.list()
+            mandates = []
+            page = customer.mandates.list()
+            while page is not None:
+                mandates.extend(page)
+                page = page.get_next()
+            return mandates
         except Exception as e:
             error_msg = f"Failed to list mandates for customer {customer_id}: {e}"
             frappe.log_error(error_msg, "Mollie Client")
@@ -564,8 +573,9 @@ class MollieClient:
                     }
                 )
 
-            # Get mandates
-            mandates = customer_obj.mandates.list()
+            # Get mandates via list_mandates so every page is included
+            # (the raw PaginationList iterator only yields the first).
+            mandates = self.list_mandates(customer_id)
             for mandate in mandates:
                 result["mandates"].append(
                     {

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -393,8 +393,10 @@ class CompletePaymentService:
     def _has_usable_directdebit_mandate(self, customer_id: str, iban: str) -> bool:
         """
         True when the customer already holds a SEPA directdebit mandate for
-        this IBAN that Mollie can still bill against (status `valid` or
-        `pending`) - in which case a fresh mandate need not be provisioned.
+        this IBAN that is `valid`, or `pending` (still being established) -
+        in which case a fresh mandate need not be provisioned. A `pending`
+        mandate is not billable yet, but provisioning a second one would
+        only stack a duplicate rather than help; it is treated as usable.
 
         IBAN comparison ignores spacing and case. Fails open: if the mandate
         list cannot be retrieved, returns False so the caller still

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -353,11 +353,16 @@ class CompletePaymentService:
         Provision a SEPA mandate from an IBAN (when `consumerAccount` is given)
         and create the Mollie subscription.
 
+        A mandate is only provisioned when the customer does not already have
+        a usable directdebit mandate for that IBAN - so a re-subscribe after a
+        cancellation reuses the existing mandate instead of stacking a
+        duplicate one at Mollie.
+
         `consumerAccount` is mandate-only input - Mollie's subscription API
         does not accept it - so it is always stripped before the create.
         """
         consumer_account = subscription_data.get("consumerAccount")
-        if consumer_account:
+        if consumer_account and not self._has_usable_directdebit_mandate(customer_id, consumer_account):
             self.client.create_mandate(
                 customer_id,
                 {
@@ -384,6 +389,40 @@ class CompletePaymentService:
                     original_error=e,
                 )
             raise
+
+    def _has_usable_directdebit_mandate(self, customer_id: str, iban: str) -> bool:
+        """
+        True when the customer already holds a SEPA directdebit mandate for
+        this IBAN that Mollie can still bill against (status `valid` or
+        `pending`) - in which case a fresh mandate need not be provisioned.
+
+        IBAN comparison ignores spacing and case. Fails open: if the mandate
+        list cannot be retrieved, returns False so the caller still
+        provisions a mandate rather than risking a subscription create with
+        no mandate at all.
+        """
+        target = iban.replace(" ", "").upper()
+        try:
+            mandates = self.client.list_mandates(customer_id)
+        except Exception as e:
+            frappe.logger().warning(
+                f"Could not list mandates for customer {customer_id}; " f"provisioning a mandate anyway: {e}"
+            )
+            return False
+
+        for mandate in mandates:
+            if getattr(mandate, "method", None) != "directdebit":
+                continue
+            if getattr(mandate, "status", None) not in ("valid", "pending"):
+                continue
+            details = getattr(mandate, "details", None) or {}
+            if isinstance(details, dict):
+                existing = details.get("consumerAccount")
+            else:
+                existing = getattr(details, "consumerAccount", None)
+            if existing and existing.replace(" ", "").upper() == target:
+                return True
+        return False
 
     def _resolve_customer_id_locked(
         self, stored_customer_id: Optional[str], customer_data: Dict[str, Any]


### PR DESCRIPTION
## Follow-up from PR #49 review

The skeptical review of Phase 3 (PR #49) flagged a latent bug in `CompletePaymentService._provision_and_create_subscription`: whenever a `consumerAccount` (IBAN) was supplied, it created a **fresh `directdebit` mandate every time** — no de-dup. On a re-subscribe after a cancellation, the member's prior mandate is usually still valid at Mollie (mandates outlive subscriptions), so this stacked a duplicate mandate.

This was pre-existing Phase 1/2 behaviour, out of scope for #49; this PR is the documented follow-up.

## Change

- **`_provision_and_create_subscription`** provisions a mandate only when the customer has no usable directdebit mandate for that IBAN.
- **New `_has_usable_directdebit_mandate(customer_id, iban)` helper** — true when the customer holds a `directdebit` mandate with status `valid` or `pending` whose `consumerAccount` matches the IBAN (spacing/case ignored). It **fails open**: if the mandate list can't be retrieved, it returns `False` so a mandate is still provisioned rather than risking a subscription create with no mandate.
- An existing mandate for a **different** IBAN does *not* block provisioning — a genuine bank change still gets a fresh mandate.
- **New `MollieClient.list_mandates(customer_id)`** wrapping `customer.mandates.list()`, with the same `MolliePaymentError` error-handling shape as the other client methods.

## Tests

`verenigingen/tests/payment/test_mollie_subscription_consolidation.py` — 36 tests, all passing. New:
- `MollieClient.list_mandates` — SDK delegation + error wrapping.
- de-dup: reuse existing valid mandate for the same IBAN (incl. spaced/mixed-case IBAN), still provision when the IBAN differs, still provision when the existing mandate is `invalid`, and fail-open when the mandate listing itself errors.

TDD'd: the reuse tests and the `list_mandates` tests are red on `develop`, green here; the "still provision" cases are characterization guards.