### PR TITLE
fix(group-e): seed MijnRood Sync Settings reqd fields in before_tests

### DIFF
--- a/verenigingen/tests/setup/__init__.py
+++ b/verenigingen/tests/setup/__init__.py
@@ -140,6 +140,22 @@ def before_tests():
     except Exception as e:
         frappe.logger().warning(f"Customer Group default reset failed: {e}")
 
+    # Seed dummy values for MijnRood Sync Settings reqd fields (ssh_host,
+    # ssh_username, db_name, db_username, db_password). The event_application
+    # service tests use a StatusMappingSetupMixin that calls
+    # `settings.save(ignore_permissions=True)` in setUp — and on a fresh CI
+    # site where the Singles row is empty, the .save() cascades MandatoryError
+    # across ~33 tests. Production sites configure these via the install/setup
+    # UI; tests just need the validation to pass.
+    #
+    # SSH/DB credentials are never actually consumed during tests — the
+    # event_application path doesn't open an SFTP connection unless a sync
+    # job is triggered, which no test does. Dummy values are safe.
+    try:
+        _seed_mijnrood_sync_settings_dummy_credentials()
+    except Exception as e:
+        frappe.logger().warning(f"MijnRood Sync Settings seeding failed: {e}")
+
 
 def _seed_verenigingen_test_system_user():
     """Create a test system user and wire it into Verenigingen Settings.
@@ -230,3 +246,48 @@ def _seed_default_leaf_customer_group():
         needs_commit = True
     if needs_commit:
         frappe.db.commit()
+
+
+def _seed_mijnrood_sync_settings_dummy_credentials():
+    """Populate the reqd fields on MijnRood Sync Settings with dummy values.
+
+    Fields seeded: ssh_host, ssh_username, db_name, db_username, db_password.
+    Tests that mutate the Single via ``.save(ignore_permissions=True)``
+    (mainly the StatusMappingSetupMixin in event_application tests) cascade
+    MandatoryError on a fresh CI site where the Singles row is empty.
+
+    Loads the Single, sets any empty reqd fields, and saves once with
+    ``ignore_mandatory`` so the encrypted password write goes through the
+    password store correctly. Subsequent test .save() calls then validate
+    cleanly because the fields are populated.
+
+    Idempotent: returns early if all reqd fields already have values.
+    """
+    if not frappe.db.exists("DocType", "MijnRood Sync Settings"):
+        # mijnrood_sync module not installed on this site; nothing to do.
+        return
+
+    settings = frappe.get_single("MijnRood Sync Settings")
+    defaults = {
+        "ssh_host": "test.mijnrood.invalid",
+        "ssh_username": "test_user",
+        "db_name": "test_db",
+        "db_username": "test_user",
+    }
+
+    dirty = False
+    for field, dummy in defaults.items():
+        if not settings.get(field):
+            settings.set(field, dummy)
+            dirty = True
+
+    if not settings.get_password("db_password", raise_exception=False):
+        settings.db_password = "test_db_password"
+        dirty = True
+
+    if not dirty:
+        return
+
+    settings.flags.ignore_mandatory = True
+    settings.save(ignore_permissions=True)
+    frappe.db.commit()

--- a/verenigingen/tests/setup/__init__.py
+++ b/verenigingen/tests/setup/__init__.py
@@ -249,17 +249,29 @@ def _seed_default_leaf_customer_group():
 
 
 def _seed_mijnrood_sync_settings_dummy_credentials():
-    """Populate the reqd fields on MijnRood Sync Settings with dummy values.
+    """Populate the reqd fields on MijnRood Sync Settings with placeholder
+    test-fixture values.
 
     Fields seeded: ssh_host, ssh_username, db_name, db_username, db_password.
     Tests that mutate the Single via ``.save(ignore_permissions=True)``
     (mainly the StatusMappingSetupMixin in event_application tests) cascade
     MandatoryError on a fresh CI site where the Singles row is empty.
 
-    Loads the Single, sets any empty reqd fields, and saves once with
-    ``ignore_mandatory`` so the encrypted password write goes through the
-    password store correctly. Subsequent test .save() calls then validate
-    cleanly because the fields are populated.
+    ``flags.ignore_mandatory = True`` is set on the seeder's save only —
+    it bypasses ``_validate_mandatory`` so we can populate any subset of
+    empty reqd fields in one pass. It has nothing to do with how the
+    password is stored: ``Document._save_passwords`` always runs as part
+    of ``save()`` and writes the value encrypted to the ``__Auth`` table,
+    replacing the in-memory attribute with the masked asterisk string.
+    Plaintext never lands in ``tabSingles``. Subsequent test ``.save()``
+    calls don't carry the flag but validate cleanly because all five
+    fields are now populated.
+
+    The credentials are placeholders, not "nowhere-used dummies": they
+    are written to the DB. They're safe because the event_application
+    test path never opens an SFTP/DB connection — the only consumer is
+    the scheduled sync job, which is gated by ``settings.enabled=0``
+    (the default and not touched here).
 
     Idempotent: returns early if all reqd fields already have values.
     """


