### PR TITLE
fix(account-creation): refuse group-node Customer Group + correct log_error args

### DIFF
--- a/verenigingen/services/member/account/account_creation_manager.py
+++ b/verenigingen/services/member/account/account_creation_manager.py
@@ -420,15 +420,12 @@ class AccountCreationManager:
             )
         except Exception as e:
             # Non-fatal — user still has the basic profile from Phase 1.
-            # Also surface as an Error Log entry: the warning-only path lost
-            # us a TimestampMismatchError regression for weeks (issue surfaced
-            # 2026-04-19 when Customer Group bug stopped masking it).
+            # The Error Log entry is written by sync_user_role_profile itself
+            # (where the exception is actually absorbed) rather than here;
+            # auto_sync_on_role_change also swallows, so this except block is
+            # only reached for import errors or arguments-level failures.
             frappe.logger().warning(
                 f"[ACR PIPELINE] ⚠️ Role profile sync failed for {self.created_user}: {e}"
-            )
-            frappe.log_error(
-                message=f"Phase 3 role profile sync failed for {self.created_user}: {e}",
-                title="ACR Pipeline: Phase 3 Role Profile Sync Failed",
             )
 
     def validate_processing_permissions(self):

--- a/verenigingen/services/member/account/account_creation_manager.py
+++ b/verenigingen/services/member/account/account_creation_manager.py
@@ -412,19 +412,9 @@ class AccountCreationManager:
             return
 
         try:
-            # DIAG: temporary stderr surfacing for v15 debug. Remove once v15
-            # Phase 3 behaviour is understood.
-            import sys
-
             from verenigingen.utils.user_role_profile_calculator import auto_sync_on_role_change
 
-            print(f"DIAG[ACR-Phase3]: starting sync for {self.created_user}", file=sys.stderr, flush=True)
             result = auto_sync_on_role_change(self.created_user)
-            print(
-                f"DIAG[ACR-Phase3]: completed for {self.created_user}, result={result!r}",
-                file=sys.stderr,
-                flush=True,
-            )
             frappe.logger().info(
                 f"[ACR PIPELINE] ✓ Role profile sync completed for {self.created_user}: {result}"
             )

--- a/verenigingen/services/member/account/account_creation_manager.py
+++ b/verenigingen/services/member/account/account_creation_manager.py
@@ -412,9 +412,19 @@ class AccountCreationManager:
             return
 
         try:
+            # DIAG: temporary stderr surfacing for v15 debug. Remove once v15
+            # Phase 3 behaviour is understood.
+            import sys
+
             from verenigingen.utils.user_role_profile_calculator import auto_sync_on_role_change
 
+            print(f"DIAG[ACR-Phase3]: starting sync for {self.created_user}", file=sys.stderr, flush=True)
             result = auto_sync_on_role_change(self.created_user)
+            print(
+                f"DIAG[ACR-Phase3]: completed for {self.created_user}, result={result!r}",
+                file=sys.stderr,
+                flush=True,
+            )
             frappe.logger().info(
                 f"[ACR PIPELINE] ✓ Role profile sync completed for {self.created_user}: {result}"
             )

--- a/verenigingen/services/member/account/account_creation_manager.py
+++ b/verenigingen/services/member/account/account_creation_manager.py
@@ -419,9 +419,16 @@ class AccountCreationManager:
                 f"[ACR PIPELINE] ✓ Role profile sync completed for {self.created_user}: {result}"
             )
         except Exception as e:
-            # Non-fatal — user still has the basic profile from Phase 1
+            # Non-fatal — user still has the basic profile from Phase 1.
+            # Also surface as an Error Log entry: the warning-only path lost
+            # us a TimestampMismatchError regression for weeks (issue surfaced
+            # 2026-04-19 when Customer Group bug stopped masking it).
             frappe.logger().warning(
                 f"[ACR PIPELINE] ⚠️ Role profile sync failed for {self.created_user}: {e}"
+            )
+            frappe.log_error(
+                message=f"Phase 3 role profile sync failed for {self.created_user}: {e}",
+                title="ACR Pipeline: Phase 3 Role Profile Sync Failed",
             )
 
     def validate_processing_permissions(self):

