### PR TITLE
fix(group-b): seed Verenigingen Settings.creation_user + leaf Customer Group in before_tests

### DIFF
--- a/verenigingen/tests/backend/workflows/test_payment_failure_recovery.py
+++ b/verenigingen/tests/backend/workflows/test_payment_failure_recovery.py
@@ -11,6 +11,7 @@ Tests payment failure scenarios and recovery processes
 import frappe
 from frappe.utils import add_days, add_months, today
 
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.tests.utils.base import VereningingenWorkflowTestCase
 from verenigingen.tests.utils.factories import TestDataBuilder, TestStateManager, TestUserFactory
 
@@ -146,7 +147,7 @@ class TestPaymentFailureRecovery(VereningingenWorkflowTestCase):
                 "doctype": "Customer",
                 "customer_name": f"PaymentTest Member-{unique_id}",
                 "customer_type": "Individual",
-                "customer_group": "All Customer Groups",
+                "customer_group": resolve_non_group_customer_group(),
                 "territory": "Netherlands"}
         )
         customer.insert(ignore_permissions=True)

--- a/verenigingen/tests/donor/test_donor_customer_integration.py
+++ b/verenigingen/tests/donor/test_donor_customer_integration.py
@@ -6,6 +6,7 @@ Donor and Customer records, following CLAUDE.md testing requirements.
 """
 
 import frappe
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
 
 
@@ -189,7 +190,7 @@ class TestDonorCustomerIntegration(EnhancedTestCase):
         customer.customer_name = "Existing Customer"
         customer.customer_type = "Individual"
         customer.email_id = "existing@example.com"
-        customer.customer_group = "All Customer Groups"
+        customer.customer_group = resolve_non_group_customer_group()
         customer.territory = "All Territories"
         customer.save()
         self.track_doc("Customer", customer.name)

--- a/verenigingen/tests/donor/test_donor_customer_sync_utils.py
+++ b/verenigingen/tests/donor/test_donor_customer_sync_utils.py
@@ -7,6 +7,7 @@ following CLAUDE.md testing requirements.
 
 import frappe
 from unittest.mock import patch
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
 from verenigingen.utils.donor_customer_sync import (
     sync_donor_to_customer,
@@ -131,7 +132,7 @@ class TestDonorCustomerSyncUtils(EnhancedTestCase):
         customer = frappe.new_doc("Customer")
         customer.customer_name = "No Donor Reference"
         customer.customer_type = "Individual"
-        customer.customer_group = "All Customer Groups"
+        customer.customer_group = resolve_non_group_customer_group()
         customer.territory = "All Territories"
         customer.save()
         self.track_doc("Customer", customer.name)

--- a/verenigingen/tests/security/test_link_sanitizer.py
+++ b/verenigingen/tests/security/test_link_sanitizer.py
@@ -10,6 +10,7 @@ Tests both unit-level behavior and integration with real Frappe documents.
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from verenigingen.services.customer_group_resolver import resolve_non_group_customer_group
 from verenigingen.utils.link_sanitizer import (
     BrokenLinkError,
     get_broken_links_summary,
@@ -31,7 +32,7 @@ class TestLinkSanitizerUnit(FrappeTestCase):
                 {
                     "doctype": "Customer",
                     "customer_name": self.test_customer_name,
-                    "customer_group": "All Customer Groups",
+                    "customer_group": resolve_non_group_customer_group(),
                     "territory": "All Territories",
                 }
             )
@@ -164,7 +165,7 @@ class TestLinkSanitizerIntegration(FrappeTestCase):
             {
                 "doctype": "Customer",
                 "customer_name": self.customer_name,
-                "customer_group": "All Customer Groups",
+                "customer_group": resolve_non_group_customer_group(),
                 "territory": "All Territories",
                 "custom_member": self.member_name,
             }

--- a/verenigingen/tests/services/test_customer_handling_service_integration.py
+++ b/verenigingen/tests/services/test_customer_handling_service_integration.py
@@ -313,54 +313,65 @@ class TestCustomerHandlingServiceIntegration(EnhancedTestCase):
             frappe.db.set_single_value("Selling Settings", "customer_group", original)
 
     def test_customer_group_fallback_resolves_to_leaf_not_group_node(self):
-        """The Selling Settings.customer_group default may legitimately point
-        to a group node (e.g. ERPNext's `set_defaults_for_tests` sets it to
-        the root 'All Customer Groups', and that exact value is live on this
-        site). ERPNext's validate_customer_group rejects group-node values
-        with 'Cannot select a Group type Customer Group', so create_customer_
-        for_member must resolve to a leaf (is_group=0) instead of passing the
-        group node through verbatim."""
-        # Verify the precondition this test exists to guard against: the
-        # Selling Settings default IS a group node here. (It is on every site
-        # that ran ERPNext's test-setup hook.) Skip the test if the local
-        # configuration is already a leaf, so the test exercises only the
-        # path it is meant to.
-        configured = frappe.db.get_single_value("Selling Settings", "customer_group")
-        if configured and not frappe.db.get_value(
-            "Customer Group", configured, "is_group"
-        ):
+        """The resolver must coerce a group-node default to a leaf.
+
+        ERPNext's validate_customer_group rejects group-node values with
+        'Cannot select a Group type Customer Group'. The test temporarily
+        points ``Selling Settings.customer_group`` at a group node (the
+        root) for the duration of the test, so the assertion exercises the
+        coercion path regardless of what the test fixture seeds. Previously
+        this test self-skipped when Settings already pointed at a leaf —
+        which became always-true after the leaf seeder landed in
+        ``before_tests``, silently turning this guarantee into a no-op.
+        """
+        original = frappe.db.get_single_value(
+            "Selling Settings", "customer_group"
+        )
+        root = frappe.db.get_value(
+            "Customer Group",
+            {"is_group": 1, "parent_customer_group": ["in", ("", None)]},
+            "name",
+        )
+        if not root:
             self.skipTest(
-                f"Selling Settings.customer_group is '{configured}' (a leaf); "
-                f"this test exercises only the group-node fallback path."
+                "No root Customer Group exists on this site; cannot exercise "
+                "the group-node fallback path."
             )
 
-        member = self.create_test_member(
-            first_name="Group",
-            last_name="Fallback",
-            email="group.fallback@verenigingen.invalid",
-            birth_date="1990-01-01",
-        )
-        self._created_members.append(member.name)
+        try:
+            frappe.db.set_single_value("Selling Settings", "customer_group", root)
 
-        if member.customer:
-            self._created_customers.append(member.customer)
-            member.db_set("customer", None, update_modified=False)
-            member.reload()
+            member = self.create_test_member(
+                first_name="Group",
+                last_name="Fallback",
+                email="group.fallback@verenigingen.invalid",
+                birth_date="1990-01-01",
+            )
+            self._created_members.append(member.name)
 
-        customer_name = self.service.create_customer_for_member(
-            member, suppress_messages=True
-        )
-        self.assertIsNotNone(customer_name)
-        self._created_customers.append(customer_name)
+            if member.customer:
+                self._created_customers.append(member.customer)
+                member.db_set("customer", None, update_modified=False)
+                member.reload()
 
-        customer = frappe.get_doc("Customer", customer_name)
-        is_group = frappe.db.get_value(
-            "Customer Group", customer.customer_group, "is_group"
-        )
-        self.assertEqual(
-            is_group,
-            0,
-            f"Customer.customer_group resolved to {customer.customer_group!r} "
-            f"which has is_group={is_group}. A group node will be rejected by "
-            f"ERPNext's validate_customer_group.",
-        )
+            customer_name = self.service.create_customer_for_member(
+                member, suppress_messages=True
+            )
+            self.assertIsNotNone(customer_name)
+            self._created_customers.append(customer_name)
+
+            customer = frappe.get_doc("Customer", customer_name)
+            is_group = frappe.db.get_value(
+                "Customer Group", customer.customer_group, "is_group"
+            )
+            self.assertEqual(
+                is_group,
+                0,
+                f"Customer.customer_group resolved to {customer.customer_group!r} "
+                f"which has is_group={is_group}. A group node will be rejected by "
+                f"ERPNext's validate_customer_group.",
+            )
+        finally:
+            frappe.db.set_single_value(
+                "Selling Settings", "customer_group", original
+            )

--- a/verenigingen/tests/setup/__init__.py
+++ b/verenigingen/tests/setup/__init__.py
@@ -144,9 +144,18 @@ def before_tests():
 def _seed_verenigingen_test_system_user():
     """Create a test system user and wire it into Verenigingen Settings.
 
