### PR TITLE
fix(setup): skip password policy save when System Settings is incomplete

### DIFF
--- a/verenigingen/setup/security_setup.py
+++ b/verenigingen/setup/security_setup.py
@@ -205,6 +205,22 @@ def setup_security_headers():
     return security_recommendations
 
 
+def _system_settings_save_ready(system_settings):
+    """Return (ready, missing_fields) for Frappe's System Settings Single.
+
+    Frappe's System Settings has `language` and `time_zone` as `reqd=1`. On
+    fresh sites those fields may be NULL before the operator has completed
+    Frappe's Setup Wizard. Any `.save()` in that state cascades a
+    MandatoryError into every downstream consumer.
+
+    Centralised here so any verenigingen call site that wants to save
+    System Settings can short-circuit cleanly. See setup_password_policy
+    and the verenigingen_configure_security onboarding step.
+    """
+    missing = [f for f in ("language", "time_zone") if not getattr(system_settings, f, None)]
+    return (not missing, missing)
+
+
 def setup_password_policy():
     """
     Configure password policy settings for the verenigingen app.
@@ -216,25 +232,35 @@ def setup_password_policy():
     test setUp that triggers an after_migrate hook — symptom in CI:
     17+ direct test failures + many cascades (PR #79 shard 4 inventory).
 
+    The skip is recoverable: `bench migrate` re-fires `after_migrate`
+    hooks, so once the operator configures System Settings the next
+    migrate applies the policy. Operators who complete Setup Wizard via
+    the UI without re-running migrate will sit on Frappe's weaker
+    defaults; the WARNING message tells them what to do.
+
     Modifying Frappe's System Settings to populate language/time_zone
-    is out of scope for this app; the operator should configure them
-    via the Setup Wizard or Desk → System Settings.
+    is out of scope for this app; PR #81 demonstrated that defaulting
+    framework-required fields silently undoes intentional security
+    hardening (re-enabled Administrator fallback).
     """
     try:
         # Get or create System Settings
         system_settings = frappe.get_single("System Settings")
 
-        # Skip if System Settings is in a state where save would fail validation.
-        # Both fields are reqd=1 in Frappe's System Settings schema.
-        missing_required = [f for f in ("language", "time_zone") if not getattr(system_settings, f, None)]
-        if missing_required:
+        ready, missing = _system_settings_save_ready(system_settings)
+        if not ready:
             msg = (
                 f"Skipping password policy setup — System Settings missing required field(s): "
-                f"{', '.join(missing_required)}. Configure these via Frappe Setup Wizard or "
+                f"{', '.join(missing)}. Configure these via Frappe Setup Wizard or "
                 f"Desk → System Settings, then re-run `bench migrate` to apply password policy."
             )
             print(f"   ⚠️  {msg}")
             frappe.logger().warning(msg)
+            # Surface to Error Log too so silent skips are visible in audit / CI logs.
+            try:
+                frappe.log_error(message=msg, title="Password Policy Setup Skipped")
+            except Exception:
+                pass
             return False
 
         # Set recommended password policy (enhanced based on security review)

--- a/verenigingen/setup/security_setup.py
+++ b/verenigingen/setup/security_setup.py
@@ -208,10 +208,34 @@ def setup_security_headers():
 def setup_password_policy():
     """
     Configure password policy settings for the verenigingen app.
+
+    Skips silently if System Settings is missing required fields
+    (language / time_zone). On fresh sites those fields may be NULL
+    before the operator has completed Frappe's initial setup wizard.
+    Saving in that state would cascade a MandatoryError into every
+    test setUp that triggers an after_migrate hook — symptom in CI:
+    17+ direct test failures + many cascades (PR #79 shard 4 inventory).
+
+    Modifying Frappe's System Settings to populate language/time_zone
+    is out of scope for this app; the operator should configure them
+    via the Setup Wizard or Desk → System Settings.
     """
     try:
         # Get or create System Settings
         system_settings = frappe.get_single("System Settings")
