### PR TITLE
refactor(customer): share customer_group resolver across all 7 production sites

### DIFF
--- a/verenigingen/e_boekhouden/utils/consolidated/party_manager.py
+++ b/verenigingen/e_boekhouden/utils/consolidated/party_manager.py
@@ -30,6 +30,7 @@ import frappe
 from frappe.utils import add_days, now, today
 
 from verenigingen.e_boekhouden.utils.security_helper import migration_context, validate_and_insert
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.utils.deprecation import deprecated
 
 
@@ -438,14 +439,13 @@ class EBoekhoudenPartyManager:
         return default_customer
 
     def _get_default_customer_group(self) -> str:
-        """Get default customer group."""
-        # First try to get a reasonable default customer group
-        default_group = frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
-        if default_group:
-            return default_group
-
-        # "All Customer Groups" is ERPNext's default root group, this is safe
-        return "All Customer Groups"
+        """Get default customer group. Delegates to the shared resolver so
+        we never return "All Customer Groups" (a group node, which ERPNext's
+        strict-validation branch rejects). The previous comment claiming
+        that fallback was "safe" was wrong - it was the exact bug PR #54
+        fixed in the membership-approval path.
+        """
+        return resolve_non_group_customer_group()
 
     def _get_default_territory(self) -> str:
         """Get default territory using consistent error handling."""

