### PR TITLE
fix(group-d): Mode of Payment fixtures + Mollie in-test bypass for fresh CI sites

### DIFF
--- a/verenigingen/services/member/approval/application_helpers.py
+++ b/verenigingen/services/member/approval/application_helpers.py
@@ -100,6 +100,9 @@ def ensure_payment_modes_exist():
         {"mode_of_payment": "Bank Transfer", "type": "Bank"},
         {"mode_of_payment": "SEPA Direct Debit", "type": "Bank"},
         {"mode_of_payment": "Mollie", "type": "General"},
+        # 'Manual' is used by integration test fixtures as a non-bank/cash
+        # symbolic mode; keep as 'General' to avoid bank-account validation.
+        {"mode_of_payment": "Manual", "type": "General"},
         {"mode_of_payment": "Cash", "type": "Cash"},
     ]
 

--- a/verenigingen/tests/setup/__init__.py
+++ b/verenigingen/tests/setup/__init__.py
@@ -93,3 +93,18 @@ def before_tests():
             frappe.db.commit()
     except Exception as e:
         frappe.logger().warning(f"Customer test record creation failed: {e}")
+
+    # Seed the Mode of Payment records the app and many tests depend on
+    # (Bank Transfer, SEPA Direct Debit, Mollie, Manual, Cash). The same helper
+    # is wired into after_migrate for production sites; CI sites are bench-new
+    # without migrate, so the records are missing at test-time and
+    # Member.payment_method / Donation.mode_of_payment link validation fails
+    # with "Could not find Payment Method: <name>" across ~119 tests.
+    try:
+        from verenigingen.services.member.approval.application_helpers import (
+            ensure_payment_modes_exist,
+        )
+
+        ensure_payment_modes_exist()
+    except Exception as e:
+        frappe.logger().warning(f"Payment mode seeding failed: {e}")

--- a/verenigingen/verenigingen_payments/clients/balances_client.py
+++ b/verenigingen/verenigingen_payments/clients/balances_client.py
@@ -50,13 +50,13 @@ class BalancesClient(MollieBaseClient):
         Raises:
             frappe.ValidationError: If backend API is not configured properly
         """
-        # In CI / `bench run-tests`, Mollie Settings is unconfigured by default and
-        # MollieBaseClient.__init__ already substitutes a dummy api_key when
-        # frappe.flags.in_test is set. The matching short-circuit here keeps this
-        # secondary validation gate from re-raising on test sites that never meant
-        # to authenticate against Mollie. Tests that target the real validation
-        # path are expected to clear this flag or patch the method directly.
-        if frappe.flags.in_test:
+        # Only short-circuit when MollieBaseClient.__init__ actually substituted
+        # the in-test dummy api_key (no real key was provided). A test that
+        # constructs the client with an explicit api_key still flows through the
+        # full validation path, even under frappe.flags.in_test. This keeps the
+        # bypass scoped to the exact failure mode the test runner produces on
+        # unconfigured CI sites.
+        if getattr(self, "_test_bypass_active", False):
             return
         try:
             # This will raise appropriate errors if backend API is not configured

--- a/verenigingen/verenigingen_payments/clients/balances_client.py
+++ b/verenigingen/verenigingen_payments/clients/balances_client.py
@@ -50,6 +50,14 @@ class BalancesClient(MollieBaseClient):
         Raises:
             frappe.ValidationError: If backend API is not configured properly
         """
+        # In CI / `bench run-tests`, Mollie Settings is unconfigured by default and
+        # MollieBaseClient.__init__ already substitutes a dummy api_key when
+        # frappe.flags.in_test is set. The matching short-circuit here keeps this
+        # secondary validation gate from re-raising on test sites that never meant
+        # to authenticate against Mollie. Tests that target the real validation
+        # path are expected to clear this flag or patch the method directly.
+        if frappe.flags.in_test:
+            return
         try:
             # This will raise appropriate errors if backend API is not configured
             self._get_backend_api_key()

--- a/verenigingen/verenigingen_payments/core/mollie_base_client.py
+++ b/verenigingen/verenigingen_payments/core/mollie_base_client.py
@@ -114,7 +114,20 @@ class MollieBaseClient:
 
         # Get API key from settings if not provided
         if not api_key:
-            if use_backend_api:
+            if frappe.flags.in_test:
+                # In CI / `bench run-tests`, Mollie Settings has empty test/live keys
+                # and `enable_backend_api=0` by default. Construction of MollieBaseClient
+                # would otherwise throw "Mollie Backend API is not enabled" or
+                # "Mollie Live API Key not configured" for every test that instantiates
+                # a client (~87 tests). Tests that exercise real Mollie behaviour are
+                # expected to mock `ResilientHTTPClient` / response payloads anyway;
+                # tests that don't need Mollie at all just need __init__ not to throw.
+                # We deliberately do NOT short-circuit `_get_backend_api_key` /
+                # `_get_api_key_from_settings` themselves — tests that target those
+                # methods (e.g. test_mollie_configuration_service.py) must still see
+                # the production error path.
+                api_key = "test_dummy_key_for_tests"
+            elif use_backend_api:
                 api_key = self._get_backend_api_key()
             else:
                 api_key = self._get_api_key_from_settings(test_mode)