+
+        # Skip if System Settings is in a state where save would fail validation.
+        # Both fields are reqd=1 in Frappe's System Settings schema.
+        missing_required = [f for f in ("language", "time_zone") if not getattr(system_settings, f, None)]
+        if missing_required:
+            msg = (
+                f"Skipping password policy setup — System Settings missing required field(s): "
+                f"{', '.join(missing_required)}. Configure these via Frappe Setup Wizard or "
+                f"Desk → System Settings, then re-run `bench migrate` to apply password policy."
+            )
+            print(f"   ⚠️  {msg}")
+            frappe.logger().warning(msg)
+            return False
 
         # Set recommended password policy (enhanced based on security review)
         password_policy = {

--- a/verenigingen/setup/security_setup.py
+++ b/verenigingen/setup/security_setup.py
@@ -255,12 +255,14 @@ def setup_password_policy():
                 f"Desk → System Settings, then re-run `bench migrate` to apply password policy."
             )
             print(f"   ⚠️  {msg}")
-            frappe.logger().warning(msg)
+            security_logger.warning(msg)
             # Surface to Error Log too so silent skips are visible in audit / CI logs.
             try:
                 frappe.log_error(message=msg, title="Password Policy Setup Skipped")
-            except Exception:
-                pass
+            except Exception as log_exc:
+                # log_error itself can fail during early after_migrate if the
+                # Error Log schema isn't migrated yet. Don't lose the signal.
+                security_logger.warning(f"Password Policy Setup Skipped (Error Log unavailable: {log_exc})")
             return False
 
         # Set recommended password policy (enhanced based on security review)

--- a/verenigingen/tests/security/test_security_setup.py
+++ b/verenigingen/tests/security/test_security_setup.py
@@ -287,36 +287,89 @@ class TestSecurityConfiguration(VereningingenTestCase):
     def test_setup_password_policy_new(self, mock_get_single):
         """Test password policy setup with new settings"""
         mock_system_settings = MagicMock()
+        # Required by _system_settings_save_ready guard (added 2026-05-24 PR #82)
+        mock_system_settings.language = "en"
+        mock_system_settings.time_zone = "UTC"
         mock_system_settings.minimum_password_score = 0
         mock_system_settings.enable_password_policy = 0
         mock_system_settings.force_user_to_reset_password = 0
         mock_get_single.return_value = mock_system_settings
-        
+
         result = setup_password_policy()
-        
+
         self.assertTrue(result)
         mock_system_settings.save.assert_called_once()
-        
+
         # Verify values were set correctly
         self.assertEqual(mock_system_settings.minimum_password_score, 3)
         self.assertEqual(mock_system_settings.enable_password_policy, 1)
         self.assertEqual(mock_system_settings.force_user_to_reset_password, 90)
-    
+
     # Mock justified: Infrastructure - external dependency, not the boundary under test
     @patch('frappe.get_single')
     def test_setup_password_policy_existing(self, mock_get_single):
         """Test password policy setup with existing correct settings"""
         mock_system_settings = MagicMock()
+        # Required by _system_settings_save_ready guard
+        mock_system_settings.language = "en"
+        mock_system_settings.time_zone = "UTC"
         mock_system_settings.minimum_password_score = 3
         mock_system_settings.enable_password_policy = 1
         mock_system_settings.force_user_to_reset_password = 90
         mock_get_single.return_value = mock_system_settings
-        
+
         result = setup_password_policy()
-        
+
         self.assertTrue(result)
         # Should not save if no changes needed
         mock_system_settings.save.assert_not_called()
