### PR TITLE
fix(mollie): pin the mandate id explicitly on subscription create

### DIFF
--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -566,6 +566,102 @@ class TestCompletePaymentServiceSubscription(EnhancedTestCase):
 
         self.assertEqual(sdk.recorder.mandates_created, [])
 
+    def test_create_subscription_pins_reused_valid_mandate_id(self):
+        """When an existing valid mandate is reused, its id is pinned on the
+        subscription via mandateId - Mollie does not auto-select."""
+        iban = "NL39RABO0300065264"
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(mandate_id="mdt_EXISTING", status="valid",
+                             method="directdebit", consumer_account=iban)
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": iban,
+            },
+        )
+
+        self.assertEqual(sdk.recorder.mandates_created, [])
+        self.assertEqual(sdk.recorder.subscriptions_created[0]["mandateId"], "mdt_EXISTING")
+
+    def test_create_subscription_pins_freshly_created_mandate_id(self):
+        """When a mandate is provisioned, that new mandate's id is pinned on
+        the subscription rather than left to Mollie's auto-select."""
+        sdk = FakeSDKClient()
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": "NL39RABO0300065264",
+            },
+        )
+
+        self.assertEqual(len(sdk.recorder.mandates_created), 1)
+        self.assertEqual(sdk.recorder.subscriptions_created[0]["mandateId"], "mdt_FAKE")
+
+    def test_create_subscription_pins_new_mandate_not_old_after_bank_change(self):
+        """A member who changed banks holds a valid mandate for the *old*
+        IBAN. The subscription must pin the freshly-provisioned mandate for
+        the new IBAN, never auto-select onto the old account."""
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(mandate_id="mdt_OLD", status="valid",
+                             method="directdebit", consumer_account="NL11INGB0001111111")
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": "NL39RABO0300065264",
+            },
+        )
+
+        self.assertEqual(len(sdk.recorder.mandates_created), 1)
+        pinned = sdk.recorder.subscriptions_created[0]["mandateId"]
+        self.assertEqual(pinned, "mdt_FAKE")
+        self.assertNotEqual(pinned, "mdt_OLD")
+
+    def test_create_subscription_does_not_pin_a_pending_mandate(self):
+        """A pending mandate blocks duplicate provisioning but is not
+        billable, so it is not pinned - Mollie selects it once it is valid."""
+        iban = "NL39RABO0300065264"
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(mandate_id="mdt_PENDING", status="pending",
+                             method="directdebit", consumer_account=iban)
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": iban,
+            },
+        )
+
+        self.assertEqual(sdk.recorder.mandates_created, [])
+        self.assertNotIn("mandateId", sdk.recorder.subscriptions_created[0])
+
     def test_create_customer_subscription_propagates_mandate_failure(self):
         """If mandate provisioning fails, the original mandate error must
         surface (not be relabelled "Failed to create subscription"), and the

--- a/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
+++ b/verenigingen/tests/payment/test_mollie_subscription_consolidation.py
@@ -637,9 +637,12 @@ class TestCompletePaymentServiceSubscription(EnhancedTestCase):
         self.assertEqual(pinned, "mdt_FAKE")
         self.assertNotEqual(pinned, "mdt_OLD")
 
-    def test_create_subscription_does_not_pin_a_pending_mandate(self):
-        """A pending mandate blocks duplicate provisioning but is not
-        billable, so it is not pinned - Mollie selects it once it is valid."""
+    def test_create_subscription_pins_pending_mandate_to_block_auto_select(self):
+        """A pending mandate is pinned too: leaving mandateId unset would
+        let Mollie auto-select a stale valid mandate for a different IBAN
+        (the bank-change risk). Pinning the pending mandate is safer -
+        Mollie either accepts it and waits for it to become valid, or
+        rejects with a clear error; both beat silent wrong-account billing."""
         iban = "NL39RABO0300065264"
         sdk = FakeSDKClient(
             existing_mandates=[
@@ -660,7 +663,95 @@ class TestCompletePaymentServiceSubscription(EnhancedTestCase):
         )
 
         self.assertEqual(sdk.recorder.mandates_created, [])
-        self.assertNotIn("mandateId", sdk.recorder.subscriptions_created[0])
+        self.assertEqual(
+            sdk.recorder.subscriptions_created[0]["mandateId"], "mdt_PENDING"
+        )
+
+    def test_create_subscription_pins_pending_when_stale_valid_for_other_iban_exists(self):
+        """The bank-change failure mode that motivated pinning: a stale
+        `valid` mandate for the OLD IBAN coexists with a `pending` mandate
+        for the NEW IBAN. With no pinning, Mollie auto-selects the only
+        billable mandate - the stale one - and bills the wrong account.
+        The pending new-IBAN mandate must be pinned even though it is not
+        yet billable, so Mollie cannot reach the old mandate."""
+        new_iban = "NL39RABO0300065264"
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(mandate_id="mdt_OLD_VALID", status="valid",
+                             method="directdebit", consumer_account="NL11INGB0001111111"),
+                _FakeMandate(mandate_id="mdt_NEW_PENDING", status="pending",
+                             method="directdebit", consumer_account=new_iban),
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": new_iban,
+            },
+        )
+
+        self.assertEqual(sdk.recorder.mandates_created, [])
+        pinned = sdk.recorder.subscriptions_created[0].get("mandateId")
+        self.assertEqual(pinned, "mdt_NEW_PENDING")
+        self.assertNotEqual(pinned, "mdt_OLD_VALID")
+
+    def test_create_subscription_preserves_caller_supplied_mandate_id(self):
+        """If the caller passes a `mandateId` in subscription_data, it is
+        left untouched - mandate resolution does not overwrite it, even
+        when an existing valid mandate would otherwise be pinned."""
+        iban = "NL39RABO0300065264"
+        sdk = FakeSDKClient(
+            existing_mandates=[
+                _FakeMandate(mandate_id="mdt_RESOLVED", status="valid",
+                             method="directdebit", consumer_account=iban)
+            ]
+        )
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": iban,
+                "mandateId": "mdt_CALLER_OVERRIDE",
+            },
+        )
+
+        self.assertEqual(
+            sdk.recorder.subscriptions_created[0]["mandateId"], "mdt_CALLER_OVERRIDE"
+        )
+
+    def test_create_subscription_pins_freshly_provisioned_mandate_after_list_fails(self):
+        """Fail-open path: when list_mandates raises, a fresh mandate is
+        provisioned and that mandate's id must still be pinned. Otherwise
+        the fail-open re-introduces the wrong-account billing risk if a
+        stale valid mandate exists at Mollie that the failed list never
+        surfaced."""
+        iban = "NL39RABO0300065264"
+        sdk = FakeSDKClient(mandate_list_raises=True)
+        service = CompletePaymentService(client=_make_mollie_client(sdk))
+
+        service.create_customer_subscription(
+            {"name": "Jane Doe", "email": _unique_email()},
+            {
+                "amount": {"value": "15.00", "currency": "EUR"},
+                "interval": "1 month",
+                "description": "Membership dues",
+                "consumerAccount": iban,
+            },
+        )
+
+        self.assertEqual(len(sdk.recorder.mandates_created), 1)
+        self.assertEqual(
+            sdk.recorder.subscriptions_created[0]["mandateId"], "mdt_FAKE"
+        )
 
     def test_create_customer_subscription_propagates_mandate_failure(self):
         """If mandate provisioning fails, the original mandate error must

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -384,12 +384,25 @@ class CompletePaymentService:
                     },
                 )
                 mandate_id = getattr(created, "id", None)
