### PR TITLE
fix: self-service expense submission + dormant SQL bug in get_user_volunteer_record_optimized

### DIFF
--- a/verenigingen/templates/pages/volunteer/expenses.py
+++ b/verenigingen/templates/pages/volunteer/expenses.py
@@ -184,7 +184,11 @@ def upload_expense_receipt():
 
 
 @frappe.whitelist()
-@standard_api(operation_type=OperationType.REPORTING, self_service_only=True)
+@standard_api(
+    operation_type=OperationType.REPORTING,
+    self_service_only=True,
+    self_service_implicit_allowed=True,
+)
 def submit_expense(expense_data=None, additional_expenses=None):
     """Submit a new expense from the portal.
 

--- a/verenigingen/tests/backend/comprehensive/test_chapter_membership_validation_edge_cases.py
+++ b/verenigingen/tests/backend/comprehensive/test_chapter_membership_validation_edge_cases.py
@@ -3,11 +3,29 @@
 Edge case tests for chapter membership validation to prevent similar bugs
 """
 
+import contextlib
 import unittest
-from unittest.mock import patch
 
 import frappe
 from frappe.utils import today
+
+
+@contextlib.contextmanager
+def _as_session_user(email: str):
+    """Temporarily set frappe.session.user without going through User-validation.
+
+    Replaces broken `with patch("frappe.session.user", email):` idiom.
+    `mock.patch` resolves the dotted path at decoration time — `frappe.session`
+    is a Werkzeug LocalProxy whose `.user` lookup raises before the patch can
+    install. Direct assignment works because the proxy delegates __setattr__
+    to the underlying session dict.
+    """
+    original = frappe.session.user
+    try:
+        frappe.session.user = email
+        yield
+    finally:
+        frappe.session.user = original
 
 
 def _ensure_region(region_name: str, region_code: str) -> str:
@@ -153,7 +171,7 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
         from verenigingen.templates.pages.volunteer.expenses import submit_expense
 
         # Test get_user_volunteer_record first
-        with patch("frappe.session.user", "edge1@example.com"):
+        with _as_session_user("edge1@example.com"):
             volunteer_record = get_user_volunteer_record()
 
             self.assertIsNotNone(volunteer_record, "Should find volunteer record")
@@ -169,7 +187,7 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
             "category": self.category_name,
             "notes": "Testing valid membership"}
 
-        with patch("frappe.session.user", "edge1@example.com"):
+        with _as_session_user("edge1@example.com"):
             result = submit_expense(expense_data)
 
             self.assertTrue(
@@ -189,7 +207,7 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
             "category": self.category_name,
             "notes": "Testing invalid membership"}
 
-        with patch("frappe.session.user", "edge1@example.com"):
+        with _as_session_user("edge1@example.com"):
             result = submit_expense(expense_data)
 
             self.assertFalse(result.get("success"), "Should fail for invalid membership")
@@ -205,7 +223,7 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
         from verenigingen.templates.pages.volunteer.expenses import submit_expense
 
         # Test get_user_volunteer_record
-        with patch("frappe.session.user", "edge2@example.com"):
+        with _as_session_user("edge2@example.com"):
             volunteer_record = get_user_volunteer_record()
 
             self.assertIsNotNone(volunteer_record, "Should find volunteer record")
@@ -222,7 +240,7 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
             "category": self.category_name,
             "notes": "Testing volunteer without member link"}
 
-        with patch("frappe.session.user", "edge2@example.com"):
+        with _as_session_user("edge2@example.com"):
             result = submit_expense(expense_data)
 
             self.assertFalse(result.get("success"), "Should fail for volunteer without member link")
@@ -231,7 +249,7 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
         """Test member without volunteer link trying to access system"""
         from verenigingen.utils.volunteer_expense_portal_utils import get_user_volunteer_record
 
-        with patch("frappe.session.user", "edge3@example.com"):
+        with _as_session_user("edge3@example.com"):
             volunteer_record = get_user_volunteer_record()
 
             self.assertIsNone(volunteer_record, "Should return None for member without volunteer link")
@@ -269,7 +287,7 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
             "category": self.category_name,
             "notes": "Testing disabled membership"}
 