+
+    # Mock justified: Infrastructure - external dependency, not the boundary under test
+    @patch('frappe.get_single')
+    def test_setup_password_policy_skips_when_language_missing(self, mock_get_single):
+        """Skip path: System Settings without language must not attempt save."""
+        mock_system_settings = MagicMock()
+        mock_system_settings.language = None
+        mock_system_settings.time_zone = "UTC"
+        mock_get_single.return_value = mock_system_settings
+
+        result = setup_password_policy()
+
+        self.assertFalse(result)
+        mock_system_settings.save.assert_not_called()
+
+    # Mock justified: Infrastructure - external dependency, not the boundary under test
+    @patch('frappe.get_single')
+    def test_setup_password_policy_skips_when_time_zone_empty_string(self, mock_get_single):
+        """Skip path: empty-string time_zone also tripped reqd=1 in production."""
+        mock_system_settings = MagicMock()
+        mock_system_settings.language = "en"
+        mock_system_settings.time_zone = ""
+        mock_get_single.return_value = mock_system_settings
+
+        result = setup_password_policy()
+
+        self.assertFalse(result)
+        mock_system_settings.save.assert_not_called()
+
+    def test_system_settings_save_ready_helper(self):
+        """Unit test for the extracted readiness helper."""
+        from verenigingen.setup.security_setup import _system_settings_save_ready
+
+        complete = MagicMock(language="en", time_zone="UTC")
+        ready, missing = _system_settings_save_ready(complete)
+        self.assertTrue(ready)
+        self.assertEqual(missing, [])
+
+        no_lang = MagicMock(language="", time_zone="UTC")
+        ready, missing = _system_settings_save_ready(no_lang)
+        self.assertFalse(ready)
+        self.assertEqual(missing, ["language"])
+
+        neither = MagicMock(language=None, time_zone=None)
+        ready, missing = _system_settings_save_ready(neither)
+        self.assertFalse(ready)
+        self.assertEqual(missing, ["language", "time_zone"])
 
 
 class TestSecurityStatus(VereningingenTestCase):


### PR DESCRIPTION
## Summary

`setup_password_policy()` (in `after_install` + `after_migrate` per `hooks/lifecycle.py:14,30`) calls `system_settings.save()` to apply hardened password policy defaults. On fresh sites where Frappe's System Settings has NULL `language` / `time_zone` (both `reqd=1`), the save trips `MandatoryError` before the password policy fields are written.

CI shard 4 of PR #79 (run 26363365112) showed **17+ direct test failures and many cascades** with the signature `Operation: save / Document: System Settings / Error: [System Settings, System Settings]: language, time_zone`.

## Why this approach

Three alternatives were considered and rejected:

1. **Backfill `language` / `time_zone` via patch** — touches Frappe core data. Defaulting `language="en"` and `time_zone="UTC"` could surprise sites that intentionally have those fields empty.
2. **Auto-populate before save** — same problem; we'd be making policy decisions about a Frappe core doctype.
3. **Let it fail loudly** — current behaviour; the cascade is what we're trying to stop.

This PR: **skip gracefully** when System Settings isn't ready. Log a clear WARNING telling the operator how to fix it (Setup Wizard or Desk → System Settings, then re-run migrate).

## Why not the same Administrator-default mistake as PR #81

PR #81 (closed) tried to backfill `creation_user` to `"Administrator"` and unknowingly re-enabled an Administrator fallback that `secure_operations.py` had explicitly hardened away. This PR avoids that class of error by **not modifying any data** — it only changes the policy of when to *attempt* the save.

No security regression: skipping the policy save just means the hardened defaults aren't applied. The operator gets actionable instruction to configure System Settings and re-run migrate.

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI shard 4: the System Settings: language/time_zone cascade should go away
- [ ] Verify on veg11.veganisme.org that the existing system_settings (which has language=en, time_zone=Europe/Amsterdam) is unaffected — both fields populated, so the guard short-circuits and the policy save proceeds normally

## Source

Tier 1 fix from the PR #79 CI inventory (failure-shape: workflow tests in shard 4 cascading from a single Settings save). Companion to PR #79 (framework drain) and PR #80 (Tier 2 runner aborts).