### PR TITLE
fix(security-setup): close 6 test errors + repair un-cleanable cache leak in rate-limit wrapper

### DIFF
--- a/verenigingen/setup/security_setup.py
+++ b/verenigingen/setup/security_setup.py
@@ -36,14 +36,25 @@ def security_rate_limit(limit=5, seconds=60):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # Use Frappe's built-in rate limiting
+            # Use the namespaced cache API (`get_value` / `set_value`)
+            # rather than raw redis `get` / `setex`. The raw calls store
+            # un-namespaced keys that `frappe.cache.delete_keys()` cannot
+            # match, leaving the only cleanup path as Redis TTL eviction.
+            # That broke test isolation (cleanup couldn't actually clear
+            # state between tests) and silently leaked keys in production
+            # until their TTL fired.
+            #
+            # `use_local_cache=False` on the read is required: `set_value`
+            # always populates `frappe.local.cache` with no TTL, and
+            # `get_value` reads from that local cache first. Without this
+            # flag, a TTL-expired Redis key still returns a stale count
+            # from the request-local cache (broke
+            # `test_rate_limit_cache_expiration`).
             key = f"security_rate_limit:{frappe.session.user}:{func.__name__}"
 
-            # Check rate limit
             from frappe.utils import cint
 
-            # Get current count
-            count = cint(frappe.cache.get(key) or 0)
+            count = cint(frappe.cache.get_value(key, use_local_cache=False) or 0)
 
             if count >= limit:
                 # Log rate limit exceeded
@@ -62,10 +73,8 @@ def security_rate_limit(limit=5, seconds=60):
                     frappe.RateLimitExceededError,
                 )
 
-            # Increment counter
-            frappe.cache.setex(key, seconds, count + 1)
+            frappe.cache.set_value(key, count + 1, expires_in_sec=seconds)
 
-            # Execute function
             return func(*args, **kwargs)
 
         return wrapper