-            elif getattr(existing_mandate, "status", None) == "valid":
-                # Reuse the existing valid mandate, pinned explicitly below.
+                if mandate_id is None:
+                    # Mollie returning a mandate object without an id should
+                    # not happen, but if it does the subscription would fall
+                    # through to no-pin and re-introduce the auto-select
+                    # risk. Surface it loudly rather than silently degrade.
+                    frappe.logger().warning(
+                        f"Mollie created a mandate for customer {customer_id} "
+                        f"without an id; subscription will be created without "
+                        f"mandateId and risks auto-selecting a stale mandate."
+                    )
+            else:
+                # Reuse the existing mandate. Both `valid` and `pending` are
+                # pinned: pinning `pending` does not bill yet, but it prevents
+                # Mollie from auto-selecting an older valid mandate that may
+                # exist for a previous IBAN (the bank-change wrong-account
+                # risk). Mollie either accepts the pending mandate and waits
+                # for it to become valid, or rejects the create with a clear
+                # error - both beat silent wrong-account billing.
                 mandate_id = getattr(existing_mandate, "id", None)
-            # else: a pending (not-yet-billable) mandate exists - reuse it by
-            # not provisioning a duplicate, but leave mandateId unset so
-            # Mollie selects it once it becomes valid.
 
         if "consumerAccount" in subscription_data:
             subscription_data = {k: v for k, v in subscription_data.items() if k != "consumerAccount"}