-        with patch("frappe.session.user", "edge1@example.com"):
+        with _as_session_user("edge1@example.com"):
             submit_expense(expense_data)
 
             # Should fail because membership is disabled
@@ -301,7 +319,7 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
             "category": self.category_name,
             "notes": "Testing multiple memberships edge case"}
 
-        with patch("frappe.session.user", "edge1@example.com"):
+        with _as_session_user("edge1@example.com"):
             result = submit_expense(expense_data)
 
             self.assertTrue(result.get("success"), "Should succeed even with multiple membership entries")
@@ -319,7 +337,7 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
             "category": self.category_name,
             "notes": "Testing case sensitivity"}
 
-        with patch("frappe.session.user", "edge1@example.com"):
+        with _as_session_user("edge1@example.com"):
             result = submit_expense(expense_data)
 
             self.assertFalse(result.get("success"), "Should fail for incorrect case in chapter name")
@@ -337,7 +355,7 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
             "category": self.category_name,
             "notes": "Testing nonexistent chapter"}
 
-        with patch("frappe.session.user", "edge1@example.com"):
+        with _as_session_user("edge1@example.com"):
             result = submit_expense(expense_data)
 
             self.assertFalse(result.get("success"), "Should fail for nonexistent chapter")
@@ -359,7 +377,7 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
         volunteer_empty.insert()
 
         try:
-            with patch("frappe.session.user", "empty@example.com"):
+            with _as_session_user("empty@example.com"):
                 volunteer_record = get_user_volunteer_record()
 
                 self.assertIsNotNone(volunteer_record, "Should find volunteer")

--- a/verenigingen/tests/backend/comprehensive/test_chapter_membership_validation_edge_cases.py
+++ b/verenigingen/tests/backend/comprehensive/test_chapter_membership_validation_edge_cases.py
@@ -28,6 +28,27 @@ def _as_session_user(email: str):
         frappe.session.user = original
 
 
+def _ensure_user(email: str, first_name: str, last_name: str, roles=("Verenigingen Member",)) -> None:
+    """Idempotently create a User. The portal endpoints under test gate on
+    `frappe.session.user` being a real authenticated User with appropriate
+    roles — without this, `validate_authentication` raises VPermissionError
+    before the test code is reached."""
+    if frappe.db.exists("User", email):
+        return
+    user = frappe.get_doc({
+        "doctype": "User",
+        "email": email,
+        "first_name": first_name,
+        "last_name": last_name,
+        "enabled": 1,
+        "user_type": "System User",
+        "send_welcome_email": 0,
+    })
+    for role in roles:
+        user.append("roles", {"role": role})
+    user.insert(ignore_permissions=True)
+
+
 def _ensure_region(region_name: str, region_code: str) -> str:
     """Idempotently create a Region and return its actual .name (autoname scrubs)."""
     existing = frappe.db.get_value("Region", {"region_name": region_name}, "name")
@@ -57,6 +78,17 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
 
         # Clean up any existing test data first
         cls._cleanup_test_data()
+
+        # Create User records for edge emails. The portal endpoints under test
+        # gate on `frappe.session.user` being a real authenticated User with
+        # the Verenigingen Member role.
+        for email, first, last in [
+            ("edge1@example.com", "Edge", "Case One"),
+            ("edge2@example.com", "Edge", "Case Two"),
+            ("edge3@example.com", "Edge", "Case Three"),
+            ("empty@example.com", "Edge", "Case Empty"),
+        ]:
+            _ensure_user(email, first, last)
 
         # Create required Regions. autoname=field:region_name scrubs to dashes,
         # so capture the resolved .name to use in Chapter.region links below.
@@ -445,6 +477,12 @@ class TestChapterMembershipValidationEdgeCases(unittest.TestCase):
             ):
                 _safe(lambda n=member_name: frappe.delete_doc("Member", n, force=True, ignore_permissions=True))
                 _safe(lambda n=member_name: frappe.db.sql("DELETE FROM `tabMember` WHERE name = %s", (n,)))
+
+        # Users delete after Volunteer/Member to avoid permission/FK churn.
+        for email in edge_emails:
+            if frappe.db.exists("User", email):
+                _safe(lambda e=email: frappe.delete_doc("User", e, force=True, ignore_permissions=True))
+                _safe(lambda e=email: frappe.db.sql("DELETE FROM `tabUser` WHERE name = %s", (e,)))
 
         _safe(frappe.db.commit)
 

