### PR TITLE
test: delete vestigial pass-only setUpClass overrides

### DIFF
--- a/verenigingen/tests/backend/components/test_membership_type_minimum_period.py
+++ b/verenigingen/tests/backend/components/test_membership_type_minimum_period.py
@@ -11,12 +11,6 @@ from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
 class TestMembershipTypeMinimumPeriod(EnhancedTestCase):
     """Test cases for the per-membership-type enforce_minimum_period setting"""
 
-    @classmethod
-    def setUpClass(cls):
-        """Set up test data using Enhanced Test Factory"""
-        super().setUpClass()
-        pass  # Enhanced Test Factory handles this automatically
-
     def setUp(self):
         """Set up before each test using Enhanced Test Factory"""
         super().setUp()

--- a/verenigingen/verenigingen_payments/doctype/sepa_mandate/test_sepa_mandate.py
+++ b/verenigingen/verenigingen_payments/doctype/sepa_mandate/test_sepa_mandate.py
@@ -5,12 +5,6 @@ from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
 
 
 class TestSEPAMandate(EnhancedTestCase):
-    @classmethod
-    def setUpClass(cls):
-        # Set up any common test data
-        super().setUpClass()
-        pass
-
     def setUp(self):
         # Create a test member for use in tests
         super().setUp()


### PR DESCRIPTION
Two test classes had \`setUpClass\` methods containing only \`super().setUpClass()\` + a comment + \`pass\`. Behavior is unchanged after deletion — the parent's \`setUpClass\` runs naturally via MRO.

- \`verenigingen/tests/backend/components/test_membership_type_minimum_period.py:14-18\`
- \`verenigingen/verenigingen_payments/doctype/sepa_mandate/test_sepa_mandate.py:8-12\`

Flagged as non-blocking by skeptical reviewer on PR #70.

## Verification

Both files still load and run; pre-existing failures unrelated to this change.