### PR TITLE
fix(volunteer): correct Board Position source_doctype (Issue #65)

### DIFF
--- a/verenigingen/services/volunteer/assignment_query_builder.py
+++ b/verenigingen/services/volunteer/assignment_query_builder.py
@@ -111,7 +111,7 @@ class AssignmentQueryBuilder:
             """
             SELECT
                 'Board Position' as source_type,
-                'Verenigingen Chapter Board Member' as source_doctype,
+                'Chapter Board Member' as source_doctype,
                 cbm.parent as source_name,
                 'Chapter' as source_doctype_display,
                 c.name as source_name_display,

--- a/verenigingen/tests/services/test_volunteer_assignment_service.py
+++ b/verenigingen/tests/services/test_volunteer_assignment_service.py
@@ -59,6 +59,7 @@ class TestVolunteerAssignmentService(EnhancedTestCase):
                 "doctype": "Chapter",
                 "name": f"Test Chapter Assignment {frappe.generate_hash(length=6)}",
                 "chapter_head": self.test_member.name,
+                "status": "Active",
             }
         )
         test_chapter.insert()
@@ -85,6 +86,7 @@ class TestVolunteerAssignmentService(EnhancedTestCase):
         self.assertEqual(len(assignments), 1)
         board_assignment = assignments[0]
         self.assertEqual(board_assignment["source_type"], "Board Position")
+        self.assertEqual(board_assignment["source_doctype"], "Chapter Board Member")
         self.assertEqual(board_assignment["role"], "Treasurer")
         self.assertTrue(board_assignment["is_active"])
         self.assertEqual(board_assignment["editable"], False)  # Board positions are not editable


### PR DESCRIPTION
Closes #65.

## Bug

\`verenigingen/services/volunteer/assignment_query_builder.py:114\` hard-coded:

\`\`\`sql
'Verenigingen Chapter Board Member' as source_doctype,
\`\`\`

…but the actual DocType is **\`Chapter Board Member\`** (see \`verenigingen/verenigingen/doctype/chapter_board_member/chapter_board_member.json\`). \`Verenigingen Chapter Board Member\` is the **Role name**, not a DocType.

## Impact

Any consumer that uses \`source_doctype\` returned by \`Volunteer.get_aggregated_assignments()\` to navigate to the linked record (e.g. \`frappe.get_doc(source_doctype, source_name)\`) for a Board Position assignment would get \`DoesNotExistError\`. UI consumers use \`source_link\` directly, so this is currently masked in practice — but the field value is wrong.

## Fix

- \`assignment_query_builder.py:114\`: \`'Verenigingen Chapter Board Member'\` → \`'Chapter Board Member'\`
- \`test_volunteer_assignment_service.py:88\`: add regression assertion \`self.assertEqual(board_assignment["source_doctype"], "Chapter Board Member")\`
- \`test_volunteer_assignment_service.py:62\`: add \`"status": "Active"\` to the test chapter setup (Chapter.status is \`reqd: 1\`, was failing in setUp on current develop with MandatoryError — unblocks the test)

## Verification

- Ran the affected test in isolation: \`bench --site veg11.veganisme.org run-tests --app verenigingen --module verenigingen.tests.services.test_volunteer_assignment_service --test test_get_aggregated_assignments_with_board_position\` → \`Ran 1 test in 7.240s OK\`.
- Verified no consumer relies on the wrong literal (\`grep -rn "Verenigingen Chapter Board Member"\` shows it only as a Role name elsewhere — never as a DocType reference; the only other \`source_doctype\` usage is \`field_sync_service.py\`, which is unrelated context).
- Static analysis: only two \`source_doctype\` consumers in the codebase. Neither is the bug-site. Neither uses the wrong value.

## Not in this PR

- When run as part of the full \`test_volunteer_assignment_service\` file, this test fails on an **unrelated pre-existing test-isolation issue** — a \`Volunteer Activity\` from \`test_aggregated_assignments_reference_links\` leaks into subsequent tests because cleanup isn't isolating properly. Documented in \`MEMORY.md\` → \`test-suite-crisis-2026-05-22\`. Out of scope here.
- Once PR #67 (CI rewire for Issue #66) merges, the broader test-suite re-baselining work will surface this test pollution as part of normal triage.