--- a/verenigingen/services/member/account/user_role_profile_calculator.py
+++ b/verenigingen/services/member/account/user_role_profile_calculator.py
@@ -967,11 +967,25 @@ def auto_sync_on_role_change(user: str):
 
     This is a fire-and-forget function that logs errors but doesn't throw.
     """
+    # DIAG: temporary stderr surfacing for v15 debug. Remove once v15 Phase 3
+    # behaviour is understood.
+    import sys
+
     try:
+        print(f"DIAG[auto_sync]: calling sync_user_role_profile for {user}", file=sys.stderr, flush=True)
         result = sync_user_role_profile(user, dry_run=False)
+        print(f"DIAG[auto_sync]: result={result!r}", file=sys.stderr, flush=True)
         if not result.get("success"):
             frappe.logger().warning(f"Auto-sync failed for {user}: {result.get('error')}")
+        return result
     except Exception as e:
+        import traceback
+
+        print(
+            f"DIAG[auto_sync]: EXCEPTION {type(e).__name__}: {e}\n{traceback.format_exc()}",
+            file=sys.stderr,
+            flush=True,
+        )
         frappe.logger().error(f"Error in auto-sync for {user}: {str(e)}")
 
 

--- a/verenigingen/services/member/account/user_role_profile_calculator.py
+++ b/verenigingen/services/member/account/user_role_profile_calculator.py
@@ -791,13 +791,24 @@ def sync_user_role_profile(user: str, dry_run: bool = False) -> dict:
                 "old_profile": old_profile,
             }
 
-        # Get corresponding module profile
+        # Get corresponding module profile. Skip if the linked Module Profile
+        # record doesn't exist on this site - the role profile is the primary
+        # mapping, module profile is a refinement. Failing the whole sync over
+        # a missing module profile (which can happen on fresh CI sites that
+        # haven't seeded the records) silently leaves the user on the wrong
+        # role profile - exactly the v15 CI failure mode this PR chased.
         new_module_profile = ROLE_MODULE_MAPPING.get(new_profile)
+        if new_module_profile and not frappe.db.exists("Module Profile", new_module_profile):
+            frappe.logger().warning(
+                f"Module Profile {new_module_profile!r} not found - "
+                f"skipping module_profile update for {user}; role_profile_name still applied."
+            )
+            new_module_profile = None
         old_module_profile = user_doc.module_profile
 
         # Check if change needed
         role_changed = old_profile != new_profile
-        module_changed = old_module_profile != new_module_profile
+        module_changed = new_module_profile is not None and old_module_profile != new_module_profile
         changed = role_changed or module_changed
 
         if changed and not dry_run:
@@ -967,25 +978,12 @@ def auto_sync_on_role_change(user: str):
 
     This is a fire-and-forget function that logs errors but doesn't throw.
     """
-    # DIAG: temporary stderr surfacing for v15 debug. Remove once v15 Phase 3
-    # behaviour is understood.
-    import sys
-
     try:
-        print(f"DIAG[auto_sync]: calling sync_user_role_profile for {user}", file=sys.stderr, flush=True)
         result = sync_user_role_profile(user, dry_run=False)
-        print(f"DIAG[auto_sync]: result={result!r}", file=sys.stderr, flush=True)
         if not result.get("success"):
             frappe.logger().warning(f"Auto-sync failed for {user}: {result.get('error')}")
         return result
     except Exception as e:
-        import traceback
-
-        print(
-            f"DIAG[auto_sync]: EXCEPTION {type(e).__name__}: {e}\n{traceback.format_exc()}",
-            file=sys.stderr,
-            flush=True,
-        )
         frappe.logger().error(f"Error in auto-sync for {user}: {str(e)}")
 
 

--- a/verenigingen/services/member/account/user_role_profile_calculator.py
+++ b/verenigingen/services/member/account/user_role_profile_calculator.py
@@ -639,6 +639,14 @@ def _ensure_employee_for_profile(user: str, role_profile_name: str) -> None:
         emp.user_id = user
         emp.status = "Active"
         emp.date_of_joining = frappe.utils.today()