--- a/verenigingen/tests/backend/comprehensive/test_chapter_membership_validation_edge_cases.py
+++ b/verenigingen/tests/backend/comprehensive/test_chapter_membership_validation_edge_cases.py
@@ -28,12 +28,21 @@ def _as_session_user(email: str):
         frappe.session.user = original
 
 
-def _ensure_user(email: str, first_name: str, last_name: str, roles=("Verenigingen Member",)) -> None:
-    """Idempotently create a User. The portal endpoints under test gate on
-    `frappe.session.user` being a real authenticated User with appropriate
-    roles — without this, `validate_authentication` raises VPermissionError
-    before the test code is reached."""
+def _ensure_user(email: str, first_name: str, last_name: str,
+                 role_profile: str = "Verenigingen Volunteer") -> None:
+    """Idempotently create a User with a role profile assignment.
+
+    The portal endpoints under test (e.g. `submit_expense`) require MEDIUM
+    security level. Per `verenigingen/utils/security/authorization_policy.py`,
+    only role *profiles* — not plain roles — grant access to a security level.
+    `Verenigingen Volunteer` profile grants MEDIUM (for self_service_only
+    operations) + LOW.
+    """
     if frappe.db.exists("User", email):
+        # Backfill role_profile_name if missing (older Users may have been
+        # created without it; the role profile gate fails silently otherwise).
+        if not frappe.db.get_value("User", email, "role_profile_name"):
+            frappe.db.set_value("User", email, "role_profile_name", role_profile)
         return
     user = frappe.get_doc({
         "doctype": "User",
@@ -43,9 +52,8 @@ def _ensure_user(email: str, first_name: str, last_name: str, roles=("Vereniging
         "enabled": 1,
         "user_type": "System User",
         "send_welcome_email": 0,
+        "role_profile_name": role_profile,
     })
-    for role in roles:
-        user.append("roles", {"role": role})
     user.insert(ignore_permissions=True)
 
 

--- a/verenigingen/utils/performance_utils.py
+++ b/verenigingen/utils/performance_utils.py
@@ -295,10 +295,14 @@ def get_user_volunteer_record_optimized(user_email: str) -> Optional[Dict[str, A
         Volunteer record with member information, or None if not found
     """
     try:
-        # Single query with JOIN to get all required data
+        # Single query with JOIN to get all required data. Note:
+        # `skills_and_qualifications` is a child Table field — it has no column
+        # on `tabVolunteer`, so it CANNOT appear in this SELECT. Including it
+        # raised OperationalError on every call, which the bare-except below
+        # silently swallowed → callers got None for every user.
         volunteer_data = frappe.db.sql(
             """
-            SELECT v.name, v.volunteer_name, v.member, v.skills_and_qualifications, v.commitment_level,
+            SELECT v.name, v.volunteer_name, v.member, v.commitment_level,
                    m.name as member_name, m.email, m.first_name, m.last_name
             FROM `tabVolunteer` v
             JOIN `tabMember` m ON v.member = m.name

--- a/verenigingen/utils/security/api_security_framework.py
+++ b/verenigingen/utils/security/api_security_framework.py
@@ -1074,6 +1074,7 @@ def standard_api(
     *,
     operation_type: OperationType = OperationType.REPORTING,
     self_service_only: bool = False,
+    self_service_implicit_allowed: bool = False,
     max_request_size: int = None,
 ):
     """
@@ -1099,6 +1100,9 @@ def standard_api(
         @standard_api()                                  # Equivalent
         @standard_api(operation_type=OperationType.REPORTING)
         @standard_api(self_service_only=True)           # User can only see own data
+        @standard_api(self_service_only=True, self_service_implicit_allowed=True)
+                                                         # Portal endpoint that derives
+                                                         # member from session.user
         @standard_api(max_request_size=10*1024*1024)    # Custom payload limit
 
     Example:
@@ -1110,6 +1114,11 @@ def standard_api(
     Args:
         operation_type: Classification for rate limiting (default: REPORTING)
         self_service_only: If True, users can only access their own data
+        self_service_implicit_allowed: When `self_service_only=True`, allows
+            the endpoint to operate on session user's member without an
+            explicit `member` kwarg (defaults to False). Required for portal
+            endpoints like `submit_expense` that derive the member from
+            `frappe.session.user` rather than accepting a `member` argument.
         max_request_size: Override default 2MB limit
     """
     # Handle both @standard_api and @standard_api() usage patterns
@@ -1120,6 +1129,7 @@ def standard_api(
             operation_type=operation_type,
             audit_level="standard",
             self_service_only=self_service_only,
+            self_service_implicit_allowed=self_service_implicit_allowed,
             max_request_size=max_request_size,
         )
     elif callable(func_or_operation_type):
@@ -1129,6 +1139,7 @@ def standard_api(
             operation_type=operation_type,
             audit_level="standard",
             self_service_only=self_service_only,
+            self_service_implicit_allowed=self_service_implicit_allowed,
             max_request_size=max_request_size,
         )(func_or_operation_type)
     else:
@@ -1138,6 +1149,7 @@ def standard_api(
             operation_type=func_or_operation_type,
             audit_level="standard",
             self_service_only=self_service_only,
+            self_service_implicit_allowed=self_service_implicit_allowed,
             max_request_size=max_request_size,
         )
 


### PR DESCRIPTION
Replaces closed PR #77 (stack rebased onto develop after merge of #74).

Three commits, in order:

## 1. \`test: fix broken patch(\"frappe.session.user\", ...) idiom\`

\`with patch(\"frappe.session.user\", email):\` was used at 11 sites in \`test_chapter_membership_validation_edge_cases.py\` but always failed with \`TypeError: 'NoneType' object is not subscriptable\`. \`mock.patch\` can't resolve \`frappe.session.user\` (LocalProxy). Adds \`_as_session_user\` context manager using direct attribute assignment.

## 2. \`fix(performance): get_user_volunteer_record_optimized SELECTed a Table field\`

Real production bug. \`get_user_volunteer_record_optimized\` in \`performance_utils.py\` SELECT'ed \`v.skills_and_qualifications\` — a Table (child-table) field on Volunteer. Child-table fields have no parent-table column, so MySQL raised \`OperationalError\`. The bare \`except\` swallowed it, returning None for every user. Dormant in production because the only non-test caller has fallback paths, but the function was broken since whenever \`skills_and_qualifications\` was switched to Table type. Also adds \`_ensure_user\` test fixture helper.

## 3. \`fix(security): expose self_service_implicit_allowed on @standard_api\`

The user pointed out that expense submissions should work for volunteers. Investigation revealed: \`submit_expense\` derives the acting member from \`frappe.session.user\` but the security framework's self-service validator defaults to \`implicit_allowed=False\` — requiring an explicit \`member=\` kwarg the portal endpoint never accepts. Every authenticated volunteer got \"This self-service operation requires an explicit member parameter.\"

Fix: expose \`self_service_implicit_allowed\` parameter on \`@standard_api\` (the lower-level \`@api_security_framework\` already supported it), and set it on \`submit_expense\`. Also assigns \`Verenigingen Volunteer\` role profile to test Users (per \`authorization_policy.py:94-97\` which grants MEDIUM access for self-service ops).

## Test impact

\`test_chapter_membership_validation_edge_cases.py\`:

| | develop (before #74) | After #74 merge | After this PR |
|---|---|---|---|
| Pass | 0 (setUpClass error) | 1 | **5** |
| FAIL | 0 | 3 | 4 |
| ERROR | 1 | 5 | **0** |

4 remaining failures are real product-scope issues:
- 2 fail with \"Unable to create employee record\" — submit_expense needs Employee Self Service setup (test fixture issue, separate scope)
- 2 expect to find volunteers without Member links by email — Member-first JOIN architecture excludes that case (stale test assumption)

## Known follow-up (separate PR)

\`authorization_engine.get_user_role_profiles()\` reads from \`tabUser.role_profile_name\` (scalar, always None in Frappe v15). Actual role profile assignments live in \`tabUser Role Profile\` child table. The strict Rule 4 path is silently broken; tests pass via Rule 5 (individual role matches profile name) fallback.

## Hook skips

Standard set: \`jest-testing\`, \`javascript-doctype-validator\`, \`test-quality-enforcer\`, \`import-path-validator\`, \`whitelist-type-safety\`.