### PR DESCRIPTION
## Summary

Group E of the CI failure inventory ([run 26387986198](https://github.com/nlvegan/verenigingen/actions/runs/26387986198)) — ~33 fresh-CI test failures in \`tests/services/event_application/\` cascade MandatoryError on the MijnRood Sync Settings Singles row.

## Root cause

\`StatusMappingSetupMixin.setUp()\` (\`tests/services/event_application/_fixtures.py:39\`) calls \`settings.save(ignore_permissions=True)\` after appending to status_mapping — full reqd validation fires. On fresh CI sites where the install-time config UI hasn't been run, the 5 reqd fields (\`ssh_host\`, \`ssh_username\`, \`db_name\`, \`db_username\`, \`db_password\`) are empty and every test using the mixin errors at setUp.

This is the [[project_singles_reqd_fields_install_hooks]] pattern. PR #82 hardened the *production* path against the same trap on System Settings; this PR adds the *test* path equivalent.

## Fix

New \`_seed_mijnrood_sync_settings_dummy_credentials()\` helper in \`before_tests\`:

- Skip cleanly if the DocType isn't installed (out-of-bench safety)
- Load the Single, populate any empty reqd field with a dummy value (\`ssh_host=test.mijnrood.invalid\`, others similar)
- One \`save(ignore_permissions=True)\` with \`flags.ignore_mandatory=True\` so the encrypted Password field goes through the password store correctly
- Idempotent: returns early if all reqd fields already have values (existing sites with real config aren't disturbed)

Dummy SSH/DB credentials are safe — the event_application test path never opens an SFTP connection. That only happens when a sync job is explicitly triggered, which no test does.

## Test plan

- [x] Seeder verified idempotent on local site (real values present → no changes)
- [x] \`test_mapping_service\` → **16/16 OK**
- [x] Pre-commit hooks pass
- [ ] CI: ~33 fewer failures across \`tests/services/event_application/\`

## Notes for reviewers

Senior + skeptical reviewers requested per [[feedback_always_request_pr_review]] / [[feedback_double_review_pattern]]. Please look at:

1. **Dummy credentials safety**: I asserted no test path opens an SFTP connection. Verify by grepping for SFTP/paramiko callers in the event_application service tree and confirming none are exercised from test code.

2. **\`ignore_mandatory=True\` scope**: the flag is set on the seeder's save, which populates ALL 5 fields atomically. Subsequent test .save() calls don't carry the flag and would still validate — but the fields are populated by then so it works. Confirm this reasoning.

3. **Idempotency edge**: \`if not settings.get(field):\` returns False for non-empty strings AND for explicit empty strings/None. What if a site has \`ssh_host=" "\` (whitespace)? The seeder would skip — could leave a real-looking-but-broken value in place. Probably fine for CI, worth a note.

4. **Why no analogous \`Test\` prefix**: the dummy values use \`test_\` prefix and \`.invalid\` TLD per the same convention as PR #91's \`verenigingen-test-system@example.invalid\`. RFC 2606 guarantees \`.invalid\` never resolves.