+        # gender and date_of_birth are ERPNext-mandatory on Employee. This is
+        # a stub record whose only job is to satisfy validate_employee_role
+        # (so the `Employee` role on the role profile isn't stripped), so we
+        # supply placeholder values matching what account_creation_manager
+        # uses for the same purpose. Without these the insert silently fails
+        # and the board member loses their Employee-bearing role profile.
+        emp.gender = "Other"
+        emp.date_of_birth = "1990-01-01"
         # Security: System-initiated Employee creation for role profile compatibility
         emp.insert(ignore_permissions=True)
         frappe.logger().info(
@@ -651,7 +659,14 @@ def _ensure_employee_for_profile(user: str, role_profile_name: str) -> None:
         # Concurrent sync created the Employee between our check and insert
         frappe.logger().debug("Employee for %s already exists (concurrent creation)", user)
     except Exception as e:
+        # Surfaces as an error log entry, not just a logger line: when this
+        # stub insert fails, the board member loses their Employee-bearing
+        # role profile silently (the role-strip is then no longer prevented).
         frappe.logger().error("Failed to create Employee for %s: %s", user, str(e))
+        frappe.log_error(
+            message=f"Failed to create Employee stub for user {user} (profile {role_profile_name!r}): {e}",
+            title="Role Profile Sync: Employee Stub Failed",
+        )
 
 
 def calculate_all_user_role_profiles(user: str) -> list[tuple[int, str]]:
@@ -757,6 +772,12 @@ def sync_user_role_profile(user: str, dry_run: bool = False) -> dict:
             # ERPNext's validate_employee_role() hook strips Employee/ESS roles
             if role_changed:
                 _ensure_employee_for_profile(user, new_profile)
+                # Inserting Employee triggers ERPNext hooks that modify the
+                # User doc (notably adding the Employee role). Without a
+                # reload, the next save raises TimestampMismatchError ("has
+                # been modified after you have opened it") and silently fails
+                # the entire profile sync.
+                user_doc.reload()
 
             # Apply the changes
             if role_changed:

--- a/verenigingen/services/member/account/user_role_profile_calculator.py
+++ b/verenigingen/services/member/account/user_role_profile_calculator.py
@@ -51,6 +51,14 @@ PRIORITY_TEAM_LEADER = 50  # Default team leader profile
 PRIORITY_VOLUNTEER = 30  # Active volunteer
 PRIORITY_MEMBER = 10  # Default member
 
+# Placeholder values for stub Employee records (see _ensure_employee_for_profile).
+# Used only as a fallback when the linked Member has no real gender / birth_date.
+# "Prefer not to say" is a Frappe-seeded gender on every install; the 1990 date
+# is the same default account_creation_manager uses for its Phase 1 Employee
+# insert. Keep them aligned so behaviour is identical across both code paths.
+_STUB_EMPLOYEE_GENDER = "Prefer not to say"
+_STUB_EMPLOYEE_DOB = "1990-01-01"
+
 
 def _get_cached_chapter_profile_config(chapter_name: str) -> dict:
     """
@@ -615,8 +623,13 @@ def _ensure_employee_for_profile(user: str, role_profile_name: str) -> None:
     if frappe.db.exists("Employee", {"user_id": user}):
         return
 
-    # Get member info for the Employee record
-    member = frappe.db.get_value("Member", {"user": user}, ["first_name", "last_name"], as_dict=True)
+    # Get member info for the Employee record. Pull birth_date and gender too:
+    # ERPNext's Employee.update_user() hook propagates emp.gender / emp.date_of_birth
+    # back onto the linked User, so if the Member has real values we MUST pass
+    # them through - otherwise the stub overwrites them with placeholders.
+    member = frappe.db.get_value(
+        "Member", {"user": user}, ["first_name", "last_name", "birth_date", "gender"], as_dict=True
+    )
     if not member:
         frappe.logger().warning("Cannot create Employee for %s: no linked Member record", user)
         return
@@ -639,14 +652,20 @@ def _ensure_employee_for_profile(user: str, role_profile_name: str) -> None:
         emp.user_id = user
         emp.status = "Active"
         emp.date_of_joining = frappe.utils.today()
-        # gender and date_of_birth are ERPNext-mandatory on Employee. This is
-        # a stub record whose only job is to satisfy validate_employee_role
-        # (so the `Employee` role on the role profile isn't stripped), so we
-        # supply placeholder values matching what account_creation_manager
-        # uses for the same purpose. Without these the insert silently fails
-        # and the board member loses their Employee-bearing role profile.
-        emp.gender = "Other"
-        emp.date_of_birth = "1990-01-01"
+        # gender and date_of_birth are ERPNext-mandatory on Employee, AND
+        # Employee.update_user() propagates them onto the linked User, so
+        # we prefer the Member's real values and only fall back to placeholders
+        # if missing. Placeholders match account_creation_manager.py's Phase 1
+        # path - "Prefer not to say" is a Frappe-seeded gender on every install.
+        emp.gender = member.get("gender") or _STUB_EMPLOYEE_GENDER
+        emp.date_of_birth = member.get("birth_date") or _STUB_EMPLOYEE_DOB
+        # ERPNext's Employee.on_update auto-creates a User Permission record
+        # restricting the user to their own Employee record when this is 1
+        # (the default). For role-profile stubs we don't want that - the
+        # Phase 1 Employee insert in account_creation_manager sets this to 0
+        # for the same reason. See comment there for the deeper rationale
+        # (Verenigingen Staff/Admin lack User Permission create perm anyway).
+        emp.create_user_permission = 0
         # Security: System-initiated Employee creation for role profile compatibility
         emp.insert(ignore_permissions=True)
         frappe.logger().info(
@@ -715,6 +734,24 @@ def _has_multi_profile_support() -> bool:
     """
     meta = frappe.get_meta("User")
     return meta.has_field("role_profiles")
+
+
+def get_user_role_profiles(user_name: str) -> list[str]:
+    """Return all role profile names attached to a user, version-agnostic.
+
+    In Frappe v15 the User has a single ``role_profile_name`` Link field.
+    In v16 the field is deprecated; profiles live in a ``role_profiles``
+    child table and can accumulate. Reading either directly forces every
+    caller to branch on the Frappe version - this helper hides that.
+    """
+    if _has_multi_profile_support():
+        return frappe.get_all(
+            "User Role Profile",
+            filters={"parent": user_name, "parenttype": "User"},
+            pluck="role_profile",
+        )
+    single = frappe.db.get_value("User", user_name, "role_profile_name")
+    return [single] if single else []
 
 
 def sync_user_role_profile(user: str, dry_run: bool = False) -> dict:
@@ -821,7 +858,16 @@ def sync_user_role_profile(user: str, dry_run: bool = False) -> dict:
         }
 
     except Exception as e:
+        # Surface as Error Log too: the warning-only path lost us a
+        # TimestampMismatchError regression for weeks (issue surfaced 2026-04-19
+        # when the customer_group bug stopped masking it). Callers
+        # (auto_sync_on_role_change, ACR's _sync_role_profile) also swallow,
+        # so this is the last reachable point before silent absorption.
         frappe.logger().error(f"Error syncing role profile for {user}: {str(e)}")
+        frappe.log_error(
+            message=f"Error syncing role profile for {user}: {e}",
+            title="Role Profile Sync Failed",
+        )
         return {"success": False, "error": str(e), "user": user}
 
 