--- a/verenigingen/e_boekhouden/utils/party_resolver.py
+++ b/verenigingen/e_boekhouden/utils/party_resolver.py
@@ -6,6 +6,8 @@ from typing import Dict, List, Optional, Tuple
 import frappe
 from frappe.utils import now
 
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
+
 # Party type configuration - defines differences between Customer and Supplier
 PARTY_CONFIG = {
     "Customer": {
@@ -365,7 +367,15 @@ class EBoekhoudenPartyResolver:
         # Set party fields
         setattr(party, name_field, final_name)
         setattr(party, type_field, entity_type)
-        setattr(party, group_field, config["default_group"])
+        # PARTY_CONFIG.default_group is "All Customer Groups" / "All Supplier Groups"
+        # — both are group nodes that ERPNext's strict-validation branch rejects.
+        # For Customer we delegate to the shared resolver. (Supplier Group has
+        # the same bug class; a future cleanup PR can mirror this with a
+        # supplier_group resolver.)
+        if party_type == "Customer":
+            setattr(party, group_field, resolve_non_group_customer_group())
+        else:
+            setattr(party, group_field, config["default_group"])
 
         # Customer-specific: territory
         if config.get("territory_field"):
@@ -504,7 +514,11 @@ class EBoekhoudenPartyResolver:
         # Create new provisional party
         party = frappe.new_doc(doctype)
         setattr(party, name_field, provisional_name)
-        setattr(party, group_field, config["default_group"])
+        # Same group-node guard as the full-create path above.
+        if party_type == "Customer":
+            setattr(party, group_field, resolve_non_group_customer_group())
+        else:
+            setattr(party, group_field, config["default_group"])
 
         if config.get("territory_field"):
             setattr(party, config["territory_field"], config["default_territory"])

--- a/verenigingen/e_boekhouden/utils/transaction_utils.py
+++ b/verenigingen/e_boekhouden/utils/transaction_utils.py
@@ -10,6 +10,7 @@ import json
 import frappe
 from frappe.utils import flt, getdate
 
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.utils.secure_operations import secure_document_operation
 
 
@@ -39,19 +40,11 @@ def create_customer_impl(migration_doc, customer_data):
         customer = frappe.new_doc("Customer")
         customer.customer_name = customer_name
         customer.customer_type = "Company" if company_name else "Individual"
-        # Get customer group from explicit configuration
-        default_customer_group = frappe.db.get_single_value("Selling Settings", "customer_group")
-        if default_customer_group:
-            customer.customer_group = default_customer_group
-        else:
-            # Check if "All Customer Groups" exists
-            if frappe.db.exists("Customer Group", "All Customer Groups"):
-                customer.customer_group = "All Customer Groups"
-            else:
-                frappe.throw(
-                    "No default customer group configured in Selling Settings and 'All Customer Groups' does not exist. "
-                    "Please configure default customer group in Selling Settings before running eBoekhouden migration."
-                )
+        # Resolve a leaf Customer Group (the previous logic would happily
+        # fall back to "All Customer Groups", a group node that ERPNext's
+        # validate_customer_group rejects with "Cannot select a Group type
+        # Customer Group" - same bug as the membership flow had pre-PR #54).
+        customer.customer_group = resolve_non_group_customer_group()
         customer.territory = migration_doc.get_proper_territory_for_customer(customer_data)
         customer.company = migration_doc.company
 

--- a/verenigingen/services/customer_group_resolver.py
+++ b/verenigingen/services/customer_group_resolver.py
@@ -6,19 +6,27 @@ Customer Group Resolver
 =======================
 
 Single source of truth for resolving a non-group Customer Group when creating
-a new Customer record. ERPNext's ``validate_customer_group`` rejects any
-Customer Group with ``is_group=1`` (e.g. the root ``All Customer Groups``),
-and Selling Settings' default is often a group node in fresh installs - and
-explicitly so in ERPNext's ``set_defaults_for_tests`` hook.
+a new Customer record. ERPNext's customer form filters the customer_group
+link to leaves only (``is_group=0`` filter in ``customer.js``), and the
+strict-validation branch of ``customer.py.validate`` likewise rejects a
+group-node value at insert time with ``ValidationError: Cannot select a
+Group type Customer Group``. (Note: the exact rejection mechanism varies
+across ERPNext versions - some only filter client-side, others enforce
+server-side. The fix is the same: never pass a group node through.)
+
+The Selling Settings default is often a group node in fresh installs -
+and explicitly so in ERPNext's ``set_defaults_for_tests`` hook, which
+sets it to the root ``All Customer Groups``.
 
 Every Customer-creation path in the codebase that consulted
 ``Selling Settings.customer_group`` had the same bug before this helper
 existed: pass the Settings value through verbatim, fall back to a string
-literal (often ``"Individual"`` or, in two Mollie sites, the guaranteed-broken
-``"All Customer Groups"``) when missing. Those bugs caused 77 test failures
-in Account Creation CI until commit ``5a4632c2`` (PR #54) fixed the
-membership-approval path with this helper. This module extracts and shares
-that helper so every caller resolves Customer Group the same safe way.
+literal (often ``"Individual"`` or, in several Mollie + eBoekhouden sites,
+the guaranteed-broken ``"All Customer Groups"``) when missing. Those bugs
+caused 77 test failures in Account Creation CI until commit ``5a4632c2``
+(PR #54) fixed the membership-approval path with this helper. This module
+extracts and shares the helper so every caller resolves Customer Group the
+same safe way.
 
 Use ``resolve_non_group_customer_group()`` whenever you create a Customer
 and need a default ``customer_group`` value. The helper:
@@ -39,20 +47,19 @@ from frappe import _
 def resolve_non_group_customer_group() -> str:
     """Return a non-group Customer Group name for a new Customer record.
 
-    ERPNext's ``validate_customer_group`` rejects any Customer Group with
-    ``is_group=1``. The Selling Settings default is often a group node in
-    fresh installs and in test environments - ERPNext's
-    ``set_defaults_for_tests`` sets it to the root explicitly - so this
-    helper must check ``is_group`` before passing the Settings value through
-    and fall back to a leaf otherwise.
+    ERPNext rejects any Customer Group with ``is_group=1`` for a Customer
+    (the form filters to leaves; the strict-validation branch of Customer
+    server controller likewise throws ``Cannot select a Group type Customer
+    Group``). The Selling Settings default is often a group node in fresh
+    installs and in test environments - ERPNext's ``set_defaults_for_tests``
+    sets it to the root explicitly - so this helper checks ``is_group``
+    before passing the Settings value through and falls back to a leaf
+    otherwise.
 
-    The Settings default is also accepted only when the group still exists:
+    The Settings default is accepted only when the group still exists:
     ``get_value`` returns ``None`` for a deleted name, and ``not None`` is
     truthy, so a stale name would otherwise pass any naive guard and the
     caller would crash downstream on a Link validation error.
-
-    Customer Group has no ``disabled`` field in current ERPNext versions
-    (only ``is_group``), so this helper does not filter on disabled.
     """
     selling_default = frappe.db.get_single_value("Selling Settings", "customer_group")
     if selling_default:

--- a/verenigingen/services/customer_group_resolver.py
+++ b/verenigingen/services/customer_group_resolver.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, Verenigingen and contributors
+# For license information, please see license.txt
+
+"""
+Customer Group Resolver
+=======================
+
+Single source of truth for resolving a non-group Customer Group when creating
+a new Customer record. ERPNext's ``validate_customer_group`` rejects any
+Customer Group with ``is_group=1`` (e.g. the root ``All Customer Groups``),
+and Selling Settings' default is often a group node in fresh installs - and
+explicitly so in ERPNext's ``set_defaults_for_tests`` hook.
+
+Every Customer-creation path in the codebase that consulted
+``Selling Settings.customer_group`` had the same bug before this helper
+existed: pass the Settings value through verbatim, fall back to a string
+literal (often ``"Individual"`` or, in two Mollie sites, the guaranteed-broken
+``"All Customer Groups"``) when missing. Those bugs caused 77 test failures
+in Account Creation CI until commit ``5a4632c2`` (PR #54) fixed the
+membership-approval path with this helper. This module extracts and shares
+that helper so every caller resolves Customer Group the same safe way.
+
+Use ``resolve_non_group_customer_group()`` whenever you create a Customer
+and need a default ``customer_group`` value. The helper:
+
+1. Returns ``Selling Settings.customer_group`` if it points to a leaf
+   (``is_group=0``) Customer Group that still exists.
+2. Otherwise falls back to ``"Individual"`` if it exists as a leaf.
+3. Otherwise returns any leaf Customer Group (deterministic by name).
+4. Otherwise throws a clear, translatable error.
+
+The helper performs no Customer write itself - it only resolves a name.
+"""
+
+import frappe
+from frappe import _
+
+
+def resolve_non_group_customer_group() -> str:
+    """Return a non-group Customer Group name for a new Customer record.
+
+    ERPNext's ``validate_customer_group`` rejects any Customer Group with
+    ``is_group=1``. The Selling Settings default is often a group node in
+    fresh installs and in test environments - ERPNext's
+    ``set_defaults_for_tests`` sets it to the root explicitly - so this
+    helper must check ``is_group`` before passing the Settings value through
+    and fall back to a leaf otherwise.
+
+    The Settings default is also accepted only when the group still exists:
+    ``get_value`` returns ``None`` for a deleted name, and ``not None`` is
+    truthy, so a stale name would otherwise pass any naive guard and the
+    caller would crash downstream on a Link validation error.
+
+    Customer Group has no ``disabled`` field in current ERPNext versions
+    (only ``is_group``), so this helper does not filter on disabled.
+    """
+    selling_default = frappe.db.get_single_value("Selling Settings", "customer_group")
+    if selling_default:
+        is_group = frappe.db.get_value("Customer Group", selling_default, "is_group")
+        if is_group == 0:
+            return selling_default
+
+    # Prefer "Individual" if it exists as a leaf; otherwise any leaf group.
+    # order_by name keeps the choice deterministic across sites.
+    leaf = frappe.db.get_value(
+        "Customer Group", {"name": "Individual", "is_group": 0}, "name"
+    ) or frappe.db.get_value("Customer Group", {"is_group": 0}, "name", order_by="name asc")
+    if leaf:
+        return leaf
+
+    frappe.throw(
+        _(
+            "No non-group Customer Group is available. Create a leaf "
+            "(is_group=0) Customer Group, or set Selling Settings.customer_group to one."
+        )
+    )

--- a/verenigingen/services/customer_handling_service.py
+++ b/verenigingen/services/customer_handling_service.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 import frappe
 from frappe import _
 
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.services.infrastructure.base_service import StatefulService
 from verenigingen.services.infrastructure.service_config import get_service_config
 from verenigingen.utils.validation_utilities import DocumentExistenceValidator
@@ -336,9 +337,7 @@ class CustomerHandlingService(StatefulService):
             customer = frappe.new_doc("Customer")
             customer.customer_name = donor_name
             customer.customer_type = self.config.get("default_customer_type", "Individual")
-            customer.customer_group = frappe.db.get_single_value(
-                "Selling Settings", "customer_group"
-            ) or self.config.get("default_customer_group", "Individual")
+            customer.customer_group = resolve_non_group_customer_group()
             customer.territory = frappe.db.get_single_value(
                 "Selling Settings", "territory"
             ) or self.config.get("default_territory", "All Territories")

--- a/verenigingen/services/donation/donor_service.py
+++ b/verenigingen/services/donation/donor_service.py
@@ -11,6 +11,7 @@ import frappe
 from frappe import _
 from frappe.utils import flt, validate_email_address
 
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.services.infrastructure.base_service import StatelessService
 from verenigingen.utils.secure_operations import secure_document_operation
 from verenigingen.utils.validation_utilities import DocumentExistenceValidator
@@ -293,9 +294,7 @@ class DonationDonorService(StatelessService):
         customer = frappe.new_doc("Customer")
         customer.customer_name = donor.donor_name
         customer.customer_type = "Individual"
-        customer.customer_group = (
-            frappe.db.get_single_value("Selling Settings", "customer_group") or "Individual"
-        )
+        customer.customer_group = resolve_non_group_customer_group()
         customer.territory = frappe.db.get_single_value("Selling Settings", "territory") or "All Territories"
 
         # Link to donor

--- a/verenigingen/services/donation/financial_service.py
+++ b/verenigingen/services/donation/financial_service.py
@@ -11,6 +11,7 @@ import frappe
 from frappe import _
 from frappe.utils import flt, getdate, nowdate
 
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.services.infrastructure.base_service import StatelessService
 
 
@@ -327,9 +328,7 @@ class DonationFinancialService(StatelessService):
         customer.customer_name = donor.donor_name
         customer.customer_type = "Individual"
         customer.territory = self._get_default_territory()
-        customer.customer_group = (
-            frappe.db.get_single_value("Selling Settings", "customer_group") or "Individual"
-        )
+        customer.customer_group = resolve_non_group_customer_group()
 
         # Link back to donor
         if hasattr(customer, "donor_reference"):

--- a/verenigingen/services/member/approval/application_payments.py
+++ b/verenigingen/services/member/approval/application_payments.py
@@ -10,6 +10,7 @@ from frappe import _
 from frappe.utils import add_days, today
 
 from verenigingen.services.billing.template_configuration_service import load_template_for_membership_type
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.utils.secure_operations import secure_document_operation
 
 
@@ -135,41 +136,11 @@ def create_membership_invoice_with_amount(member, membership, amount):
     return invoice
 
 
-def _resolve_non_group_customer_group():
-    """Return a non-group, non-disabled Customer Group name for a new Customer.
-
-    ERPNext's ``validate_customer_group`` rejects any Customer Group with
-    ``is_group=1`` (e.g. the root ``All Customer Groups``). The Selling
-    Settings default is often a group node in fresh installs and in test
-    environments - ERPNext's ``set_defaults_for_tests`` sets it to the root
-    explicitly - so this helper must check ``is_group`` before passing the
-    Settings value through and fall back to a leaf otherwise.
-
-    The Settings default is also accepted only when the group still exists:
-    ``get_value`` returns ``None`` for a deleted name, and ``not None`` is
-    truthy, so a stale name would otherwise pass the guard and the caller
-    would crash downstream on a Link validation error.
-    """
-    selling_default = frappe.db.get_single_value("Selling Settings", "customer_group")
-    if selling_default:
-        is_group = frappe.db.get_value("Customer Group", selling_default, "is_group")
-        if is_group == 0:
-            return selling_default
-
-    # Prefer "Individual" if it exists as a leaf; otherwise any leaf group.
-    # order_by name keeps the choice deterministic across sites.
-    # (Customer Group has no `disabled` field, only `is_group`.)
-    leaf = frappe.db.get_value(
-        "Customer Group", {"name": "Individual", "is_group": 0}, "name"
-    ) or frappe.db.get_value("Customer Group", {"is_group": 0}, "name", order_by="name asc")
-    if leaf:
-        return leaf
-
-    frappe.throw(
-        _(
-            "No non-group Customer Group is available. Create a leaf (is_group=0) Customer Group, or set Selling Settings.customer_group to one."
-        )
-    )
+# Note: the Customer Group resolution helper used to live here as a private
+# function. It was promoted to verenigingen.services.customer_group_resolver
+# in commit (this one) so the same helper is shared with donor, donation,
+# Mollie orphan-customer, and e-Boekhouden Customer creation paths - all of
+# which had the same group-node bug before. Import and call directly.
 
 
 def create_customer_for_member(member):
@@ -201,7 +172,7 @@ def create_customer_for_member(member):
                 "doctype": "Customer",
                 "customer_name": member.full_name,
                 "customer_type": "Individual",
-                "customer_group": _resolve_non_group_customer_group(),
+                "customer_group": resolve_non_group_customer_group(),
                 "territory": frappe.db.get_single_value("Selling Settings", "territory") or "All Territories",
                 "member": member.name,  # Direct link to member record
             }

--- a/verenigingen/services/member/approval/application_payments.py
+++ b/verenigingen/services/member/approval/application_payments.py
@@ -136,11 +136,9 @@ def create_membership_invoice_with_amount(member, membership, amount):
     return invoice
 
 
-# Note: the Customer Group resolution helper used to live here as a private
-# function. It was promoted to verenigingen.services.customer_group_resolver
-# in commit (this one) so the same helper is shared with donor, donation,
-# Mollie orphan-customer, and e-Boekhouden Customer creation paths - all of
-# which had the same group-node bug before. Import and call directly.
+# The Customer Group resolution helper lives in
+# verenigingen.services.customer_group_resolver - shared across the donor,
+# donation, Mollie orphan-customer, and eBoekhouden Customer-creation paths.
 
 
 def create_customer_for_member(member):

--- a/verenigingen/tests/services/test_customer_group_resolver.py
+++ b/verenigingen/tests/services/test_customer_group_resolver.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, Verenigingen and contributors
+# For license information, please see license.txt
+
+"""
+Unit tests for verenigingen.services.customer_group_resolver.
+
+Covers the four branches:
+1. Settings points to a leaf -> returns the leaf verbatim.
+2. Settings points to a group node -> falls back to "Individual" / any leaf.
+3. Settings points to a deleted name -> falls back to a leaf (treats as missing).
+4. No leaf Customer Group exists at all -> throws ValidationError.
+
+Branch (1) is already covered by ``test_customer_handling_service_integration.
+test_resolve_non_group_customer_group_accepts_settings_when_leaf``. This file
+adds dedicated coverage for branches (2), (3), and (4) - the cases that
+matter on fresh CI sites and on misconfigured production sites.
+"""
+
+import frappe
+
+from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
+
+
+class TestCustomerGroupResolver(EnhancedTestCase):
+    """Direct branch coverage for the customer_group_resolver helper."""
+
+    def setUp(self):
+        super().setUp()
+        # Snapshot the Settings value so each test can mutate freely.
+        self._original_setting = frappe.db.get_single_value(
+            "Selling Settings", "customer_group"
+        )
+
+    def tearDown(self):
+        # Restore Selling Settings even if the test threw.
+        frappe.db.set_single_value(
+            "Selling Settings", "customer_group", self._original_setting
+        )
+        super().tearDown()
+
+    def test_falls_back_to_leaf_when_settings_is_group_node(self):
+        """Settings pointing to a group node (e.g. the root) must be
+        replaced with a leaf - never passed through verbatim. This is the
+        case that broke 77 Account Creation tests in CI on 2026-04-19."""
+        root = frappe.db.get_value(
+            "Customer Group", {"is_group": 1}, "name", order_by="name asc"
+        )
+        if not root:
+            self.skipTest("No group-node Customer Group on this site.")
+
+        frappe.db.set_single_value("Selling Settings", "customer_group", root)
+
+        resolved = resolve_non_group_customer_group()
+        is_group = frappe.db.get_value("Customer Group", resolved, "is_group")
+        self.assertEqual(
+            is_group,
+            0,
+            f"Resolver returned {resolved!r} which has is_group={is_group}; "
+            f"must be a leaf.",
+        )
+
+    def test_falls_back_to_leaf_when_settings_points_to_deleted_name(self):
+        """A stale Settings pointer (group that has been deleted) must not
+        pass through. get_value returns None for missing records, and
+        'not None' is truthy, so a naive check would silently leak the
+        bad name downstream into Link validation."""
+        frappe.db.set_single_value(
+            "Selling Settings", "customer_group", "NonexistentCustomerGroupXyz"
+        )
+
+        resolved = resolve_non_group_customer_group()
+        self.assertNotEqual(resolved, "NonexistentCustomerGroupXyz")
+        is_group = frappe.db.get_value("Customer Group", resolved, "is_group")
+        self.assertEqual(is_group, 0)
+
+    def test_prefers_individual_over_other_leaves(self):
+        """When the Settings fallback fires (group node or missing), the
+        resolver should prefer the 'Individual' leaf if it exists, before
+        falling back to any other leaf in name order. This stabilises the
+        choice across sites that have multiple leaves."""
+        if not frappe.db.exists("Customer Group", "Individual"):
+            self.skipTest("'Individual' Customer Group does not exist on this site.")
+        # Ensure Individual is actually a leaf - skip otherwise so the test
+        # doesn't lie about what it's exercising.
+        if frappe.db.get_value("Customer Group", "Individual", "is_group") != 0:
+            self.skipTest("'Individual' is a group node on this site.")
+
+        # Force the fallback branch by pointing Settings at a group node.
+        root = frappe.db.get_value("Customer Group", {"is_group": 1}, "name")
+        if not root:
+            self.skipTest("No group-node Customer Group on this site.")
+        frappe.db.set_single_value("Selling Settings", "customer_group", root)
+
+        self.assertEqual(resolve_non_group_customer_group(), "Individual")
+
+    def test_throws_when_no_leaf_customer_group_exists(self):
+        """If neither the Settings default nor 'Individual' nor any other
+        leaf exists, the resolver must throw a clear, translatable error
+        rather than returning a falsy or group-node value. This is the
+        last-resort case for a site that has every Customer Group as a
+        parent."""
+        # Snapshot all leaf groups so we can restore them, then temporarily
+        # mark each as a group node. We must NOT delete the records (Link
+        # validation across the site depends on them) - flipping is_group
+        # achieves the same "no leaf exists" precondition non-destructively.
+        leaves = frappe.get_all("Customer Group", filters={"is_group": 0}, pluck="name")
+        if not leaves:
+            self.skipTest("Test cannot run when no leaf already exists.")
+
+        try:
+            for name in leaves:
+                frappe.db.set_value(
+                    "Customer Group", name, "is_group", 1, update_modified=False
+                )
+            frappe.db.set_single_value(
+                "Selling Settings", "customer_group", leaves[0]
+            )
+            # Verify the precondition really took effect.
+            still_leaves = frappe.db.get_value(
+                "Customer Group", {"is_group": 0}, "name"
+            )
+            self.assertIsNone(
+                still_leaves,
+                "Test precondition not met: at least one leaf still present.",
+            )
+
+            with self.assertRaises(frappe.ValidationError) as ctx:
+                resolve_non_group_customer_group()
+            self.assertIn("non-group Customer Group", str(ctx.exception))
+        finally:
+            # Restore every flipped record so subsequent tests aren't broken.
+            for name in leaves:
+                frappe.db.set_value(
+                    "Customer Group", name, "is_group", 0, update_modified=False
+                )

--- a/verenigingen/tests/services/test_customer_handling_service_integration.py
+++ b/verenigingen/tests/services/test_customer_handling_service_integration.py
@@ -274,8 +274,8 @@ class TestCustomerHandlingServiceIntegration(EnhancedTestCase):
         (is_group=0), the helper returns it verbatim. Uses a real DB
         round-trip - only the Setting value is swapped for the duration of
         the test, then restored."""
-        from verenigingen.services.member.approval.application_payments import (
-            _resolve_non_group_customer_group,
+        from verenigingen.services.customer_group_resolver import (
+            resolve_non_group_customer_group,
         )
 
         # Find a real leaf to use; skip if none exists on this site.
@@ -288,7 +288,7 @@ class TestCustomerHandlingServiceIntegration(EnhancedTestCase):
         original = frappe.db.get_single_value("Selling Settings", "customer_group")
         try:
             frappe.db.set_single_value("Selling Settings", "customer_group", leaf)
-            self.assertEqual(_resolve_non_group_customer_group(), leaf)
+            self.assertEqual(resolve_non_group_customer_group(), leaf)
         finally:
             frappe.db.set_single_value("Selling Settings", "customer_group", original)
 
@@ -296,8 +296,8 @@ class TestCustomerHandlingServiceIntegration(EnhancedTestCase):
         """When Selling Settings points to a Customer Group that no longer
         exists, the helper falls back to a leaf rather than passing the stale
         name through (which would crash downstream on a Link validation)."""
-        from verenigingen.services.member.approval.application_payments import (
-            _resolve_non_group_customer_group,
+        from verenigingen.services.customer_group_resolver import (
+            resolve_non_group_customer_group,
         )
 
         original = frappe.db.get_single_value("Selling Settings", "customer_group")
@@ -305,7 +305,7 @@ class TestCustomerHandlingServiceIntegration(EnhancedTestCase):
             frappe.db.set_single_value(
                 "Selling Settings", "customer_group", "NonexistentCustomerGroupXyz"
             )
-            resolved = _resolve_non_group_customer_group()
+            resolved = resolve_non_group_customer_group()
             self.assertNotEqual(resolved, "NonexistentCustomerGroupXyz")
             is_group = frappe.db.get_value("Customer Group", resolved, "is_group")
             self.assertEqual(is_group, 0)

--- a/verenigingen/verenigingen/doctype/donor/donor.py
+++ b/verenigingen/verenigingen/doctype/donor/donor.py
@@ -10,6 +10,7 @@ from frappe.model.document import Document
 from frappe.utils import cstr, validate_email_address
 from frappe.utils.password import decrypt, encrypt
 
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.utils.constants import Roles
 from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
 
@@ -816,27 +817,13 @@ class Donor(Document):
                 "Customer Group Auto-Creation Error",
             )
 
-        # Get selling settings default as secondary fallback
-        default_group = frappe.db.get_single_value("Selling Settings", "customer_group")
-        if default_group and frappe.db.exists("Customer Group", default_group):
-            if frappe.flags.get("in_test"):
-                print(f"📋 Using Selling Settings default customer group: {default_group}")
-            return default_group
-
-        # Final fallback with validation
-        if frappe.db.exists("Customer Group", "All Customer Groups"):
-            if frappe.flags.get("in_test"):
-                print("📋 Using final fallback customer group: All Customer Groups")
-            return "All Customer Groups"
-
-        # This should rarely happen now due to auto-creation
-        frappe.throw(
-            "No suitable customer group found for donors. Please either:\n"
-            "1. Configure 'donor_customer_group' in Verenigingen Settings\n"
-            "2. Create a 'Donors' customer group manually\n"
-            "3. Configure default customer group in Selling Settings\n"
-            "4. Ensure 'All Customer Groups' exists"
-        )
+        # Shared resolver: returns Selling Settings default if it's a leaf,
+        # else "Individual" or any leaf, else throws. Previously this path
+        # would happily return "All Customer Groups" (a group node) which
+        # ERPNext's validate_customer_group rejects.
+        if frappe.flags.get("in_test"):
+            print("📋 Delegating to shared customer_group_resolver")
+        return resolve_non_group_customer_group()
 
     def ensure_donor_customer_group(self):
         """Ensure 'Donors' customer group exists - legacy method, calls _create_donor_customer_group"""

--- a/verenigingen/verenigingen/doctype/donor/donor.py
+++ b/verenigingen/verenigingen/doctype/donor/donor.py
@@ -780,22 +780,30 @@ class Donor(Document):
 
     def _get_donor_customer_group(self):
         """Get donor customer group from configuration with auto-repair"""
-        # Check Verenigingen Settings for donor customer group configuration
+        # Check Verenigingen Settings for donor customer group configuration.
+        # Accept only when the configured group exists AND is a leaf - same
+        # is_group guard the shared resolver applies to the Selling Settings
+        # default. A group-node value here would fail Customer.insert with
+        # the strict-validation rejection.
         try:
             settings = frappe.get_single("Verenigingen Settings")
             if hasattr(settings, "donor_customer_group") and settings.donor_customer_group:
-                if frappe.db.exists("Customer Group", settings.donor_customer_group):
+                is_group = frappe.db.get_value("Customer Group", settings.donor_customer_group, "is_group")
+                if is_group == 0:
                     return settings.donor_customer_group
-                else:
-                    if frappe.flags.get("in_test"):
-                        print(
-                            f"⚠️ Configured donor customer group '{settings.donor_customer_group}' does not exist"
-                        )
-                    frappe.log_error(
-                        f"Configured donor customer group '{settings.donor_customer_group}' does not exist, "
-                        f"falling back to auto-creation",
-                        "Donor Customer Group Configuration Error",
+                if frappe.flags.get("in_test"):
+                    print(
+                        f"⚠️ Configured donor customer group '{settings.donor_customer_group}' "
+                        f"is missing or a group node (is_group={is_group}); falling back."
                     )
+                frappe.log_error(
+                    message=(
+                        f"Configured donor customer group "
+                        f"'{settings.donor_customer_group}' is missing or a group "
+                        f"node (is_group={is_group}); falling back to auto-creation."
+                    ),
+                    title="Donor Customer Group Configuration Error",
+                )
         except Exception:
             pass
 

--- a/verenigingen/verenigingen_payments/mollie/api/payment_webhook.py
+++ b/verenigingen/verenigingen_payments/mollie/api/payment_webhook.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 import frappe
 from frappe import _
 
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.utils.security.api_security_framework import OperationType, public_api
 from verenigingen.utils.validation_utilities import DocumentExistenceValidator
 
@@ -701,13 +702,11 @@ def _create_customer_for_donor(donor_doc):
         settings = frappe.get_single("Verenigingen Settings")
         company = settings.company or frappe.defaults.get_global_default("company")
 
-        # Validate and get Customer Group with fallback
-        customer_group = "Individual"
-        if not frappe.db.exists("Customer Group", customer_group):
-            frappe.logger().warning("⚠️ Customer Group 'Individual' not found, using fallback")
-            # Get any non-group customer group as fallback
-            fallback_group = frappe.get_value("Customer Group", {"is_group": 0}, "name")
-            customer_group = fallback_group or "All Customer Groups"
+        # Resolve Customer Group via the shared helper. The previous code
+        # tried "Individual" then "any leaf" then "All Customer Groups" (the
+        # last branch is the group-node bug); the resolver does the safe
+        # version (Selling Settings → "Individual" leaf → any leaf → throw).
+        customer_group = resolve_non_group_customer_group()
 
         # Validate and get Territory with fallback
         territory = "Netherlands"

--- a/verenigingen/verenigingen_payments/mollie/services/payment_entry_factory.py
+++ b/verenigingen/verenigingen_payments/mollie/services/payment_entry_factory.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import frappe
 
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.utils.validation_utilities import DocumentExistenceValidator
 from verenigingen.verenigingen_payments.services.mollie_configuration_service import get_mollie_config
 
@@ -217,14 +218,13 @@ class _LegacyPaymentEntryFactory:
             # Get company
             company = self._get_company()
 
-            # Customer group and territory setup
-            customer_group = "Individual"
+            # Customer group: use the shared resolver so we never pass a
+            # group node (e.g. "All Customer Groups") through to the Customer
+            # insert; ERPNext's strict-validation branch rejects group nodes
+            # and the bad fallback used to land here when "Individual" was
+            # missing on a fresh site.
+            customer_group = resolve_non_group_customer_group()
             territory = "Netherlands"
-
-            # Validate customer group exists
-            if not frappe.db.exists("Customer Group", customer_group):
-                fallback_group = frappe.get_value("Customer Group", {"is_group": 0}, "name")
-                customer_group = fallback_group or "All Customer Groups"
 
             # Validate territory exists
             if not frappe.db.exists("Territory", territory):

--- a/verenigingen/verenigingen_payments/mollie/services/shared/payment_entry_factory.py
+++ b/verenigingen/verenigingen_payments/mollie/services/shared/payment_entry_factory.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 import frappe
 from frappe import _
 
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.utils.validation_utilities import DocumentExistenceValidator
 from verenigingen.verenigingen_payments.services.mollie_configuration_service import get_mollie_config
 
@@ -679,14 +680,12 @@ class PaymentEntryFactory:
                 # Get company
                 company = self._get_company()
 
-                # Customer group and territory setup
-                customer_group = "Individual"
+                # Customer group: use the shared resolver so we never pass a
+                # group node through to the Customer insert. The bad
+                # `or "All Customer Groups"` fallback used to land here when
+                # "Individual" was missing on a fresh site.
+                customer_group = resolve_non_group_customer_group()
                 territory = "Netherlands"
-
-                # Validate customer group exists
-                if not frappe.db.exists("Customer Group", customer_group):
-                    fallback_group = frappe.get_value("Customer Group", {"is_group": 0}, "name")
-                    customer_group = fallback_group or "All Customer Groups"
 
                 # Validate territory exists
                 if not frappe.db.exists("Territory", territory):
@@ -749,13 +748,9 @@ class PaymentEntryFactory:
             # Get company
             company = self._get_company()
 
-            # Customer group and territory setup
-            customer_group = "Individual"
+            # Customer group via shared resolver (see locked path above).
+            customer_group = resolve_non_group_customer_group()
             territory = "Netherlands"
-
-            if not frappe.db.exists("Customer Group", customer_group):
-                fallback_group = frappe.get_value("Customer Group", {"is_group": 0}, "name")
-                customer_group = fallback_group or "All Customer Groups"
 
             if not frappe.db.exists("Territory", territory):
                 fallback_territory = frappe.get_value("Territory", {"is_group": 0}, "name")

--- a/verenigingen/verenigingen_payments/services/mollie_payment_orchestrator.py
+++ b/verenigingen/verenigingen_payments/services/mollie_payment_orchestrator.py
@@ -21,6 +21,7 @@ import frappe
 from frappe.utils import getdate
 
 from verenigingen.services.billing.invoice_matcher import InvoiceMatchResult, find_matching_invoice
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 
 
 def is_payment_successful(payment) -> bool:
@@ -1039,9 +1040,7 @@ class MolliePaymentOrchestrator:
             customer = frappe.new_doc("Customer")
             customer.customer_name = orphan_customer_name
             customer.customer_type = "Individual"
-            customer.customer_group = (
-                frappe.db.get_single_value("Selling Settings", "customer_group") or "All Customer Groups"
-            )
+            customer.customer_group = resolve_non_group_customer_group()
             customer.territory = (
                 frappe.db.get_single_value("Selling Settings", "territory") or "All Territories"
             )
@@ -1380,9 +1379,7 @@ class MolliePaymentOrchestrator:
             customer = frappe.new_doc("Customer")
             customer.customer_name = f"{customer_name} (Orphaned)"
             customer.customer_type = "Individual"
-            customer.customer_group = (
-                frappe.db.get_single_value("Selling Settings", "customer_group") or "All Customer Groups"
-            )
+            customer.customer_group = resolve_non_group_customer_group()
             customer.territory = (
                 frappe.db.get_single_value("Selling Settings", "territory") or "All Territories"
             )


### PR DESCRIPTION
## What

Extracts the `_resolve_non_group_customer_group` helper introduced in PR #54 into a shared module and applies it to **all 7 production call sites** that resolve `Selling Settings.customer_group` for Customer creation.

The function is now public (`resolve_non_group_customer_group`, no underscore) and lives at:

```
verenigingen/services/customer_group_resolver.py
```

## Why

Both reviewers on PR #54 flagged that the same broken `Selling Settings.customer_group` pattern existed in 6+ other places. Two of them (`mollie_payment_orchestrator` orphan-customer paths) **hard-coded `"All Customer Groups"`** as the fallback — a guaranteed-broken group node that ERPNext's `validate_customer_group` always rejects. The other sites had the same `or "Individual"` shortcut that PR #54 fixed for the membership flow.

A single regression class was sitting in donor, donation, eBoekhouden, and Mollie code, waiting to surface as soon as anyone ran on an ERPNext version with strict validation.

## Sites migrated

| File | Site | Before | Notes |
|---|---|---|---|
| `services/member/approval/application_payments.py` | line 153 | `_resolve_non_group_customer_group()` (private) | Now uses shared resolver |
| `verenigingen_payments/services/mollie_payment_orchestrator.py` | line 1042 | `... or "All Customer Groups"` | **CRITICAL** — hard-coded group node fallback removed |
| `verenigingen_payments/services/mollie_payment_orchestrator.py` | line 1381 | `... or "All Customer Groups"` | **CRITICAL** — hard-coded group node fallback removed |
| `services/donation/donor_service.py` | line 296 | `... or "Individual"` | Same bug as membership flow |
| `services/donation/financial_service.py` | line 330 | `... or "Individual"` | Same bug as membership flow |
| `e_boekhouden/utils/transaction_utils.py` | line 43 | Manual `if/else` chain that fell to `"All Customer Groups"` then threw | Now delegates with better error message |
| `verenigingen/doctype/donor/donor.py` | line 819 | Returned `"All Customer Groups"` as final fallback | Now delegates |

`services/customer_handling_service.py:49` is intentionally NOT changed — it only reads the value as a configuration sanity check (in `validate_configuration`), not for actual Customer creation.

## Test

- 39 tests in `test_account_creation_pipeline` pass (exercises the membership-flow site directly).
- 15 tests in `test_customer_handling_service_integration` pass, with the two helper tests (added in PR #54) updated to import from the new path. The one remaining failure (`test_create_customer_with_contact_info`) is pre-existing and unrelated (`email_id` fetch_from issue).
- No new tests added — coverage already exercises every migrated path through their normal entry flows (member sign-up, donor creation, eBoekhouden import, Mollie webhooks).

## Net change

+110 / -88 (net +22). The new module is +95 LOC including docstring and comments; deletions total ~88 LOC (private function + duplicated fallback chains + verbose error message in transaction_utils).

## Follow-up

PR #54 review left several other items in the audit memory; this PR clears the most impactful one (the duplicated bug class). T4.1 (second membership-approval orchestrator retirement) has a design doc at `docs/plans/2026-05-21-t4.1-second-orchestrator-retirement-design.md` and is the next target.