### PR TITLE
ci: remove dead integration-test job from code-validation workflow

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -120,11 +120,15 @@ jobs:
             body: body
           });
 
-  # The former `integration-test` job was deleted in 2026-05.
+  # The former `integration-test` job was deleted in PR #53.
   # It invoked scripts/testing/runners/validation_test_runner.py, which was
   # removed on 2026-03-03 by the test-suite Phase 1 dead-code sweep (commit
-  # a60d1870). The script had been a no-op even when green: with the
-  # configured --fast --no-frappe-tests flags it only iterated a single
-  # nonexistent file and returned success without running any checks. The
-  # real validation gate is the `validation` job above; integration testing
-  # happens in `_base-server-tests.yml`.
+  # a60d1870). Pre-deletion, that wrapper duplicated the field / template /
+  # child-table validators the sibling `validation` job above already runs
+  # directly; its custom-test-scripts stage iterated a nonexistent smoke
+  # file and returned True. So no coverage is lost by removing the wrapper -
+  # `validation` above remains the real gate.
+  #
+  # Real bench-driven integration testing lives in `_base-server-tests.yml`
+  # under a separate job named `integration-tests` (plural) - not to be
+  # confused with this deleted job.

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -120,27 +120,11 @@ jobs:
             body: body
           });
 
-  integration-test:
-    runs-on: ubuntu-latest
-    needs: validation
-    if: success()
-    timeout-minutes: 15
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
-
-    - name: Run Integration Tests with Validation
-      run: |
-        python scripts/testing/runners/validation_test_runner.py --fast --no-frappe-tests
-
-    - name: Test Summary
-      if: always()
-      run: |
-        echo "## Integration Test Results" >> $GITHUB_STEP_SUMMARY
-        echo "Ran fast integration tests including code validation" >> $GITHUB_STEP_SUMMARY
+  # The former `integration-test` job was deleted in 2026-05.
+  # It invoked scripts/testing/runners/validation_test_runner.py, which was
+  # removed on 2026-03-03 by the test-suite Phase 1 dead-code sweep (commit
+  # a60d1870). The script had been a no-op even when green: with the
+  # configured --fast --no-frappe-tests flags it only iterated a single
+  # nonexistent file and returned success without running any checks. The
+  # real validation gate is the `validation` job above; integration testing
+  # happens in `_base-server-tests.yml`.


### PR DESCRIPTION
## What

Removes the `integration-test` job from `.github/workflows/code-validation.yml`. The job invoked `scripts/testing/runners/validation_test_runner.py`, which was deleted on 2026-03-03 (commit `a60d1870`, test-suite Phase 1 dead-code sweep). The audit pruned the script but missed this workflow caller.

## Why

- Every run on `develop` and every PR has gone red on this step for ~2.5 months (73 consecutive failures).
- The job was a no-op even when 'passing': `validation_test_runner.py --fast --no-frappe-tests` only iterated `['scripts/testing/integration/test_smoke.py']`, which also did not exist; it printed 'Skipping... (not found)' and returned True without running any checks. The noise is not masking a real signal.
- The real validation gate is the sibling `validation` job in the same workflow (database field validation, template variables, child tables); integration testing happens in `_base-server-tests.yml`. Both remain intact.

## Verification

- Investigated via subagent against the actual failed CI log (`gh run view 26146118838 --log-failed --job 76902007074`); root cause is unambiguous file-not-found.
- Confirmed last green run on develop: 2026-02-28 (`c697d603`). First failure: 2026-03-05 (`22924a83`) — exactly one run after `a60d1870` merged.
- Inspected the deleted script's pre-deletion source to confirm it was a no-op in the configured invocation mode.