### PR TITLE
test: restore super().setUp() in 36 EnhancedTestCase test classes

### DIFF
--- a/verenigingen/tests/backend/components/test_chapter_assignment_edge_cases.py
+++ b/verenigingen/tests/backend/components/test_chapter_assignment_edge_cases.py
@@ -67,6 +67,7 @@ class TestChapterAssignmentEdgeCases(EnhancedTestCase):
 
     def setUp(self):
         """Set up for each test"""
+        super().setUp()
         self.test_counter = getattr(self, "_test_counter", 0) + 1
         setattr(self, "_test_counter", self.test_counter)
 

--- a/verenigingen/tests/backend/components/test_membership_application.py
+++ b/verenigingen/tests/backend/components/test_membership_application.py
@@ -325,6 +325,7 @@ class TestMembershipApplicationLoad(EnhancedTestCase):
 
     def setUp(self):
         """Set up for each test"""
+        super().setUp()
         self.test_email = f"load_test_{frappe.generate_hash(length=8)}@example.com"
         self.application_data = {
             "first_name": "Load",
@@ -2027,6 +2028,7 @@ class TestChapterSelection(EnhancedTestCase):
 
     def setUp(self):
         """Set up for each test"""
+        super().setUp()
         self.test_email = f"chapter_test_{frappe.generate_hash(length=8)}@example.com"
         self.base_application_data = {
             "first_name": "Chapter",
@@ -2562,6 +2564,7 @@ class TestMembershipApplicationEdgeCases(EnhancedTestCase):
 
     def setUp(self):
         """Set up for each test"""
+        super().setUp()
         self.test_email = f"edge_test_{frappe.generate_hash(length=8)}@example.com"
 
         # Ensure test membership type exists

--- a/verenigingen/tests/backend/components/test_payment_failure_scenarios.py
+++ b/verenigingen/tests/backend/components/test_payment_failure_scenarios.py
@@ -100,6 +100,7 @@ class TestPaymentFailureScenarios(EnhancedTestCase):
 
     def setUp(self):
         """Set up each test"""
+        super().setUp()
         frappe.set_user("Administrator")
 
     # ===== MEMBERSHIP PAYMENT FAILURES =====

--- a/verenigingen/tests/backend/components/test_sepa_notifications.py
+++ b/verenigingen/tests/backend/components/test_sepa_notifications.py
@@ -18,6 +18,7 @@ class TestSEPANotificationBusinessLogic(EnhancedTestCase):
 
     def setUp(self):
         """Set up for each test"""
+        super().setUp()
         self.notification_manager = SEPAMandateNotificationManager()
 
     def test_iban_masking(self):

--- a/verenigingen/tests/backend/components/test_team_assignment_history.py
+++ b/verenigingen/tests/backend/components/test_team_assignment_history.py
@@ -10,6 +10,7 @@ class TestTeamAssignmentHistory(EnhancedTestCase):
 
     def setUp(self):
         """Set up test data"""
+        super().setUp()
         # Get or create a test volunteer
         volunteers = frappe.get_all("Volunteer", limit=1)
         if volunteers:

--- a/verenigingen/tests/backend/comprehensive/test_doctype_validation.py
+++ b/verenigingen/tests/backend/comprehensive/test_doctype_validation.py
@@ -14,6 +14,7 @@ class TestDoctypeValidationComprehensive(EnhancedTestCase):
 
     def setUp(self):
         """Set up test environment"""
+        super().setUp()
         # EnhancedTestCase handles permissions automatically
 
     def tearDown(self):

--- a/verenigingen/tests/backend/comprehensive/test_financial_integration_edge_cases.py
+++ b/verenigingen/tests/backend/comprehensive/test_financial_integration_edge_cases.py
@@ -78,6 +78,7 @@ class TestFinancialIntegrationEdgeCases(EnhancedTestCase):
 
     def setUp(self):
         """Set up each test"""
+        super().setUp()
         # EnhancedTestCase handles permissions automatically
 
     # ===== MEMBERSHIP FEE EDGE CASES =====

--- a/verenigingen/tests/backend/comprehensive/test_termination_workflow_edge_cases.py
+++ b/verenigingen/tests/backend/comprehensive/test_termination_workflow_edge_cases.py
@@ -83,6 +83,7 @@ class TestTerminationWorkflowEdgeCases(EnhancedTestCase):
 
     def setUp(self):
         """Set up each test"""
+        super().setUp()
         # EnhancedTestCase handles permissions automatically
 
     def tearDown(self):

--- a/verenigingen/tests/backend/features/test_application_submission_validation.py
+++ b/verenigingen/tests/backend/features/test_application_submission_validation.py
@@ -15,6 +15,7 @@ class TestApplicationSubmissionValidation(EnhancedTestCase):
 
     def setUp(self):
         """Set up test environment"""
+        super().setUp()
         # EnhancedTestCase handles permissions automatically
         self.test_cleanup_records = []
 

--- a/verenigingen/tests/backend/integration/test_eboekhouden_integration.py
+++ b/verenigingen/tests/backend/integration/test_eboekhouden_integration.py
@@ -55,6 +55,7 @@ class TestEBoekhoudenIntegration(EnhancedTestCase):
             
     def setUp(self):
         """Set up test environment"""
+        super().setUp()
         self.mock_settings = {
             "username": "test_user",
             "security_code_1": "test_code_1",

--- a/verenigingen/tests/backend/integration/test_policy_expense_integration.py
+++ b/verenigingen/tests/backend/integration/test_policy_expense_integration.py
@@ -335,6 +335,7 @@ class TestPolicyExpenseReporting(EnhancedTestCase):
     """Test policy expense reporting and analytics"""
 
     def setUp(self):
+        super().setUp()
         frappe.set_user("Administrator")
 
     def test_policy_expense_tracking_in_report(self):

--- a/verenigingen/tests/backend/validation/test_special_characters_validation.py
+++ b/verenigingen/tests/backend/validation/test_special_characters_validation.py
@@ -13,6 +13,7 @@ class TestSpecialCharactersValidation(EnhancedTestCase):
 
     def setUp(self):
         """Set up test environment"""
+        super().setUp()
 
     def test_validate_name_with_accented_characters(self):
         """Test name validation with accented characters"""

--- a/verenigingen/tests/frontend/integration/test_iban_validation_integration.py
+++ b/verenigingen/tests/frontend/integration/test_iban_validation_integration.py
@@ -17,6 +17,7 @@ class TestIBANValidationIntegration(EnhancedTestCase):
 
     def setUp(self):
         """Set up test data"""
+        super().setUp()
         frappe.set_user("Administrator")
 
     def test_iban_validation_comprehensive(self):

--- a/verenigingen/tests/integration/test_performance_with_real_data.py
+++ b/verenigingen/tests/integration/test_performance_with_real_data.py
@@ -26,6 +26,7 @@ class TestRealDataPerformance(EnhancedTestCase):
     
     def setUp(self):
         """Set up test with current user context"""
+        super().setUp()
         frappe.set_user("Administrator")
         self.start_time = None
         self.query_counts = []
@@ -335,6 +336,7 @@ class TestRealDataScenarios(EnhancedTestCase):
     
     def setUp(self):
         """Set up test with current user context"""
+        super().setUp()
         frappe.set_user("Administrator")
         self.start_time = None
         

--- a/verenigingen/tests/member/test_membership_application_skills.py
+++ b/verenigingen/tests/member/test_membership_application_skills.py
@@ -24,6 +24,7 @@ class TestMembershipApplicationSkills(EnhancedTestCase):
 
     def setUp(self):
         """Set up test data"""
+        super().setUp()
         # Create test data first
         self.test_email = "test_skills_member@example.com"
         

--- a/verenigingen/tests/payment/test_contribution_system.py
+++ b/verenigingen/tests/payment/test_contribution_system.py
@@ -15,6 +15,7 @@ class TestContributionSystem(EnhancedTestCase):
     
     def setUp(self):
         """Set up test data"""
+        super().setUp()
         self.membership_type = None
         self.template = None
         

--- a/verenigingen/tests/payment/test_mollie_edge_cases_integration.py
+++ b/verenigingen/tests/payment/test_mollie_edge_cases_integration.py
@@ -33,6 +33,7 @@ class TestMollieEdgeCasesIntegration(EnhancedTestCase):
     
     def setUp(self):
         """Set up integration test environment"""
+        super().setUp()
         self.factory = MollieApiDataFactory(seed=100)
         
         # Set up dashboard with mocked components
@@ -448,6 +449,7 @@ class TestMollieApiParameterValidation(EnhancedTestCase):
     
     def setUp(self):
         """Set up parameter validation tests"""
+        super().setUp()
         self.factory = MollieApiDataFactory(seed=200)
     
     def test_api_parameter_sanitization(self):

--- a/verenigingen/tests/payment/test_payment_api_mutations.py
+++ b/verenigingen/tests/payment/test_payment_api_mutations.py
@@ -107,6 +107,7 @@ class TestActualPaymentMutations(EnhancedTestCase):
     
     def setUp(self):
         """Set up for each test."""
+        super().setUp()
         self.handler = PaymentEntryHandler(self.company)
         
     def tearDown(self):

--- a/verenigingen/tests/payment/test_payment_entry_handler.py
+++ b/verenigingen/tests/payment/test_payment_entry_handler.py
@@ -29,6 +29,7 @@ class TestPaymentEntryHandler(EnhancedTestCase):
         
     def setUp(self):
         """Set up for each test."""
+        super().setUp()
         self.handler = PaymentEntryHandler(self.company)
         
     def tearDown(self):

--- a/verenigingen/tests/security/test_role_profile_integration.py
+++ b/verenigingen/tests/security/test_role_profile_integration.py
@@ -19,6 +19,7 @@ class TestRoleProfileIntegration(EnhancedTestCase):
 
     def setUp(self):
         """Setup test environment"""
+        super().setUp()
         self.framework = APISecurityFramework()
         self.test_user = "test@example.com"
 
@@ -169,6 +170,7 @@ class TestSelfServiceOperations(EnhancedTestCase):
 
     def setUp(self):
         """Setup test environment"""
+        super().setUp()
         self.framework = APISecurityFramework()
 
     def test_self_service_parameter_exists(self):

--- a/verenigingen/tests/security/test_security_framework_comprehensive.py
+++ b/verenigingen/tests/security/test_security_framework_comprehensive.py
@@ -53,6 +53,7 @@ class TestSecurityFrameworkCore(EnhancedTestCase):
     """Test core security framework functionality"""
 
     def setUp(self):
+        super().setUp()
         self.framework = get_security_framework()
         self.validator = get_enhanced_validator()
         self.classifier = get_api_classifier()
@@ -131,6 +132,7 @@ class TestSecurityValidation(EnhancedTestCase):
     """Test security validation functionality"""
 
     def setUp(self):
+        super().setUp()
         self.validator = get_enhanced_validator()
 
     def test_validation_schemas_registered(self):
@@ -274,6 +276,7 @@ class TestAPIClassifier(EnhancedTestCase):
     """Test API classification functionality"""
 
     def setUp(self):
+        super().setUp()
         self.classifier = get_api_classifier()
 
     def test_operation_type_classification(self):
@@ -325,6 +328,7 @@ class TestSecurityMonitoring(EnhancedTestCase):
     """Test security monitoring functionality"""
 
     def setUp(self):
+        super().setUp()
         self.monitor = get_security_monitor()
         self.tester = get_security_tester()
 

--- a/verenigingen/tests/security/test_security_vulnerability_regression.py
+++ b/verenigingen/tests/security/test_security_vulnerability_regression.py
@@ -20,6 +20,7 @@ class TestSecurityVulnerabilityRegression(EnhancedTestCase):
 
     def setUp(self):
         """Setup test environment"""
+        super().setUp()
         self.test_user = "test@example.com"
 
     def test_role_profile_query_security_fix(self):

--- a/verenigingen/tests/utils/test_improved_error_handling.py
+++ b/verenigingen/tests/utils/test_improved_error_handling.py
@@ -13,6 +13,7 @@ class TestImprovedErrorHandling(EnhancedTestCase):
     
     def setUp(self):
         """Set up test environment"""
+        super().setUp()
         self.results = {
             "total_tests": 0,
             "passed": 0,

--- a/verenigingen/verenigingen/doctype/chapter/test_chapter_head.py
+++ b/verenigingen/verenigingen/doctype/chapter/test_chapter_head.py
@@ -10,6 +10,7 @@ from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
 class TestChapterHead(EnhancedTestCase):
     def setUp(self):
         # Generate a unique identifier using only alphanumeric characters
+        super().setUp()
         self.unique_id = "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
 
         # Clean up any existing test data

--- a/verenigingen/verenigingen/doctype/chapter/test_chapter_volunteer_integration.py
+++ b/verenigingen/verenigingen/doctype/chapter/test_chapter_volunteer_integration.py
@@ -13,6 +13,7 @@ from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
 class TestChapterVolunteerIntegration(EnhancedTestCase):
     def setUp(self):
         # Create a unique identifier for this test run
+        super().setUp()
         self.test_id = str(uuid.uuid4()).replace("-", "")[:12]
 
         # Test data

--- a/verenigingen/verenigingen/doctype/team/test_team.py
+++ b/verenigingen/verenigingen/doctype/team/test_team.py
@@ -57,6 +57,7 @@ class TestTeam(EnhancedTestCase):
 
     def setUp(self):
         # Generate a unique ID for this test method
+        super().setUp()
         self.test_id = "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
         # Create test data
         self.create_test_volunteers()

--- a/verenigingen/verenigingen/doctype/volunteer/test_volunteer_aggregated.py
+++ b/verenigingen/verenigingen/doctype/volunteer/test_volunteer_aggregated.py
@@ -12,6 +12,7 @@ from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
 class TestVolunteerAggregatedAssignments(EnhancedTestCase):
     def setUp(self):
         # Initialize the cleanup list
+        super().setUp()
         self._docs_to_delete = []
 
         # Create test data

--- a/verenigingen/verenigingen_payments/doctype/sepa_mandate/test_sepa_mandate.py
+++ b/verenigingen/verenigingen_payments/doctype/sepa_mandate/test_sepa_mandate.py
@@ -12,6 +12,7 @@ class TestSEPAMandate(EnhancedTestCase):
 
     def setUp(self):
         # Create a test member for use in tests
+        super().setUp()
         self.test_member = create_test_member()
         # Create a clean mandate for each test
         self.mandate = frappe.get_doc(


### PR DESCRIPTION
Follow-up to PR #62 (tearDown sweep). Same idea, setUp half.

## Problem

36 \`EnhancedTestCase\` subclasses across 28 test files override \`setUp\` without calling \`super().setUp()\`. The base class's per-test initialization at \`verenigingen/tests/fixtures/enhanced_test_factory.py:1477-1548\` silently never runs:
- \`self.factory\` (test data factory)
- \`self.uid\` (per-test unique ID)
- \`self.created_records\` (cleanup tracking)
- \`self.email_patches\` (email mocking)
- \`self.rate_limit_patches\` (rate-limit mocking)
- \`frappe.set_user(Administrator)\` reset
- Stale-data cleanup, fixture validation

## Fix

AST scan finds the 36 classes; programmatic edit inserts \`super().setUp()\` at the top of each subclass setUp method (after docstring if present). Post-PR AST scan: 0 \`EnhancedTestCase\` subclasses with setUp missing super().

## Risk profile

- **34 of 36** had no parent-attr access in setUp (trivially safe — pure ordering doesn't matter).
- **2 in \`tests/payment/test_mollie_edge_cases_integration.py\`** reassign \`self.factory\` to a custom \`MollieApiDataFactory\` after super(). \`super().setUp()\` runs first (cleanup hooks register), then subclass overrides \`self.factory\` with its Mollie-specific factory. Order is correct.
- The base setUp is **defensively coded** (\`try/except: pass\`, \`hasattr\` guards). super() call cannot raise.
- **Latent bug exposure**: tests that were accidentally passing because parent setUp wasn't running (e.g., fixtures from prior tests leaking into assertions) will start failing. That's exposing existing bugs, not introducing new ones — same caveat as PR #62.

## Verification

Spot-checked locally against current develop:
- \`test_team_assignment_history\` — **4 tests OK** after edit
- \`test_sepa_notifications\` — **6 tests OK** after edit
- \`test_chapter_assignment_edge_cases\` — same \`FAILED (errors=1, skipped=1)\` pattern with and without my change (failure is in \`setUpClass\` on a pre-existing Chapter \`status\` mandatory-field bug, unrelated to \`setUp\`)

CI now actually runs the suite thanks to PR #67's matrix fix. The 4-shard run on this PR is the real verification.

## Hook skips

Two pre-existing hook failures on touched files; verified pre-existing on develop:
- \`test-quality-enforcer\`: \`set_user(\"Administrator\")\` in \`test_chapter_assignment_edge_cases.py:514\`, \`patch(\"frappe.db.get_value\")\` in \`test_chapter_membership_workflow.py:295\`
- \`import-path-validator\`: \`from verenigingen.api.financial import ...\` and \`from verenigingen.utils.payment_recovery import ...\` in \`test_payment_failure_scenarios.py\` (broken imports unrelated to this PR)

Same scope-discipline call as PR #62 — fixing these would be unrelated scope creep.

## Follow-ups

Per the handoff and the PR #62 reviews, the next missing-super sweep targets:
- \`setUpClass\`/\`tearDownClass\` (~10 methods)
- Other base-class subclasses (\`FrappeTestCase\`, \`VereningingenTestCase\`) if any have the same pattern