### PR TITLE
fix(tier-3): correct Donation field references — mode_of_payment / donation_date

### DIFF
--- a/verenigingen/utils/donation_history_manager.py
+++ b/verenigingen/utils/donation_history_manager.py
@@ -96,7 +96,11 @@ class DonationHistoryManager(BaseHistoryManager):
                 "name",
                 "donation_date",
                 "amount",
-                "payment_method",
+                # Donation schema has `mode_of_payment`, not `payment_method`.
+                # `payment_method` is the donor_history CHILD TABLE field name
+                # (see line 121 below — we map mode_of_payment → payment_method
+                # when appending to the child table).
+                "mode_of_payment",
                 "status",
                 "fund_designation",
                 "donation_purpose",

--- a/verenigingen/web_form/donation_form/donation_form.py
+++ b/verenigingen/web_form/donation_form/donation_form.py
@@ -155,9 +155,11 @@ def create_donation(donor, data):
 
     donation = frappe.new_doc("Donation")
     donation.donor = donor
-    donation.date = data.get("date") or frappe.utils.today()
+    # Donation schema uses donation_date + mode_of_payment, not date + payment_method.
+    # Accept either input key for backward compat with form payloads.
+    donation.donation_date = data.get("donation_date") or data.get("date") or frappe.utils.today()
     donation.amount = float(data.get("amount"))
-    donation.payment_method = data.get("payment_method")
+    donation.mode_of_payment = data.get("mode_of_payment") or data.get("payment_method")
     donation.status = data.get("donation_status", "One-time")
     donation.donation_purpose_type = data.get("donation_purpose_type", "General")
 

--- a/verenigingen/web_form/donation_form/donation_form.py
+++ b/verenigingen/web_form/donation_form/donation_form.py
@@ -207,8 +207,10 @@ def create_donation(donor, data):
 
     donation = result.document
 
-    # Submit if payment method is not requiring further action
-    if data.get("payment_method") not in ["SEPA Direct Debit", "Mollie"]:
+    # Submit if payment method is not requiring further action.
+    # Read from the doc (canonical) rather than the input payload — handles
+    # both old (payment_method) and new (mode_of_payment) input keys.
+    if donation.mode_of_payment not in ["SEPA Direct Debit", "Mollie"]:
         donation.submit()
 
     return donation
@@ -225,7 +227,7 @@ def create_periodic_agreement_from_donation(donor, data):
         donor=donor,
         annual_amount=float(data.get("amount")) * 12,  # Assuming monthly
         payment_frequency=data.get("recurring_frequency", "Monthly"),
-        payment_method=data.get("payment_method"),
+        payment_method=data.get("mode_of_payment") or data.get("payment_method"),
         agreement_type="Private Written",
     )
 
@@ -263,7 +265,7 @@ def get_confirmation_email_content(donation, donor):
     <p><strong>Donation Details:</strong></p>
     <ul>
         <li>Reference: {donation.name}</li>
-        <li>Date: {frappe.utils.formatdate(donation.date)}</li>
+        <li>Date: {frappe.utils.formatdate(donation.donation_date)}</li>
         <li>Amount: €{donation.amount:.2f}</li>
         <li>Payment Method: {donation.mode_of_payment}</li>
     </ul>


### PR DESCRIPTION
## Summary

`Donation` doctype's schema has `mode_of_payment` and `donation_date`, not `payment_method` and `date`. Two production sites used the stale names — fixed.

## Changes

### 1. `utils/donation_history_manager.py:99`

`frappe.get_all('Donation', fields=[..., 'payment_method', ...])` raised `(1054, 'Unknown column payment_method in SELECT')` in CI shard 1 (9 occurrences traced to the HIST_001 "Partial update completed with errors" path in `member_history_update_service.py:218`).

The donor_history CHILD TABLE does have a `payment_method` field — hence the confusion. But the SOURCE query against `tabDonation` needs the actual schema name. Line 121 already maps `donation.mode_of_payment → donor_history.payment_method` when appending to the child table; the fix completes that contract.

### 2. `web_form/donation_form/donation_form.py:158, 160`

Direct assignments to `donation.date` and `donation.payment_method` on a freshly-created `Donation` doc. Frappe silently drops unknown attributes at save time, so donations were being inserted without a date or payment method — silent data corruption from public guest donations.

Now writes to `donation_date` + `mode_of_payment`, accepting either input key for backward compat with existing form payloads.

## Out of scope (separate PRs)

- Donation form HTML/JS that posts the payload — kept the `data.get("payment_method")` fallback for compat; future cleanup can drop the alias once all callers are migrated.
- `services/mollie_debug_service.py:155` queries Member for `payment_method` — that's correct (Member DOES have payment_method field).

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI shard 1: `Unknown column 'payment_method' in 'SELECT'` count from HIST_001 path should drop to 0
- [ ] Verify donation submission via web form now persists date + mode_of_payment

## Source

Tier 3 mechanical fix from the PR #79 inventory (F9d).