-    The user is enabled, has System Manager + Verenigingen Administrator
-    roles so service-side operations succeed, and uses a non-routable email
-    domain so any test email leak is harmless.
+    The user is enabled, has the System Manager role (sufficient for
+    ``utils.secure_operations.get_system_user_for_operation`` which only
+    gates on user-exists + enabled), and uses a non-routable email domain
+    so any test email leak is harmless.
+
+    Deliberately does NOT add the ``Verenigingen Administrator`` role:
+    it is a custom-fixture role loaded by ``bench migrate`` / ``bench
+    import-fixtures``, neither of which runs on fresh CI sites created
+    via ``bench new-site``. Appending a non-existent role link would make
+    ``user.insert()`` throw and the outer ``try/except`` would silently
+    log — leaving ``creation_user`` empty and reproducing the very B1
+    failure this helper exists to fix.
     """
     test_user_email = "verenigingen-test-system@example.invalid"
     if not frappe.db.exists("User", test_user_email):
@@ -157,8 +166,7 @@ def _seed_verenigingen_test_system_user():
         user.enabled = 1
         user.user_type = "System User"
         user.send_welcome_email = 0
-        for role in ("System Manager", "Verenigingen Administrator"):
-            user.append("roles", {"role": role})
+        user.append("roles", {"role": "System Manager"})
         user.insert(ignore_permissions=True)
         frappe.db.commit()
 
@@ -173,15 +181,20 @@ def _seed_verenigingen_test_system_user():
 
 
 def _seed_default_leaf_customer_group():
-    """Ensure Selling Settings.customer_group points at a leaf (is_group=0).
+    """Ensure Selling Settings.customer_group and the user default both
+    point at a leaf (is_group=0).
 
     Creates "Individual" (or reuses any leaf) under the root if needed.
-    """
-    current = frappe.db.get_single_value("Selling Settings", "customer_group")
-    if current and frappe.db.get_value("Customer Group", current, "is_group") == 0:
-        # Already a leaf, nothing to do.
-        return
 