@@ -420,8 +433,9 @@ class CompletePaymentService:
 
         A `valid` mandate is preferred and returned as soon as one is found.
         A `pending` mandate (still being established) is returned only if no
-        valid one exists: it still blocks provisioning a duplicate, but it is
-        not yet billable so the caller does not pin it.
+        valid one exists. Both block provisioning a duplicate AND are pinned
+        by the caller - pinning a pending mandate prevents Mollie from
+        falling back to a stale valid mandate for a different IBAN.
 
         IBAN comparison ignores spacing and case. Fails open: if the mandate
         list cannot be retrieved, returns None so the caller still provisions

--- a/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
+++ b/verenigingen/verenigingen_payments/mollie/services/complete_payment_service.py
@@ -358,23 +358,47 @@ class CompletePaymentService:
         cancellation reuses the existing mandate instead of stacking a
         duplicate one at Mollie.
 
+        The mandate is then pinned on the subscription via `mandateId`, so
+        Mollie does not auto-select a different mandate the customer may
+        still hold (e.g. an older one for a previous bank account).
+
         `consumerAccount` is mandate-only input - Mollie's subscription API
         does not accept it - so it is always stripped before the create.
         """
         consumer_account = subscription_data.get("consumerAccount")
-        if consumer_account and not self._has_usable_directdebit_mandate(customer_id, consumer_account):
-            self.client.create_mandate(
-                customer_id,
-                {
-                    "method": "directdebit",
-                    "consumerName": customer_data.get("name", ""),
-                    "consumerAccount": consumer_account,
-                    "signatureDate": frappe.utils.today(),
-                    "mandateReference": f"MANDATE-{frappe.utils.random_string(8)}",
-                },
-            )
+        mandate_id = None
+        if consumer_account:
+            existing_mandate = self._find_usable_directdebit_mandate(customer_id, consumer_account)
+            if existing_mandate is None:
+                # No usable mandate for this IBAN - provision one. A mandate
+                # created via the Mandates API with directdebit details is
+                # valid immediately, so its id is safe to pin below.
+                created = self.client.create_mandate(
+                    customer_id,
+                    {
+                        "method": "directdebit",
+                        "consumerName": customer_data.get("name", ""),
+                        "consumerAccount": consumer_account,
+                        "signatureDate": frappe.utils.today(),
+                        "mandateReference": f"MANDATE-{frappe.utils.random_string(8)}",
+                    },
+                )
+                mandate_id = getattr(created, "id", None)
+            elif getattr(existing_mandate, "status", None) == "valid":
+                # Reuse the existing valid mandate, pinned explicitly below.
+                mandate_id = getattr(existing_mandate, "id", None)
+            # else: a pending (not-yet-billable) mandate exists - reuse it by
+            # not provisioning a duplicate, but leave mandateId unset so
+            # Mollie selects it once it becomes valid.
+
         if "consumerAccount" in subscription_data:
             subscription_data = {k: v for k, v in subscription_data.items() if k != "consumerAccount"}
+
+        # Pin the mandate so Mollie cannot auto-select a different one (an
+        # older mandate for a previous IBAN would otherwise bill the wrong
+        # account). A caller-supplied mandateId is left untouched.
+        if mandate_id and not subscription_data.get("mandateId"):
+            subscription_data = {**subscription_data, "mandateId": mandate_id}
 
         # Without a mandate (no consumerAccount and none established via a
         # sequenceType="first" payment) Mollie rejects the create.
@@ -390,18 +414,18 @@ class CompletePaymentService:
                 )
             raise
 
-    def _has_usable_directdebit_mandate(self, customer_id: str, iban: str) -> bool:
+    def _find_usable_directdebit_mandate(self, customer_id: str, iban: str) -> Optional[Any]:
         """
