### PR TITLE
fix(membership-application): replace removed module-level import with service accessor (P1)

### DIFF
--- a/verenigingen/services/member/approval/application_helpers.py
+++ b/verenigingen/services/member/approval/application_helpers.py
@@ -257,11 +257,11 @@ def get_form_data():
         # Get enhanced membership types with contribution options in one bulk operation
         membership_types = []
         try:
-            from verenigingen.templates.pages.membership_application import (
-                get_membership_types_with_contributions,
+            from verenigingen.services.member.application.membership_application_service import (
+                get_membership_application_service,
             )
 
-            membership_types = get_membership_types_with_contributions()
+            membership_types = get_membership_application_service().get_membership_types_with_contributions()
         except Exception as e:
             # Fallback to basic membership types if enhanced version fails
             frappe.log_error(f"Error getting enhanced membership types, falling back to basic: {str(e)}")

--- a/verenigingen/templates/pages/apply_for_membership.py
+++ b/verenigingen/templates/pages/apply_for_membership.py
@@ -82,9 +82,13 @@ def get_context(context):
     context.is_dutch_installation = is_dutch_installation()
 
     # Get membership types with enhanced contribution options
-    from verenigingen.templates.pages.membership_application import get_membership_types_with_contributions
+    from verenigingen.services.member.application.membership_application_service import (
+        get_membership_application_service,
+    )
 
-    context.enhanced_membership_types = get_membership_types_with_contributions()
+    context.enhanced_membership_types = (
+        get_membership_application_service().get_membership_types_with_contributions()
+    )
 
     # Basic context setup
     context.already_member = False

--- a/verenigingen/tests/backend/components/test_membership_application_page_imports.py
+++ b/verenigingen/tests/backend/components/test_membership_application_page_imports.py
@@ -1,0 +1,52 @@
+"""
+Regression tests for membership application page imports.
+
+Background: `get_membership_types_with_contributions` was promoted from a
+module-level helper in `templates.pages.membership_application` to an instance
+method on `MembershipApplicationService`. Two callers continued to import the
+module-level symbol — one silently degraded to a fallback, the other hard-failed
+on page load.
+
+These tests pin the canonical service-accessor pattern at both call sites so a
+future regression surfaces immediately.
+"""
+
+import frappe
+from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
+
+
+class TestMembershipApplicationPageImports(EnhancedTestCase):
+    def test_apply_for_membership_get_context_resolves_imports(self):
+        """`/apply_for_membership` page load must not raise ImportError."""
+        from verenigingen.templates.pages.apply_for_membership import get_context
+
+        original_user = frappe.session.user
+        try:
+            frappe.set_user("Guest")
+            context = frappe._dict()
+            result = get_context(context)
+        finally:
+            frappe.set_user(original_user)
+
+        self.assertIn("enhanced_membership_types", result)
+        self.assertIsInstance(result.enhanced_membership_types, list)
+
+    def test_get_form_data_uses_service_path(self):
+        """`get_form_data` must reach the service accessor, not the fallback.
+
+        The service path enriches each membership type with `contribution_options`;
+        the bare-except fallback only adds `billing_frequency`. Asserting on
+        `contribution_options` confirms the import resolved.
+        """
+        from verenigingen.services.member.approval.application_helpers import get_form_data
+
+        result = get_form_data()
+
+        self.assertTrue(result["success"], f"get_form_data failed: {result}")
+        if result["membership_types"]:
+            for mt in result["membership_types"]:
+                self.assertIn(
+                    "contribution_options",
+                    mt,
+                    "Fallback path ran — service import is broken again",
+                )

--- a/verenigingen/tests/backend/components/test_membership_application_page_imports.py
+++ b/verenigingen/tests/backend/components/test_membership_application_page_imports.py
@@ -16,8 +16,16 @@ from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
 
 
 class TestMembershipApplicationPageImports(EnhancedTestCase):
+    def setUp(self):
+        super().setUp()
+        # Seed at least one active Membership Type. Without this, both tests below
+        # would have vacuous-pass paths on a bare site: an empty list satisfies
+        # `isinstance(..., list)` and skips the `contribution_options` for-loop.
+        self.test_membership_type = self.create_test_membership_type()
+
     def test_apply_for_membership_get_context_resolves_imports(self):
-        """`/apply_for_membership` page load must not raise ImportError."""
+        """`/apply_for_membership` page load must not raise ImportError and must
+        reach the service path (not silently fall back to an empty list)."""
         from verenigingen.templates.pages.apply_for_membership import get_context
 
         original_user = frappe.session.user
@@ -30,11 +38,21 @@ class TestMembershipApplicationPageImports(EnhancedTestCase):
 
         self.assertIn("enhanced_membership_types", result)
         self.assertIsInstance(result.enhanced_membership_types, list)
+        # setUp seeded a Membership Type — service path must surface it.
+        self.assertGreater(
+            len(result.enhanced_membership_types),
+            0,
+            "Expected at least the setUp-seeded membership type in service output",
+        )
+        # Service path enriches each entry with contribution_options; the gone
+        # module-level function would have raised ImportError before reaching here.
+        for mt in result.enhanced_membership_types:
+            self.assertIn("contribution_options", mt)
 
     def test_get_form_data_uses_service_path(self):
         """`get_form_data` must reach the service accessor, not the fallback.
 
-        The service path enriches each membership type with `contribution_options`;
+        Service path enriches each membership type with `contribution_options`;
         the bare-except fallback only adds `billing_frequency`. Asserting on
         `contribution_options` confirms the import resolved.
         """
@@ -43,10 +61,17 @@ class TestMembershipApplicationPageImports(EnhancedTestCase):
         result = get_form_data()
 
         self.assertTrue(result["success"], f"get_form_data failed: {result}")
-        if result["membership_types"]:
-            for mt in result["membership_types"]:
-                self.assertIn(
-                    "contribution_options",
-                    mt,
-                    "Fallback path ran — service import is broken again",
-                )
+        # setUp seeded a Membership Type — a vacuous-pass guard would hide a
+        # regression of the service import back to the silent fallback (the
+        # fallback returns success=True with the same shape).
+        self.assertGreater(
+            len(result["membership_types"]),
+            0,
+            "Expected at least the setUp-seeded membership type in form data",
+        )
+        for mt in result["membership_types"]:
+            self.assertIn(
+                "contribution_options",
+                mt,
+                "Fallback path ran — service import is broken again",
+            )


### PR DESCRIPTION
## Summary

P1 production bug: `/apply_for_membership` page hard-failed with `ImportError` on every request.

- `templates/pages/apply_for_membership.py:85` imported a module-level `get_membership_types_with_contributions` that no longer exists — it was promoted to `MembershipApplicationService.get_membership_types_with_contributions` (instance method) in a prior refactor. No `try/except` guard → 500 on page load.
- `services/member/approval/application_helpers.py:260-264` had the same broken import but silently degraded via a bare `except`, falling back to the basic membership-types query and skipping the `contribution_options` enrichment.

Both call sites now use the canonical pattern already in `templates/pages/membership_application.py:45-46`:
\`\`\`python
get_membership_application_service().get_membership_types_with_contributions()
\`\`\`

## Regression test

New `tests/backend/components/test_membership_application_page_imports.py`:
- `test_apply_for_membership_get_context_resolves_imports` — exercises the page-load path and asserts `enhanced_membership_types` is populated.
- `test_get_form_data_uses_service_path` — asserts the service-path is reached (each membership type has `contribution_options`) so a future regression to the fallback path surfaces immediately.

## Bench verification

\`\`\`
Module: verenigingen.tests.backend.components.test_membership_application_page_imports
Ran 2 tests — 2 pass / 0 fail / 0 error / 0 skip
0 new Error Log entries during the run (veg11.veganisme.org)
\`\`\`

## Test plan

- [x] `bench --site veg11.veganisme.org execute` against the new regression test passes
- [x] No new entries in `tabError Log` during the run
- [ ] CI confirms tests pass against full suite