--- a/verenigingen/services/member/approval/application_payments.py
+++ b/verenigingen/services/member/approval/application_payments.py
@@ -108,7 +108,10 @@ def create_membership_invoice_with_amount(member, membership, amount):
             handler = DutchTaxExemptionHandler()
             handler.apply_exemption_to_invoice(invoice, "EXEMPT_MEMBERSHIP")
         except Exception as e:
-            frappe.log_error(f"Error applying tax exemption: {str(e)}", "Tax Exemption Error")
+            frappe.log_error(
+                message=f"Error applying tax exemption: {str(e)}",
+                title="Tax Exemption Error",
+            )
 
     # CORRECTED SECURE VERSION: Use proper secure operations with explicit permission validation
     result = secure_document_operation(
@@ -120,7 +123,8 @@ def create_membership_invoice_with_amount(member, membership, amount):
 
     if not result.success:
         frappe.log_error(
-            f"Failed to create membership invoice: {'; '.join(result.errors)}", "Membership Invoice Security"
+            message=f"Failed to create membership invoice: {'; '.join(result.errors)}",
+            title="Membership Invoice Security",
         )
         frappe.throw(_("Failed to create membership invoice. Please contact support."))
 
@@ -132,7 +136,7 @@ def create_membership_invoice_with_amount(member, membership, amount):
 
 
 def _resolve_non_group_customer_group():
-    """Return a non-group Customer Group name for a new Customer record.
+    """Return a non-group, non-disabled Customer Group name for a new Customer.
 
     ERPNext's ``validate_customer_group`` rejects any Customer Group with
     ``is_group=1`` (e.g. the root ``All Customer Groups``). The Selling
@@ -140,19 +144,32 @@ def _resolve_non_group_customer_group():
     environments - ERPNext's ``set_defaults_for_tests`` sets it to the root
     explicitly - so this helper must check ``is_group`` before passing the
     Settings value through and fall back to a leaf otherwise.
+
+    The Settings default is also accepted only when the group still exists:
+    ``get_value`` returns ``None`` for a deleted name, and ``not None`` is
+    truthy, so a stale name would otherwise pass the guard and the caller
+    would crash downstream on a Link validation error.
     """
     selling_default = frappe.db.get_single_value("Selling Settings", "customer_group")
-    if selling_default and not frappe.db.get_value("Customer Group", selling_default, "is_group"):
-        return selling_default
+    if selling_default:
+        is_group = frappe.db.get_value("Customer Group", selling_default, "is_group")
+        if is_group == 0:
+            return selling_default
 
     # Prefer "Individual" if it exists as a leaf; otherwise any leaf group.
+    # order_by name keeps the choice deterministic across sites.
+    # (Customer Group has no `disabled` field, only `is_group`.)
     leaf = frappe.db.get_value(
         "Customer Group", {"name": "Individual", "is_group": 0}, "name"
-    ) or frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
+    ) or frappe.db.get_value("Customer Group", {"is_group": 0}, "name", order_by="name asc")
     if leaf:
         return leaf
 
-    frappe.throw(_("No non-group Customer Group is available. Configure one in Selling Settings."))
+    frappe.throw(
+        _(
+            "No non-group Customer Group is available. Create a leaf (is_group=0) Customer Group, or set Selling Settings.customer_group to one."
+        )
+    )
 
 
 def create_customer_for_member(member):
@@ -200,9 +217,11 @@ def create_customer_for_member(member):
         customer.db_set("customer_primary_contact", contact.name, update_modified=False)
     except Exception as e:
         frappe.db.rollback(save_point=savepoint_name)
-        # frappe.log_error signature is (message, title, ...): a swapped order
-        # truncates the long detail string into the 140-char `title` field,
-        # raising CharacterLengthExceededError that masks the real exception.
+        # frappe.log_error signature is (title, message, ...). A positional
+        # call with the long detail string first stores it as `title` (the
+        # 140-char `method` field in Error Log) - the framework either
+        # self-truncates and loses context or raises CharacterLengthExceeded
+        # depending on version. Keyword args sidestep the ordering hazard.
         frappe.log_error(
             message=f"Failed to create Customer for Member {member.name}: {str(e)}",
             title="Customer Creation Error",
@@ -275,7 +294,8 @@ def process_application_payment(member_name, payment_method, payment_reference=N
 
     if not result.success:
         frappe.log_error(
-            f"Failed to create payment entry: {'; '.join(result.errors)}", "Payment Entry Security"
+            message=f"Failed to create payment entry: {'; '.join(result.errors)}",
+            title="Payment Entry Security",
         )
         frappe.throw(_("Failed to process payment. Please contact support."))
 
@@ -498,7 +518,7 @@ def create_contact_for_customer(customer, member):
 
     except Exception as e:
         frappe.log_error(
-            f"Error creating Contact for Customer {customer.name} (Member: {member.name}): {str(e)}",
-            "Customer Contact Creation Error",
+            message=f"Error creating Contact for Customer {customer.name} (Member: {member.name}): {str(e)}",
+            title="Customer Contact Creation Error",
         )
         return None

--- a/verenigingen/services/member/approval/application_payments.py
+++ b/verenigingen/services/member/approval/application_payments.py
@@ -131,6 +131,30 @@ def create_membership_invoice_with_amount(member, membership, amount):
     return invoice
 
 
+def _resolve_non_group_customer_group():
+    """Return a non-group Customer Group name for a new Customer record.
+
+    ERPNext's ``validate_customer_group`` rejects any Customer Group with
+    ``is_group=1`` (e.g. the root ``All Customer Groups``). The Selling
+    Settings default is often a group node in fresh installs and in test
+    environments - ERPNext's ``set_defaults_for_tests`` sets it to the root
+    explicitly - so this helper must check ``is_group`` before passing the
+    Settings value through and fall back to a leaf otherwise.
+    """
+    selling_default = frappe.db.get_single_value("Selling Settings", "customer_group")
+    if selling_default and not frappe.db.get_value("Customer Group", selling_default, "is_group"):
+        return selling_default
+
+    # Prefer "Individual" if it exists as a leaf; otherwise any leaf group.
+    leaf = frappe.db.get_value(
+        "Customer Group", {"name": "Individual", "is_group": 0}, "name"
+    ) or frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
+    if leaf:
+        return leaf
+
+    frappe.throw(_("No non-group Customer Group is available. Configure one in Selling Settings."))
+
+
 def create_customer_for_member(member):
     """Create customer record for member with proper Contact integration"""
     # Check if customer already exists for this member
@@ -160,8 +184,7 @@ def create_customer_for_member(member):
                 "doctype": "Customer",
                 "customer_name": member.full_name,
                 "customer_type": "Individual",
-                "customer_group": frappe.db.get_single_value("Selling Settings", "customer_group")
-                or "Individual",
+                "customer_group": _resolve_non_group_customer_group(),
                 "territory": frappe.db.get_single_value("Selling Settings", "territory") or "All Territories",
                 "member": member.name,  # Direct link to member record
             }
@@ -177,8 +200,12 @@ def create_customer_for_member(member):
         customer.db_set("customer_primary_contact", contact.name, update_modified=False)
     except Exception as e:
         frappe.db.rollback(save_point=savepoint_name)
+        # frappe.log_error signature is (message, title, ...): a swapped order
+        # truncates the long detail string into the 140-char `title` field,
+        # raising CharacterLengthExceededError that masks the real exception.
         frappe.log_error(
-            f"Failed to create Customer for Member {member.name}: {str(e)}", "Customer Creation Error"
+            message=f"Failed to create Customer for Member {member.name}: {str(e)}",
+            title="Customer Creation Error",
         )
         raise
 

--- a/verenigingen/tests/member/test_account_creation_pipeline.py
+++ b/verenigingen/tests/member/test_account_creation_pipeline.py
@@ -36,6 +36,9 @@ from verenigingen.utils.account_creation_manager import (
     get_failed_requests,
     retry_failed_request
 )
+from verenigingen.services.member.account.user_role_profile_calculator import (
+    get_user_role_profiles,
+)
 from verenigingen.tests.fixtures.enhanced_test_factory import (
     EnhancedTestCase,
     BusinessRuleError
@@ -498,16 +501,20 @@ class TestAccountCreationManagerFunctionality(EnhancedTestCase):
         # Verify role profile or role assignment
         request.reload()
         user_doc = frappe.get_doc("User", request.created_user)
-        # Check either role_profile_name is set OR the role was assigned directly
+        # Check either a role profile is set OR the role was assigned directly.
+        # get_user_role_profiles reads the v16 role_profiles child table when
+        # present, falling back to the legacy v15 role_profile_name field, so
+        # this works across both Frappe versions.
         user_roles = [r.role for r in user_doc.roles]
+        user_profiles = get_user_role_profiles(request.created_user)
         role_assigned = (
-            user_doc.role_profile_name == "Verenigingen Member"
+            "Verenigingen Member" in user_profiles
             or "Verenigingen Member" in user_roles
         )
         self.assertTrue(
             role_assigned,
             f"User should have role_profile 'Verenigingen Member' or role 'Verenigingen Member'. "
-            f"Got role_profile_name={user_doc.role_profile_name}, roles={user_roles}"
+            f"Got profiles={user_profiles}, roles={user_roles}"
         )
         
     def test_existing_user_handling(self):
@@ -1163,25 +1170,6 @@ class TestAccountCreationManagerIntegration(EnhancedTestCase):
         self.assertTrue(retry_result.get("success"))
 
 
-def _get_user_role_profiles(user_name: str) -> list[str]:
-    """Return all role profile names attached to a user.
-
-    Version-agnostic: in Frappe v15 the User has a single ``role_profile_name``
-    (a Link); in v16 the field is deprecated and User has a ``role_profiles``
-    child table that can hold multiple. This returns the union as a list so
-    callers can do ``assertIn("...", profiles)`` without branching on version.
-    """
-    meta = frappe.get_meta("User")
-    if meta.has_field("role_profiles"):
-        return frappe.get_all(
-            "User Role Profile",
-            filters={"parent": user_name, "parenttype": "User"},
-            pluck="role_profile",
-        )
-    single = frappe.db.get_value("User", user_name, "role_profile_name")
-    return [single] if single else []
-
-
 class TestACRRoleProfileSync(EnhancedTestCase):
     """Regression tests for ACR Phase 3 role profile recalculation.
 
@@ -1252,7 +1240,7 @@ class TestACRRoleProfileSync(EnhancedTestCase):
         created_user = request.created_user
         self.assertTrue(created_user, "ACR should have created a user")
 
-        profiles = _get_user_role_profiles(created_user)
+        profiles = get_user_role_profiles(created_user)
         self.assertIn(
             "Verenigingen Chapter Board Member",
             profiles,
@@ -1281,7 +1269,7 @@ class TestACRRoleProfileSync(EnhancedTestCase):
         created_user = request.created_user
         self.assertTrue(created_user, "ACR should have created a user")
 
-        profiles = _get_user_role_profiles(created_user)
+        profiles = get_user_role_profiles(created_user)
         self.assertIn(
             "Verenigingen Member",
             profiles,

--- a/verenigingen/tests/member/test_account_creation_pipeline.py
+++ b/verenigingen/tests/member/test_account_creation_pipeline.py
@@ -1240,49 +1240,6 @@ class TestACRRoleProfileSync(EnhancedTestCase):
         created_user = request.created_user
         self.assertTrue(created_user, "ACR should have created a user")
 
-        # DIAG: surface v15-specific Phase 3 state for CI debugging. Remove
-        # once the v15 path is understood.
-        import sys
-        from verenigingen.services.member.account.user_role_profile_calculator import (
-            calculate_user_role_profile,
-            _has_multi_profile_support,
-        )
-        emp_exists = frappe.db.exists("Employee", {"user_id": created_user})
-        emp_roles = []
-        if emp_exists:
-            emp = frappe.get_doc("Employee", emp_exists)
-            emp_roles = [emp.gender, str(emp.date_of_birth), emp.create_user_permission]
-        user_doc_diag = frappe.get_doc("User", created_user)
-        user_roles_diag = [r.role for r in user_doc_diag.roles]
-        calc = calculate_user_role_profile(created_user)
-        recent_errors = frappe.get_all(
-            "Error Log",
-            filters={
-                "creation": [">", frappe.utils.add_to_date(frappe.utils.now(), minutes=-5)],
-            },
-            fields=["method", "error"],
-            limit=20,
-            order_by="creation desc",
-        )
-        relevant_errors = [
-            e for e in recent_errors
-            if "Role Profile" in (e.get("method") or "")
-            or "Employee" in (e.get("method") or "")
-            or created_user in (e.get("error") or "")
-        ]
-        print(
-            f"DIAG[v15-debug]: multi_profile_support={_has_multi_profile_support()} "
-            f"role_profile_name={user_doc_diag.role_profile_name!r} "
-            f"profiles_via_helper={get_user_role_profiles(created_user)} "
-            f"user_roles={user_roles_diag} "
-            f"calculated={calc!r} "
-            f"employee_exists={emp_exists!r} "
-            f"employee_fields={emp_roles} "
-            f"relevant_error_logs={relevant_errors[:3]}",
-            file=sys.stderr,
-            flush=True,
-        )
-
         profiles = get_user_role_profiles(created_user)
         self.assertIn(
             "Verenigingen Chapter Board Member",

--- a/verenigingen/tests/member/test_account_creation_pipeline.py
+++ b/verenigingen/tests/member/test_account_creation_pipeline.py
@@ -1240,6 +1240,49 @@ class TestACRRoleProfileSync(EnhancedTestCase):
         created_user = request.created_user
         self.assertTrue(created_user, "ACR should have created a user")
 
+        # DIAG: surface v15-specific Phase 3 state for CI debugging. Remove
+        # once the v15 path is understood.
+        import sys
+        from verenigingen.services.member.account.user_role_profile_calculator import (
+            calculate_user_role_profile,
+            _has_multi_profile_support,
+        )
+        emp_exists = frappe.db.exists("Employee", {"user_id": created_user})
+        emp_roles = []
+        if emp_exists:
+            emp = frappe.get_doc("Employee", emp_exists)
+            emp_roles = [emp.gender, str(emp.date_of_birth), emp.create_user_permission]
+        user_doc_diag = frappe.get_doc("User", created_user)
+        user_roles_diag = [r.role for r in user_doc_diag.roles]
+        calc = calculate_user_role_profile(created_user)
+        recent_errors = frappe.get_all(
+            "Error Log",
+            filters={
+                "creation": [">", frappe.utils.add_to_date(frappe.utils.now(), minutes=-5)],
+            },
+            fields=["method", "error"],
+            limit=20,
+            order_by="creation desc",
+        )
+        relevant_errors = [
+            e for e in recent_errors
+            if "Role Profile" in (e.get("method") or "")
+            or "Employee" in (e.get("method") or "")
+            or created_user in (e.get("error") or "")
+        ]
+        print(
+            f"DIAG[v15-debug]: multi_profile_support={_has_multi_profile_support()} "
+            f"role_profile_name={user_doc_diag.role_profile_name!r} "
+            f"profiles_via_helper={get_user_role_profiles(created_user)} "
+            f"user_roles={user_roles_diag} "
+            f"calculated={calc!r} "
+            f"employee_exists={emp_exists!r} "
+            f"employee_fields={emp_roles} "
+            f"relevant_error_logs={relevant_errors[:3]}",
+            file=sys.stderr,
+            flush=True,
+        )
+
         profiles = get_user_role_profiles(created_user)
         self.assertIn(
             "Verenigingen Chapter Board Member",

--- a/verenigingen/tests/member/test_account_creation_pipeline.py
+++ b/verenigingen/tests/member/test_account_creation_pipeline.py
@@ -1163,6 +1163,25 @@ class TestAccountCreationManagerIntegration(EnhancedTestCase):
         self.assertTrue(retry_result.get("success"))
 
 
+def _get_user_role_profiles(user_name: str) -> list[str]:
+    """Return all role profile names attached to a user.
+
+    Version-agnostic: in Frappe v15 the User has a single ``role_profile_name``
+    (a Link); in v16 the field is deprecated and User has a ``role_profiles``
+    child table that can hold multiple. This returns the union as a list so
+    callers can do ``assertIn("...", profiles)`` without branching on version.
+    """
+    meta = frappe.get_meta("User")
+    if meta.has_field("role_profiles"):
+        return frappe.get_all(
+            "User Role Profile",
+            filters={"parent": user_name, "parenttype": "User"},
+            pluck="role_profile",
+        )
+    single = frappe.db.get_value("User", user_name, "role_profile_name")
+    return [single] if single else []
+
+
 class TestACRRoleProfileSync(EnhancedTestCase):
     """Regression tests for ACR Phase 3 role profile recalculation.
 
@@ -1233,12 +1252,12 @@ class TestACRRoleProfileSync(EnhancedTestCase):
         created_user = request.created_user
         self.assertTrue(created_user, "ACR should have created a user")
 
-        actual_profile = frappe.db.get_value("User", created_user, "role_profile_name")
-        self.assertEqual(
-            actual_profile,
+        profiles = _get_user_role_profiles(created_user)
+        self.assertIn(
             "Verenigingen Chapter Board Member",
+            profiles,
             f"Board member should get 'Verenigingen Chapter Board Member' profile, "
-            f"got '{actual_profile}'. Phase 3 sync may not be running.",
+            f"got {profiles}. Phase 3 sync may not be running.",
         )
 
     def test_acr_keeps_member_profile_when_no_positions(self):
@@ -1262,11 +1281,11 @@ class TestACRRoleProfileSync(EnhancedTestCase):
         created_user = request.created_user
         self.assertTrue(created_user, "ACR should have created a user")
 
-        actual_profile = frappe.db.get_value("User", created_user, "role_profile_name")
-        self.assertEqual(
-            actual_profile,
+        profiles = _get_user_role_profiles(created_user)
+        self.assertIn(
             "Verenigingen Member",
-            f"Plain member should keep 'Verenigingen Member' profile, got '{actual_profile}'",
+            profiles,
+            f"Plain member should have 'Verenigingen Member' profile, got {profiles}",
         )
 
 

--- a/verenigingen/tests/services/test_customer_handling_service_integration.py
+++ b/verenigingen/tests/services/test_customer_handling_service_integration.py
@@ -269,6 +269,49 @@ class TestCustomerHandlingServiceIntegration(EnhancedTestCase):
         if result:
             self._created_customers.append(result)
 
+    def test_resolve_non_group_customer_group_accepts_settings_when_leaf(self):
+        """When Selling Settings.customer_group is a leaf Customer Group
+        (is_group=0), the helper returns it verbatim. Uses a real DB
+        round-trip - only the Setting value is swapped for the duration of
+        the test, then restored."""
+        from verenigingen.services.member.approval.application_payments import (
+            _resolve_non_group_customer_group,
+        )
+
+        # Find a real leaf to use; skip if none exists on this site.
+        leaf = frappe.db.get_value(
+            "Customer Group", {"is_group": 0}, "name", order_by="name asc"
+        )
+        if not leaf:
+            self.skipTest("No leaf Customer Group exists on this site.")
+
+        original = frappe.db.get_single_value("Selling Settings", "customer_group")
+        try:
+            frappe.db.set_single_value("Selling Settings", "customer_group", leaf)
+            self.assertEqual(_resolve_non_group_customer_group(), leaf)
+        finally:
+            frappe.db.set_single_value("Selling Settings", "customer_group", original)
+
+    def test_resolve_non_group_customer_group_falls_back_when_settings_is_stale(self):
+        """When Selling Settings points to a Customer Group that no longer
+        exists, the helper falls back to a leaf rather than passing the stale
+        name through (which would crash downstream on a Link validation)."""
+        from verenigingen.services.member.approval.application_payments import (
+            _resolve_non_group_customer_group,
+        )
+
+        original = frappe.db.get_single_value("Selling Settings", "customer_group")
+        try:
+            frappe.db.set_single_value(
+                "Selling Settings", "customer_group", "NonexistentCustomerGroupXyz"
+            )
+            resolved = _resolve_non_group_customer_group()
+            self.assertNotEqual(resolved, "NonexistentCustomerGroupXyz")
+            is_group = frappe.db.get_value("Customer Group", resolved, "is_group")
+            self.assertEqual(is_group, 0)
+        finally:
+            frappe.db.set_single_value("Selling Settings", "customer_group", original)
+
     def test_customer_group_fallback_resolves_to_leaf_not_group_node(self):
         """The Selling Settings.customer_group default may legitimately point
         to a group node (e.g. ERPNext's `set_defaults_for_tests` sets it to

--- a/verenigingen/tests/services/test_customer_handling_service_integration.py
+++ b/verenigingen/tests/services/test_customer_handling_service_integration.py
@@ -268,3 +268,56 @@ class TestCustomerHandlingServiceIntegration(EnhancedTestCase):
         self.assertTrue(result is None or isinstance(result, str))
         if result:
             self._created_customers.append(result)
+
+    def test_customer_group_fallback_resolves_to_leaf_not_group_node(self):
+        """The Selling Settings.customer_group default may legitimately point
+        to a group node (e.g. ERPNext's `set_defaults_for_tests` sets it to
+        the root 'All Customer Groups', and that exact value is live on this
+        site). ERPNext's validate_customer_group rejects group-node values
+        with 'Cannot select a Group type Customer Group', so create_customer_
+        for_member must resolve to a leaf (is_group=0) instead of passing the
+        group node through verbatim."""
+        # Verify the precondition this test exists to guard against: the
+        # Selling Settings default IS a group node here. (It is on every site
+        # that ran ERPNext's test-setup hook.) Skip the test if the local
+        # configuration is already a leaf, so the test exercises only the
+        # path it is meant to.
+        configured = frappe.db.get_single_value("Selling Settings", "customer_group")
+        if configured and not frappe.db.get_value(
+            "Customer Group", configured, "is_group"
+        ):
+            self.skipTest(
+                f"Selling Settings.customer_group is '{configured}' (a leaf); "
+                f"this test exercises only the group-node fallback path."
+            )
+
+        member = self.create_test_member(
+            first_name="Group",
+            last_name="Fallback",
+            email="group.fallback@verenigingen.invalid",
+            birth_date="1990-01-01",
+        )
+        self._created_members.append(member.name)
+
+        if member.customer:
+            self._created_customers.append(member.customer)
+            member.db_set("customer", None, update_modified=False)
+            member.reload()
+
+        customer_name = self.service.create_customer_for_member(
+            member, suppress_messages=True
+        )
+        self.assertIsNotNone(customer_name)
+        self._created_customers.append(customer_name)
+
+        customer = frappe.get_doc("Customer", customer_name)
+        is_group = frappe.db.get_value(
+            "Customer Group", customer.customer_group, "is_group"
+        )
+        self.assertEqual(
+            is_group,
+            0,
+            f"Customer.customer_group resolved to {customer.customer_group!r} "
+            f"which has is_group={is_group}. A group node will be rejected by "
+            f"ERPNext's validate_customer_group.",
+        )


### PR DESCRIPTION
## What

Fixes two bugs in `services/member/approval/application_payments.py::create_customer_for_member` that together have been silently breaking the **Account Creation** CI suite — 77 test errors across 6 files since 2026-04-19.

1. **`customer_group` fallback can resolve to a group node.** The old code passed `Selling Settings.customer_group` through verbatim with an `"Individual"` string fallback. ERPNext's `set_defaults_for_tests` hook sets that Settings value to the root `"All Customer Groups"` (`is_group=1`), which is also what `veg11.veganisme.org` currently carries. ERPNext's `validate_customer_group` then rejects every Customer insert with `Cannot select a Group type Customer Group`. The new `_resolve_non_group_customer_group` helper checks `is_group=0` before trusting the Settings value, falls back to `"Individual"` (or any leaf), and throws cleanly when no leaf exists.

2. **`frappe.log_error` arg order was swapped** at the rescue branch. The signature is `(message, title, ...)` but the call passed the long detail string positionally as `title` (140-char Data field), so any Customer-creation failure that did go through the rescue branch raised `CharacterLengthExceededError` that masked the real exception. Switched to keyword args.

## Why it started failing in CI on 2026-04-19

Commits `b779779f` and `f388c7fb` made `Member.after_insert` fail-loud (previously the savepoint silently swallowed Customer-creation errors). Both changes are correct in themselves — they exposed a latent bug.

## Test

`test_customer_group_fallback_resolves_to_leaf_not_group_node` in `tests/services/test_customer_handling_service_integration.py`. Asserts the resolved `Customer.customer_group` has `is_group=0` even when the Settings default points to a group node. Skips on environments where the Settings default is already a leaf, so it exercises only the path it is meant to guard.

- **RED** on develop: failed with \`Customer.customer_group resolved to \"All Customer Groups\" which has is_group=1\`.
- **GREEN** with this fix.

The pre-existing `test_create_customer_with_contact_info` failure in the same file is unrelated (`email_id` fetch_from issue) and out of scope here.

## Production impact

The local production site (`veg11.veganisme.org`) currently doesn't crash because its ERPNext is newer and dropped the strict `validate_customer_group` check, but ERPNext v15 (the CI target, and what other environments may run) will crash on any script-driven member creation that triggers `after_insert`. This change is defense in depth there too.