--- a/verenigingen/tests/security/test_security_setup.py
+++ b/verenigingen/tests/security/test_security_setup.py
@@ -34,18 +34,21 @@ from verenigingen.setup.security_setup import (
 
 class TestSecurityRateLimit(VereningingenTestCase):
     """Test custom rate limiting decorator"""
-    
+
     def setUp(self):
         super().setUp()
         self.original_user = frappe.session.user
         frappe.session.user = "test_user@example.com"
-    
+        # Clear cache from prior runs. The first test in the class
+        # otherwise inherits keys whose 10-60s TTL may not have expired
+        # (only tearDown was clearing — there's no tearDown before the
+        # first setUp in a session). RedisWrapper.delete_keys appends a
+        # trailing `*` internally via get_keys (redis_wrapper.py:131),
+        # so the bare prefix is correct.
+        frappe.cache.delete_keys("security_rate_limit:")
+
     def tearDown(self):
         frappe.session.user = self.original_user
-        # Clear cache between tests. `from frappe.cache import cache` was removed
-        # in current Frappe; `frappe.cache` is now the RedisWrapper directly.
-        # No trailing `*` — `RedisWrapper.delete_keys` appends one internally
-        # via `get_keys` (redis_wrapper.py:131).
         frappe.cache.delete_keys("security_rate_limit:")
         super().tearDown()
     
@@ -477,9 +480,16 @@ class TestSecurityAPIEndpoints(VereningingenTestCase):
         super().setUp()
         self.original_user = frappe.session.user
         frappe.session.user = "admin@example.com"
+        # `enable_csrf_protection` is wrapped with `@security_rate_limit`;
+        # without clearing the prior run's cache the first invocation of
+        # the API tests trips the rate limit before reaching the
+        # permission check under test.
+        frappe.cache.delete_keys("security_rate_limit:")
 
     def tearDown(self):
         frappe.session.user = self.original_user
+        frappe.cache.delete_keys("security_rate_limit:")
+        super().tearDown()
 
     @contextlib.contextmanager
     def _with_admin_user(self):
@@ -493,13 +503,17 @@ class TestSecurityAPIEndpoints(VereningingenTestCase):
             yield
         finally:
             frappe.set_user(previous)
-        super().tearDown()
     
     # Mock justified: Infrastructure - external dependency, not the boundary under test
     @patch('verenigingen.setup.security_setup.log_security_audit')
     # Mock justified: Infrastructure - external dependency, not the boundary under test
     @patch('frappe.installer.update_site_config')
-    def test_enable_csrf_protection_success(self, mock_update_config, mock_audit):
+    # Mock justified: validate_csrf_token reads frappe.local.request which is
+    # unbound in the unittest runner (RuntimeError: object is not bound). The
+    # CSRF validation logic itself is exercised by TestCSRFValidation; here we
+    # only care about the enable-CSRF flow downstream of the gate.
+    @patch('verenigingen.setup.security_setup.validate_csrf_token')
+    def test_enable_csrf_protection_success(self, mock_csrf, mock_update_config, mock_audit):
         """Test successful CSRF protection enabling with real permissions.
 
         ``enable_csrf_protection`` writes site_config — a privileged operation
@@ -518,22 +532,31 @@ class TestSecurityAPIEndpoints(VereningingenTestCase):
     
     def test_enable_csrf_protection_permission_denied(self):
         """Test CSRF protection enabling without permissions"""
-        # Test with regular user (no System Settings write permission)
-        frappe.set_user("test_user@example.com")
-        
-        # Ensure user exists with basic role
+        # Create the test user as Administrator (insert + role assignment
+        # both need write permission on User), THEN switch to the user to
+        # exercise the actual permission boundary. Without this split, the
+        # test errored on `user_doc.insert()` before reaching the assertion.
         if not frappe.db.exists("User", "test_user@example.com"):
-            user_doc = frappe.get_doc({
-                "doctype": "User",
-                "email": "test_user@example.com",
-                "first_name": "Test",
-                "last_name": "User",
-                "enabled": 1
-            })
-            user_doc.insert()
-            user_doc.add_roles("Employee")
-        
-        with self.assertRaises(frappe.PermissionError):
+            with self._with_admin_user():
+                user_doc = frappe.get_doc({
+                    "doctype": "User",
+                    "email": "test_user@example.com",
+                    "first_name": "Test",
+                    "last_name": "User",
+                    "enabled": 1
+                })
+                user_doc.insert()
+                user_doc.add_roles("Employee")
+
+        frappe.set_user("test_user@example.com")
+
+        # The @critical_api decorator raises
+        # `verenigingen.utils.error_handling.PermissionError`, which extends
+        # `VerenigingenException` (→ `frappe.ValidationError`), NOT
+        # `frappe.PermissionError`. Accept either to cover both the
+        # framework's permission gate and the application's stricter gate.
+        from verenigingen.utils.error_handling import PermissionError as VPermissionError
+        with self.assertRaises((frappe.PermissionError, VPermissionError)):
             enable_csrf_protection()
     
     # Mock justified: Infrastructure - external dependency, not the boundary under test
@@ -546,9 +569,14 @@ class TestSecurityAPIEndpoints(VereningingenTestCase):
             "recommendations": []
         }
         mock_check.return_value = mock_status
-        
-        result = check_current_security_status()
-        
+
+        # check_current_security_status is wrapped with @critical_api; the
+        # session.user set in setUp ("admin@example.com") doesn't grant the
+        # critical-role membership the decorator enforces. Switch to a real
+        # Administrator session for the call.
+        with self._with_admin_user():
+            result = check_current_security_status()
+
         self.assertTrue(result["success"])
         self.assertEqual(result["status"], mock_status)
     
@@ -558,20 +586,29 @@ class TestSecurityAPIEndpoints(VereningingenTestCase):
     @patch('frappe.installer.update_site_config')
     def test_apply_production_security_comprehensive(self, mock_update_config, mock_audit):
         """Test applying production security settings with real permissions"""
-        # Test with admin permissions set up in setUp - FrappeTestCase handles permissions
-        # frappe.set_user moved to setUp context
-        
-        # Mock current insecure configuration
-        with patch.object(frappe.conf, 'developer_mode', 1):
-            with patch.object(frappe.conf, 'get', side_effect=lambda key, default=None: {
-                'ignore_csrf': 1,
-                'allow_tests': 1,
-                'secret_key': None
-            }.get(key, default)):
-                # Mock justified: Infrastructure - external dependency, not the boundary under test
-                with patch('verenigingen.setup.security_setup.generate_session_secret', return_value=True):
+        # apply_production_security is @critical_api; run inside the
+        # Administrator context for the call.
+        #
+        # `patch.object(frappe.conf, 'developer_mode', 1)` was failing with
+        # `TypeError: 'NoneType' object is not subscriptable` inside mock's
+        # `get_original` because `frappe.conf` is a `frappe._dict` whose
+        # attribute access proxies to dict access — there is no real
+        # instance attribute for mock to capture. Use `patch.dict` instead;
+        # `frappe._dict.__getattr__` reads the dict, so the production
+        # `frappe.conf.developer_mode` attribute access still resolves to
+        # the patched value.
+        config_overrides = {
+            'developer_mode': 1,
+            'ignore_csrf': 1,
+            'allow_tests': 1,
+            'secret_key': None,
+        }
+        with patch.dict(frappe.conf, config_overrides):
+            # Mock justified: Infrastructure - external dependency, not the boundary under test
+            with patch('verenigingen.setup.security_setup.generate_session_secret', return_value=True):
+                with self._with_admin_user():
                     result = apply_production_security()
-        
+
         self.assertTrue(result["success"])
         self.assertGreater(len(result["changes"]), 0)
         
@@ -659,10 +696,14 @@ class TestSecurityEdgeCases(VereningingenTestCase):
         mock_get_config.return_value = {"ignore_csrf": 1, "developer_mode": 0}
         
         result = setup_csrf_protection()
-        
+
         self.assertEqual(result["status"], "error")
-        self.assertIn("error", result)
-    
+        # Production code returns {"status": "error", "message": ...} — verify
+        # the failure carries a message rather than asserting a non-existent
+        # "error" key.
+        self.assertIn("message", result)
+        self.assertIn("Update failed", result["message"])
+
     def test_security_audit_with_none_user(self):
         """Test audit logging with None user"""
         original_user = frappe.session.user


### PR DESCRIPTION
## Summary

- Closes the 6 remaining `test_security_setup` errors from the post-PR-#101 handoff (`docs/plans/2026-05-27-test-failure-triage-plan.md`) plus one pre-existing assertion bug surfaced by the same run.
- Fixes a real production bug in `security_setup.py` where the custom rate-limit wrapper stored counters with un-namespaced keys that `frappe.cache.delete_keys()` could not match — making the cache uncleanable by application code, only by Redis TTL eviction.
- **30 → 30 passing** (`OK (skipped=1)`); was previously `FAILED (failures=1, errors=6, skipped=1)`.

## Production change: `security_setup.py` — rate-limit cache fix

### Bug 1: un-namespaced keys

`security_rate_limit` was using `frappe.cache.setex` / `frappe.cache.get`. `RedisWrapper` inherits `setex` and `get` from `redis-py` unchanged — they bypass the `make_key()` namespace prefix that the rest of the framework applies. Stored keys looked like `security_rate_limit:user:func` (raw), while `frappe.cache.delete_keys("security_rate_limit:")` searched for `{site}|security_rate_limit:*` (namespaced) and matched nothing. Confirmed via bench console:

```
>>> frappe.cache.setex("security_rate_limit:debug_user:debug_func", 60, 5)
>>> frappe.cache.get("...")
b'5'
>>> frappe.cache.delete_keys("security_rate_limit:")
>>> frappe.cache.get("...")
b'5'   # still there
```

**Consequence in production:** every (user, function) combination accumulated a key that lived until its TTL fired. No leak-of-data concern, but a small "uncleanable cache" footgun for any admin tool trying to reset rate limits.

**Consequence in tests:** the tearDown cleanup was silently a no-op.

**Fix:** switched to `frappe.cache.get_value` / `set_value` which use the namespace.

### Bug 2: local_cache stale read after TTL expiry

`set_value` writes `frappe.local.cache[key] = val` with no TTL on the request-local layer, even when `expires_in_sec` is passed for the Redis layer. `get_value` reads from `frappe.local.cache` first. Within a single process (e.g. a long-running test), an expired Redis key still returns the stale local-cache value.

Caught by `test_rate_limit_cache_expiration` (`time.sleep(1.1)` after exhausting the limit; expects the next call to succeed).

**Fix:** `get_value(key, use_local_cache=False)`.

## Test-side fixes

| Test | Bug | Fix |
| --- | --- | --- |
| `test_rate_limit_decorator_application` | Cache pollution from prior session (count=2 already in cache at the 2nd call) | Clear cache in setUp, not just tearDown |
| `test_rate_limit_cache_expiration` | Same + local_cache survives Redis TTL | setUp clear + production fix above |
| `test_enable_csrf_protection_success` | `RuntimeError: object is not bound` from `validate_csrf_token → frappe.get_request_header` (no HTTP request in unittest) | Mock `validate_csrf_token`; CSRF flow itself exercised by `TestCSRFValidation` |
| `test_enable_csrf_protection_permission_denied` | (a) User creation tried as non-admin (fails before reaching the assertion); (b) `assertRaises(frappe.PermissionError)` — `@critical_api` raises `verenigingen.utils.error_handling.PermissionError`, subclass of `frappe.ValidationError`, NOT `frappe.PermissionError` | (a) split: create user inside `_with_admin_user`, THEN switch; (b) widen assertion to tuple |
| `test_check_current_security_status_success` | `@critical_api` rejects `frappe.session.user = "admin@example.com"` (string assignment doesn't grant the critical role) | Wrap call in `_with_admin_user` |
| `test_apply_production_security_comprehensive` | `TypeError: 'NoneType' object is not subscriptable` from `patch.object(frappe.conf, 'developer_mode', 1)` — `frappe.conf` is a `frappe._dict` whose attribute access proxies to dict access; mock's `get_original` chokes | Use `patch.dict` |
| `test_setup_csrf_protection_update_failure` | `assertIn("error", result)` checks dict KEYS; result dict has keys `status`/`message`, not `error` | Check `message` field instead |

## Structural bug fixed

`_with_admin_user` had `super().tearDown()` indented INSIDE the contextmanager body (after the `try/finally`). It fired every time the `with`-block exited mid-test, breaking test isolation in subtle ways. Moved to the actual `tearDown` method.

## Bench verification (veg11.veganisme.org)

```
Before:
$ bench run-tests --module verenigingen.tests.security.test_security_setup
Ran 30 tests in 16.990s
FAILED (failures=1, errors=6, skipped=1)

After:
$ bench run-tests --module verenigingen.tests.security.test_security_setup
Ran 30 tests in 19.328s
OK (skipped=1)
```

## Test plan

- [x] `bench --site veg11.veganisme.org run-tests --module verenigingen.tests.security.test_security_setup` → `OK (skipped=1)`
- [x] All 7 originally-failing scenarios now pass
- [x] No new failures or errors introduced