+    Both the Single and the user-level default must agree on a leaf:
+    - The Single is read by `services.customer_group_resolver` and by
+      ERPNext's Customer form defaults.
+    - The user-level default (`frappe.db.set_default("customer_group", ...)`)
+      is what `frappe.new_doc("Customer")` inherits when the caller doesn't
+      set the field explicitly. ERPNext's Customer controller would reject
+      a root-group inherited value with "Cannot select a Group type
+      Customer Group".
+    """
     leaf = frappe.db.get_value(
         "Customer Group", {"name": "Individual", "is_group": 0}, "name"
     ) or frappe.db.get_value(
@@ -204,5 +217,16 @@ def _seed_default_leaf_customer_group():
         leaf = group.name
         frappe.db.commit()
 
-    frappe.db.set_single_value("Selling Settings", "customer_group", leaf)
-    frappe.db.commit()
+    current_single = frappe.db.get_single_value(
+        "Selling Settings", "customer_group"
+    )
+    current_default = frappe.db.get_default("customer_group")
+    needs_commit = False
+    if current_single != leaf:
+        frappe.db.set_single_value("Selling Settings", "customer_group", leaf)
+        needs_commit = True
+    if current_default != leaf:
+        frappe.db.set_default("customer_group", leaf)
+        needs_commit = True
+    if needs_commit:
+        frappe.db.commit()

--- a/verenigingen/tests/setup/__init__.py
+++ b/verenigingen/tests/setup/__init__.py
@@ -108,3 +108,101 @@ def before_tests():
         ensure_payment_modes_exist()
     except Exception as e:
         frappe.logger().warning(f"Payment mode seeding failed: {e}")
+
+    # Seed Verenigingen Settings.creation_user (reqd=1) with a dedicated
+    # non-Administrator test user. Required by utils.secure_operations
+    # `get_system_user_for_operation`, which raises ConfigurationError when the
+    # field is empty (~91 fails) and cascades MandatoryError on any later
+    # .save() of the Singles doc (~71 fails). The install path normally seeds
+    # this via setup/__init__.py:412 but the seed silently fails on fresh CI
+    # sites; the test-side seed makes the setup deterministic.
+    #
+    # IMPORTANT: do NOT default to "Administrator" — PR #81 was closed for
+    # silently re-enabling an Administrator fallback that secure_operations.py
+    # had been hardened to refuse. We create a dedicated test user instead.
+    # Use db.set_single_value to bypass the Singles .save() validation chain
+    # (System Settings / Verenigingen Settings both have other reqd fields
+    # that would cascade their own MandatoryError).
+    try:
+        _seed_verenigingen_test_system_user()
+    except Exception as e:
+        frappe.logger().warning(f"Verenigingen Settings creation_user seeding failed: {e}")
+
+    # Reset Selling Settings.customer_group away from the root "All Customer
+    # Groups" that erpnext_before_tests() sets. ERPNext's Customer controller
+    # rejects any Customer Group with is_group=1 with "Cannot select a Group
+    # type Customer Group" (~72 fails). Production code already uses
+    # services.customer_group_resolver.resolve_non_group_customer_group() to
+    # work around the bad default; this matches the resolver's behaviour for
+    # tests that bypass it by writing customer.customer_group directly.
+    try:
+        _seed_default_leaf_customer_group()
+    except Exception as e:
+        frappe.logger().warning(f"Customer Group default reset failed: {e}")
+
+
+def _seed_verenigingen_test_system_user():
+    """Create a test system user and wire it into Verenigingen Settings.
+
+    The user is enabled, has System Manager + Verenigingen Administrator
+    roles so service-side operations succeed, and uses a non-routable email
+    domain so any test email leak is harmless.
+    """
+    test_user_email = "verenigingen-test-system@example.invalid"
+    if not frappe.db.exists("User", test_user_email):
+        user = frappe.new_doc("User")
+        user.email = test_user_email
+        user.first_name = "Verenigingen"
+        user.last_name = "Test System"
+        user.enabled = 1
+        user.user_type = "System User"
+        user.send_welcome_email = 0
+        for role in ("System Manager", "Verenigingen Administrator"):
+            user.append("roles", {"role": role})
+        user.insert(ignore_permissions=True)
+        frappe.db.commit()
+
+    current = frappe.db.get_single_value("Verenigingen Settings", "creation_user")
+    if current != test_user_email:
+        # set_single_value writes the Singles row directly without firing
+        # validate (which would trip on other reqd fields on a fresh site).
+        frappe.db.set_single_value(
+            "Verenigingen Settings", "creation_user", test_user_email
+        )
+        frappe.db.commit()
+
+
+def _seed_default_leaf_customer_group():
+    """Ensure Selling Settings.customer_group points at a leaf (is_group=0).
+
+    Creates "Individual" (or reuses any leaf) under the root if needed.
+    """
+    current = frappe.db.get_single_value("Selling Settings", "customer_group")
+    if current and frappe.db.get_value("Customer Group", current, "is_group") == 0:
+        # Already a leaf, nothing to do.
+        return
+
+    leaf = frappe.db.get_value(
+        "Customer Group", {"name": "Individual", "is_group": 0}, "name"
+    ) or frappe.db.get_value(
+        "Customer Group", {"is_group": 0}, "name", order_by="name asc"
+    )
+
+    if not leaf:
+        # No leaf exists — create "Individual" under the root.
+        root = frappe.db.get_value(
+            "Customer Group", {"is_group": 1, "parent_customer_group": ["in", ("", None)]}, "name"
+        )
+        if not root:
+            # No tree at all (unlikely after erpnext_before_tests, but safe).
+            return
+        group = frappe.new_doc("Customer Group")
+        group.customer_group_name = "Individual"
+        group.parent_customer_group = root
+        group.is_group = 0
+        group.insert(ignore_permissions=True)
+        leaf = group.name
+        frappe.db.commit()
+
+    frappe.db.set_single_value("Selling Settings", "customer_group", leaf)
+    frappe.db.commit()


### PR DESCRIPTION
## Summary

Group B of the CI failure inventory from develop run [26387986198](https://github.com/nlvegan/verenigingen/actions/runs/26387986198). ~163 failures across two related install-hook gaps on fresh CI sites.

## Root causes

**B1 — Verenigingen Settings.creation_user empty (~91 fails)**

\`creation_user\` is \`reqd=1\`. Production seeds it via \`setup/__init__.py:412\` but the seed is wrapped in try/except that only logs — on fresh CI sites the field stays empty, and two symptoms cascade:
- \`utils/secure_operations.py:get_system_user_for_operation\` raises \`ConfigurationError("System user for automated operations is not configured")\` (~20 fails)
- The first downstream \`.save()\` of the Singles doc cascades \`MandatoryError: [Verenigingen Settings]: creation_user\` (~71 fails)

**B2 — Customer Group default points at a group (~72 fails)**

ERPNext's \`set_defaults_for_tests()\` sets \`Selling Settings.customer_group = get_root_of(...)\` = "All Customer Groups" (\`is_group=1\`). ERPNext's Customer controller rejects this with \`Cannot select a Group type Customer Group\`.

Examples: \`tests/security/test_link_sanitizer.py\` x2, \`tests/backend/workflows/test_payment_failure_recovery.py\`, \`tests/donor/test_donor_customer_integration.py\`, \`tests/donor/test_donor_customer_sync_utils.py\`.

## Fix

**\`tests/setup/__init__.py\`** — two new idempotent seeders called from \`before_tests\`:

1. \`_seed_verenigingen_test_system_user()\` creates \`verenigingen-test-system@example.invalid\` (System Manager + Verenigingen Administrator roles, non-routable email domain) and writes it to \`Verenigingen Settings.creation_user\` via \`frappe.db.set_single_value\`. Direct-DB write bypasses the Singles \`.save()\` validate chain so other reqd fields (language/time_zone) don't trip MandatoryError too.

2. \`_seed_default_leaf_customer_group()\` ensures an "Individual" leaf Customer Group exists (creates one under the root if missing) and resets \`Selling Settings.customer_group\` to it. Mirrors the choice that \`services.customer_group_resolver.resolve_non_group_customer_group()\` would make.

**4 test files** updated to call \`resolve_non_group_customer_group()\` instead of hardcoding \`"All Customer Groups"\`. Explicit-intent + survives any future leaf rename.

## Crucial guardrail

**Do NOT default \`creation_user\` to "Administrator"** — PR #81 was closed for silently re-enabling the Administrator fallback that \`utils/secure_operations.py:585-626\` had been deliberately hardened to refuse. The dedicated test user is non-Administrator and the existing security audit at \`tests/security/test_secure_operations_security_audit.py:55-75\` continues to hold. See [[project_singles_reqd_fields_install_hooks]].

## Test plan

- [x] \`_seed_verenigingen_test_system_user()\` + \`_seed_default_leaf_customer_group()\` verified idempotent on local site
- [x] \`Verenigingen Settings.creation_user\` set to test user (not Administrator)
- [x] \`Selling Settings.customer_group\` set to "Individual" leaf
- [x] \`test_existing_customer_linking_by_email\` (uses edited customer_group line) now passes the Customer save; remaining failure is unrelated \`track_doc\` scaffolding rot
- [x] Pre-commit hooks pass
- [ ] CI: ~163 fewer failures across 4 shards

## Notes for reviewers

Senior + skeptical reviewers requested per [[feedback_always_request_pr_review]] / [[feedback_double_review_pattern]]. Please look at:

1. **Security regression check**: confirm the new \`verenigingen-test-system@example.invalid\` user does NOT inadvertently re-enable the Administrator fallback that PR #81 tried to. Look at \`utils/secure_operations.py:get_system_user_for_operation\` and verify the test user is acceptable + non-Administrator.

2. **Test pollution**: the new shared test user has System Manager. If a test ever queries "all System Manager users" and asserts count, it'd silently start failing. Verify no such test exists.

3. **Leaf customer group choice**: I created "Individual" if missing. ERPNext's stock tree usually has "Individual" as a leaf already. Edge case: a site customized to remove "Individual" — the seeder falls back to any leaf or creates "Individual" under root. Is that the right behaviour?

4. **Test-only fix vs production fix**: the underlying install hook (\`setup/__init__.py:412\`) silently swallows seed failures. Should we tighten that too (out of scope here, follow-up worth flagging)?

Group C (~54 fails from orphan Volunteer Expense DocType references in dead tests) is deferred to a separate PR — it's a test-deletion change rather than install-hook work.