--- a/verenigingen/verenigingen_payments/core/mollie_base_client.py
+++ b/verenigingen/verenigingen_payments/core/mollie_base_client.py
@@ -112,7 +112,12 @@ class MollieBaseClient:
         self.strict_financial_validation = strict_financial_validation
         self.enable_cache = enable_cache
 
-        # Get API key from settings if not provided
+        # Get API key from settings if not provided.
+        # Track whether the in-test bypass actually fired. Subclasses (e.g.
+        # BalancesClient) gate their own secondary validation on this flag so a
+        # test that constructs a client with a REAL api_key while
+        # `frappe.flags.in_test` is set still gets full validation.
+        self._test_bypass_active = False
         if not api_key:
             if frappe.flags.in_test:
                 # In CI / `bench run-tests`, Mollie Settings has empty test/live keys
@@ -127,6 +132,7 @@ class MollieBaseClient:
                 # methods (e.g. test_mollie_configuration_service.py) must still see
                 # the production error path.
                 api_key = "test_dummy_key_for_tests"
+                self._test_bypass_active = True
             elif use_backend_api:
                 api_key = self._get_backend_api_key()
             else:


### PR DESCRIPTION
## Summary

Group D of the CI failure inventory from develop run [26387986198](https://github.com/nlvegan/verenigingen/actions/runs/26387986198) — ~180 failures across ~12 files traced to two related root causes on fresh CI sites.

## Root causes

**Mode of Payment records missing on fresh CI sites (~119 tests)**

The app registers \`ensure_payment_modes_exist()\` as an \`after_migrate\` hook (\`hooks/lifecycle.py:23\`), but CI sites are created via \`bench new-site\` without running migrate, so the records never get seeded. Frappe's link validation then formats every \`payment_method=\"Bank Transfer\"\` / \`mode_of_payment=\"Manual\"\` / etc. as the same error string: \`Could not find Payment Method: <name>\`.

Examples:
- \`verenigingen.tests.services.test_payment_entry_creation_service.TestPaymentEntryCreationService.test_decimal_to_float_conversion\`
- \`verenigingen.tests.donor.test_donor_customer_integration\`
- \`verenigingen.tests.integration.services.test_invoice_generator\`

**Mollie API key check on fresh CI sites (~87 tests)**

\`MollieBaseClient.__init__\` calls \`_get_backend_api_key()\` (or \`_get_api_key_from_settings()\`) when no \`api_key\` is provided. Both throw \`frappe.ValidationError\` on fresh CI sites where Mollie Settings has empty \`test_secret_key\` / \`live_secret_key\` and \`enable_backend_api=0\` by default. Every test that instantiates a Mollie client erorrs at init time. \`BalancesClient\` then re-invokes \`_get_backend_api_key()\` from \`_validate_backend_api_access()\`, so the bypass needs to hold end-to-end.

Examples:
- \`verenigingen.tests.payment.test_balances_client.TestBalancesClientCacheBehavior.test_*\`
- \`verenigingen.tests.unit.test_mollie_bulk_transaction_core_functionality\`

## Fix

1. **\`tests/setup/__init__.py\`**: call \`ensure_payment_modes_exist()\` after ERPNext fixture setup in \`before_tests\`. Same helper that \`after_migrate\` runs in production.
2. **\`application_helpers.py\`**: add \`{\"mode_of_payment\": \"Manual\", \"type\": \"General\"}\` to the seeded list. Test fixtures use \"Manual\" symbolically; \`General\` avoids bank-account validation.
3. **\`mollie_base_client.py\`**: short-circuit the API-key lookup in \`__init__\` when \`frappe.flags.in_test\` is set, substituting a dummy string. Comment explains why we don't bypass the key-lookup methods themselves (the configuration-service test asserts the real boolean contract).
4. **\`balances_client.py\`**: matching \`frappe.flags.in_test\` short-circuit in \`_validate_backend_api_access\` since it re-invokes \`_get_backend_api_key()\` after base \`__init__\` returns.

## Test plan

- [x] \`tests/payment/test_balances_client\`: **12/12 OK** (was 4 errors on fresh setup)
- [x] 5 settlement_client mock-assertion failures unchanged vs develop baseline (pre-existing test-content drift, separate cleanup target)
- [x] \`application_helpers.ensure_payment_modes_exist()\` creates 'Manual' on this local site that was missing it
- [x] Pre-commit hooks all pass (SKIP per [[feedback_pre_existing_hook_failures]])
- [ ] CI: ~180 fewer failures across 4 shards

## Notes for reviewers

Senior + skeptical reviewers requested per [[feedback_always_request_pr_review]] / [[feedback_double_review_pattern]]. Please look at:

1. **Defense layering**: the in-test bypass at \`MollieBaseClient.__init__\` is intentionally NOT mirrored on \`_get_backend_api_key\` / \`_get_api_key_from_settings\` / \`MollieConfigurationService.is_backend_api_enabled\`. Is that the right boundary? \`test_mollie_configuration_service.py:91\` asserts the boolean contract on \`is_backend_api_enabled\` and a sweeping bypass would silently flip it to True.
2. **Coverage drop risk**: does any production code path call \`MollieBaseClient.__init__\` while \`frappe.flags.in_test\` is set (e.g., a scheduled job test, a webhook integration test)? If yes, the dummy key would mask a real misconfiguration.
3. **Manual mode type**: I used \`type=\"General\"\` for Mode of Payment \"Manual\" to avoid bank-account validation downstream. Worth confirming that's the right type for the symbolic test usage.