### PR TITLE
fix(settings): backfill creation_user on Verenigingen Settings

### DIFF
--- a/verenigingen/patches.txt
+++ b/verenigingen/patches.txt
@@ -49,3 +49,4 @@ verenigingen.patches.v2_1.rename_email_configuration_doctype
 verenigingen.patches.v2_2.remove_all_chapter_user_permissions
 verenigingen.patches.v2_2.clean_overloaded_upload_date
 verenigingen.patches.v2_2.backfill_belastingdienst_reportable
+verenigingen.patches.v2_2.backfill_verenigingen_settings_creation_user

--- a/verenigingen/patches/v2_2/backfill_verenigingen_settings_creation_user.py
+++ b/verenigingen/patches/v2_2/backfill_verenigingen_settings_creation_user.py
@@ -1,0 +1,36 @@
+"""Backfill creation_user on Verenigingen Settings when missing.
+
+The `creation_user` field on `Verenigingen Settings` is `reqd=1` in the
+schema. Sites whose Settings doc was inserted before that requirement
+existed have a NULL value. Subsequent `.save()` on the Settings doc
+(e.g. via `_seed_default_document_categories`) then fails with a
+MandatoryError, cascading into hundreds of test failures and any
+production code that ever resaves the Settings.
+
+Symptom in CI shard 4 (run 26363365112): 957 "Failed to create
+Verenigingen Settings: ...creation_user" log lines.
+
+Defaults to Administrator (the standard system user that would have
+inserted the Settings doc had `creation_user` been required at the time).
+"""
+
+import frappe
+
+
+def execute():
+    if not frappe.db.exists("Verenigingen Settings", "Verenigingen Settings"):
+        return
+
+    current = frappe.db.get_value("Verenigingen Settings", "Verenigingen Settings", "creation_user")
+    if current:
+        return
+
+    frappe.db.set_value(
+        "Verenigingen Settings",
+        "Verenigingen Settings",
+        "creation_user",
+        "Administrator",
+        update_modified=False,
+    )
+    frappe.db.commit()
+    print("✅ Backfilled creation_user on Verenigingen Settings")


### PR DESCRIPTION
## Summary

Adds a one-time migration patch to backfill `creation_user` on `Verenigingen Settings` for sites whose Settings document was inserted before the field became required (`reqd=1`).

## Why

`creation_user` is `reqd=1` in `verenigingen_settings.json` (line 262). Sites with a pre-existing Settings doc have `NULL` in the column, so any later \`.save()\` — including `_seed_default_document_categories` and any setup hook that resaves the Settings — fails with `MandatoryError: [Verenigingen Settings]: creation_user`.

## Impact

In CI run 26363365112 (PR #79, shard 4): **957 "Failed to create Verenigingen Settings: ...creation_user" log lines**, cascading into ~250 test failures across `tests/member/*` and `tests/workflows/*`.

This is one of the two top-leverage Tier 1 fixes from the post-PR-#79 test inventory.

## Implementation

- New patch `v2_2/backfill_verenigingen_settings_creation_user.py`
- Idempotent: no-op when `creation_user` is already populated
- Defaults to `Administrator` (the standard system user that would have inserted the Settings doc had `creation_user` been required at the time)
- Registered in `patches.txt`

## Test plan

- [x] Patch logic is idempotent (re-runnable safely)
- [ ] CI: subsequent test runs see Settings save succeed (verify failure count drop in shard 4)

## Out of scope

- F2 — System Settings `language` / `time_zone` validation regression (separate PR; ~17 distinct failures + many cascades)
- Tier 3-5 fixes from the PR #79 inventory (separate PRs)