-        True when the customer already holds a SEPA directdebit mandate for
-        this IBAN that is `valid`, or `pending` (still being established) -
-        in which case a fresh mandate need not be provisioned. A `pending`
-        mandate is not billable yet, but provisioning a second one would
-        only stack a duplicate rather than help; it is treated as usable.
+        Return the customer's SEPA directdebit mandate for this IBAN, or None.
+
+        A `valid` mandate is preferred and returned as soon as one is found.
+        A `pending` mandate (still being established) is returned only if no
+        valid one exists: it still blocks provisioning a duplicate, but it is
+        not yet billable so the caller does not pin it.
 
         IBAN comparison ignores spacing and case. Fails open: if the mandate
-        list cannot be retrieved, returns False so the caller still
-        provisions a mandate rather than risking a subscription create with
-        no mandate at all.
+        list cannot be retrieved, returns None so the caller still provisions
+        a mandate rather than risking a subscription create with no mandate.
         """
         target = iban.replace(" ", "").upper()
         try:
@@ -410,21 +434,26 @@ class CompletePaymentService:
             frappe.logger().warning(
                 f"Could not list mandates for customer {customer_id}; " f"provisioning a mandate anyway: {e}"
             )
-            return False
+            return None
 
+        pending_match = None
         for mandate in mandates:
             if getattr(mandate, "method", None) != "directdebit":
                 continue
-            if getattr(mandate, "status", None) not in ("valid", "pending"):
+            status = getattr(mandate, "status", None)
+            if status not in ("valid", "pending"):
                 continue
             details = getattr(mandate, "details", None) or {}
             if isinstance(details, dict):
                 existing = details.get("consumerAccount")
             else:
                 existing = getattr(details, "consumerAccount", None)
-            if existing and existing.replace(" ", "").upper() == target:
-                return True
-        return False
+            if not existing or existing.replace(" ", "").upper() != target:
+                continue
+            if status == "valid":
+                return mandate
+            pending_match = pending_match or mandate
+        return pending_match
 
     def _resolve_customer_id_locked(
         self, stored_customer_id: Optional[str], customer_data: Dict[str, Any]


### PR DESCRIPTION
## Follow-up from PR #50 review (finding #3)

The PR #50 review noted: after the mandate de-dup, `_provision_and_create_subscription` still called `create_subscription` with **no `mandateId`**, so Mollie auto-selected. That is fine in the single-mandate case, but a member who changed banks can hold a *valid* mandate for the previous IBAN alongside a newly-provisioned one — and auto-select could then bill the old account.

## Change

- **`_find_usable_directdebit_mandate`** (renamed from `_has_usable_directdebit_mandate`, now returns the matching mandate object — `Optional[Any]` — instead of `bool`). Prefers a `valid` match over a `pending` one (it scans for valid first and only falls back to pending if no valid match exists).
- **`_provision_and_create_subscription`** pins the mandate via `subscription_data["mandateId"]`:
  - **valid match for the IBAN** → pin it.
  - **no usable match** → provision a new mandate and pin its id (mandates created via Mollie's Mandates API with `directdebit` details are valid immediately, so pinning is safe).
  - **only a `pending` match exists** → reuse it (no duplicate provisioned) but leave `mandateId` unset, because a pending mandate is not billable yet; Mollie will select it once it becomes valid.
- A caller-supplied `mandateId` is left untouched.

## Tests

`verenigingen/tests/payment/test_mollie_subscription_consolidation.py` — 43 tests, all passing. 4 new:
- `pins_reused_valid_mandate_id` — reused valid mandate's id lands in `subscription_data["mandateId"]`.
- `pins_freshly_created_mandate_id` — the new mandate's id is pinned, not left for auto-select.
- `pins_new_mandate_not_old_after_bank_change` — the real fix: a stale valid mandate for the *previous* IBAN does not get auto-selected; the freshly-provisioned mandate for the new IBAN is pinned.
- `does_not_pin_a_pending_mandate` — characterises the pending edge case.

TDD'd: the 3 `pins_*` tests reference a `mandateId` key the develop branch never sets (`KeyError`), so they're genuinely red on `develop`; green here.

All PR #50 tests (de-dup, pagination, fail-open, etc.) remain green — none of them asserted absence of `mandateId`, so the additional key is non-breaking.