### PR TITLE
fix(security-rate-limit): replace check-then-set with atomic INCR+EXPIRE

### DIFF
--- a/verenigingen/setup/security_setup.py
+++ b/verenigingen/setup/security_setup.py
@@ -58,26 +58,40 @@ def security_rate_limit(limit=5, seconds=60):
         def wrapper(*args, **kwargs):
             # Atomic INCR+EXPIRE bypasses the pickled get_value/set_value
             # layer entirely. We namespace explicitly via make_key so the
-            # keys still match frappe.cache.delete_keys('security_rate_limit:*')
-            # patterns used by test cleanup and the rest of this codebase.
-            # Raw INCR is incompatible with set_value's pickle.dumps wrapping —
-            # the two paths must never write to the same key, which is why
-            # we drop set_value/get_value here entirely.
+            # keys still match the frappe.cache.delete_keys('security_rate_limit:')
+            # cleanup pattern used by tests. Raw INCR is incompatible with
+            # set_value's pickle.dumps wrapping — the two paths must never
+            # write to the same key, which is why we drop set_value/get_value
+            # here entirely.
+            #
+            # Failure mode on Redis down: frappe.cache.eval raises
+            # redis.exceptions.ConnectionError. We deliberately do NOT
+            # suppress it the way the old set_value/get_value paths did.
+            # The previous behavior was fail-open (rate limiter silently
+            # bypassed); for a security endpoint fail-closed (the request
+            # 500s) is preferable.
             from frappe.utils import cint
+            from redis.exceptions import ResponseError
 
             logical_key = f"security_rate_limit:{frappe.session.user}:{func.__name__}"
             namespaced_key = frappe.cache.make_key(logical_key)
 
             try:
                 count = cint(frappe.cache.eval(_RATE_LIMIT_LUA, 1, namespaced_key, seconds))
-            except Exception as e:
-                # Transition guard: a pre-existing pickled value from the
-                # prior implementation (or stale state from a partial deploy)
-                # will make INCR fail with "value is not an integer". Drop
-                # the stale key and retry once. After ``seconds`` of clean
-                # traffic this branch becomes unreachable.
+            except ResponseError as e:
+                # Transition guard: a pre-existing pickled value left by
+                # the prior implementation makes INCR fail with the Redis
+                # error "value is not an integer or out of range" (wrapped
+                # by EVAL into a script error message that still contains
+                # the substring). Drop the stale key (via delete_value so
+                # frappe.local.cache is also cleared) and retry once.
+                #
+                # TODO(remove after 2026-06-04): the longest configured
+                # TTL is 300s; one week post-deploy any stale pickled
+                # values are guaranteed evicted and this branch becomes
+                # unreachable. Delete then.
                 if "not an integer" in str(e):
-                    frappe.cache.delete(namespaced_key)
+                    frappe.cache.delete_value([namespaced_key], make_keys=False)
                     count = cint(frappe.cache.eval(_RATE_LIMIT_LUA, 1, namespaced_key, seconds))
                 else:
                     raise
@@ -663,6 +677,12 @@ def setup_all_security():
 
 @frappe.whitelist()
 @critical_api(operation_type=OperationType.ADMIN)
+# Decorator stack note: ``@rate_limit`` is Frappe's built-in IP-based
+# best-effort limiter; ``@security_rate_limit`` is the user-based atomic
+# (Lua INCR+EXPIRE) gate added here. The custom one is the authoritative
+# limit — do not remove it on the assumption that the framework version
+# is sufficient; the framework version has its own check-then-set race
+# (see apps/frappe/frappe/rate_limiter.py).
 @rate_limit(limit=5, seconds=60)  # 5 attempts per minute
 @security_rate_limit(limit=3, seconds=300)  # Additional: 3 attempts per 5 minutes
 def enable_csrf_protection():

--- a/verenigingen/setup/security_setup.py
+++ b/verenigingen/setup/security_setup.py
@@ -6,7 +6,6 @@ Ensures proper security configuration during installation
 
 import secrets
 import string
-import time
 from functools import wraps
 
 import frappe
@@ -27,6 +26,27 @@ except ImportError:
     security_logger = frappe.logger("verenigingen.security")
 
 
+# Atomic increment-and-expire executed server-side in Redis. Replaces the
+# previous check-then-set pattern (read count via get_value, compare, write
+# count+1 via set_value) that allowed N concurrent workers reading the same
+# sub-limit count to all proceed — effective ceiling became limit + (N-1).
+#
+# Semantics:
+#   - INCR creates the key at 1 if absent, otherwise increments by 1.
+#   - EXPIRE runs only on first INCR (count == 1) so the fixed window does
+#     not slide forward on every hit. Without this guard, an attacker could
+#     keep their counter alive indefinitely by hitting the endpoint just
+#     under the limit every (seconds - 1) seconds.
+#   - Returns the new count atomically.
+_RATE_LIMIT_LUA = """
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return count
+"""
+
+
 def security_rate_limit(limit=5, seconds=60):
     """
     Custom rate limiter for security endpoints with enhanced logging.
@@ -36,27 +56,33 @@ def security_rate_limit(limit=5, seconds=60):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # Use the namespaced cache API (`get_value` / `set_value`)
-            # rather than raw redis `get` / `setex`. The raw calls store
-            # un-namespaced keys that `frappe.cache.delete_keys()` cannot
-            # match, leaving the only cleanup path as Redis TTL eviction.
-            # That broke test isolation (cleanup couldn't actually clear
-            # state between tests) and silently leaked keys in production
-            # until their TTL fired.
-            #
-            # `use_local_cache=False` on the read is required: `set_value`
-            # always populates `frappe.local.cache` with no TTL, and
-            # `get_value` reads from that local cache first. Without this
-            # flag, a TTL-expired Redis key still returns a stale count
-            # from the request-local cache (broke
-            # `test_rate_limit_cache_expiration`).
-            key = f"security_rate_limit:{frappe.session.user}:{func.__name__}"
-
+            # Atomic INCR+EXPIRE bypasses the pickled get_value/set_value
+            # layer entirely. We namespace explicitly via make_key so the
+            # keys still match frappe.cache.delete_keys('security_rate_limit:*')
+            # patterns used by test cleanup and the rest of this codebase.
+            # Raw INCR is incompatible with set_value's pickle.dumps wrapping —
+            # the two paths must never write to the same key, which is why
+            # we drop set_value/get_value here entirely.
             from frappe.utils import cint
 
-            count = cint(frappe.cache.get_value(key, use_local_cache=False) or 0)
+            logical_key = f"security_rate_limit:{frappe.session.user}:{func.__name__}"
+            namespaced_key = frappe.cache.make_key(logical_key)
 
-            if count >= limit:
+            try:
+                count = cint(frappe.cache.eval(_RATE_LIMIT_LUA, 1, namespaced_key, seconds))
+            except Exception as e:
+                # Transition guard: a pre-existing pickled value from the
+                # prior implementation (or stale state from a partial deploy)
+                # will make INCR fail with "value is not an integer". Drop
+                # the stale key and retry once. After ``seconds`` of clean
+                # traffic this branch becomes unreachable.
+                if "not an integer" in str(e):
+                    frappe.cache.delete(namespaced_key)
+                    count = cint(frappe.cache.eval(_RATE_LIMIT_LUA, 1, namespaced_key, seconds))
+                else:
+                    raise
+
+            if count > limit:
                 # Log rate limit exceeded
                 log_security_audit(
                     "Rate Limit Exceeded",
@@ -72,8 +98,6 @@ def security_rate_limit(limit=5, seconds=60):
                     _("Too many security configuration attempts. Please wait before trying again."),
                     frappe.RateLimitExceededError,
                 )
-
-            frappe.cache.set_value(key, count + 1, expires_in_sec=seconds)
 
             return func(*args, **kwargs)
 

--- a/verenigingen/tests/security/test_security_setup.py
+++ b/verenigingen/tests/security/test_security_setup.py
@@ -167,7 +167,11 @@ class TestSecurityRateLimit(VereningingenTestCase):
             frappe.init(site=site, force=True)
             frappe.local.session = frappe._dict(user=test_user)
             try:
-                barrier.wait(timeout=5)
+                # 15s (not 5s): frappe.init(force=True) × 40 workers on
+                # a slow CI shard can serialise long enough to time the
+                # barrier out, surfacing as BrokenBarrierError noise
+                # rather than a real rate-limit regression.
+                barrier.wait(timeout=15)
                 test_function()
                 with results_lock:
                     results["success"] += 1
@@ -197,6 +201,70 @@ class TestSecurityRateLimit(VereningingenTestCase):
         self.assertEqual(
             results["rate_limited"], n_threads - limit,
             f"Expected {n_threads - limit} rate-limited responses, got {results['rate_limited']}"
+        )
+
+    def test_rate_limit_transition_guard_recovers_from_pickled_value(self):
+        """Transition guard: a stale pickled value left by the prior
+        implementation must not 500 the endpoint — it should be cleared
+        and the call retried atomically. Without this regression test
+        the guard is implementation-only (no proof it actually works).
+        """
+        import pickle
+
+        @security_rate_limit(limit=2, seconds=60)
+        def test_function():
+            return "success"
+
+        # Mimic the pre-fix state: a pickled integer left in Redis by
+        # the old set_value(key, count, expires_in_sec=seconds) path.
+        # Use the same key the decorator computes.
+        namespaced_key = frappe.cache.make_key(
+            f"security_rate_limit:{frappe.session.user}:test_function"
+        )
+        frappe.cache.set(namespaced_key, pickle.dumps(1), ex=60)
+
+        # First call: INCR sees pickled bytes → ResponseError → guard
+        # deletes + retries. Retry returns 1 (clean slate). Allowed.
+        self.assertEqual(test_function(), "success")
+
+        # Second call: count=2 ≤ limit. Allowed.
+        self.assertEqual(test_function(), "success")
+
+        # Third call: count=3 > limit. Rate-limited.
+        with self.assertRaises(frappe.RateLimitExceededError):
+            test_function()
+
+    def test_rate_limit_window_does_not_slide(self):
+        """Security property: the fixed window does NOT slide.
+
+        EXPIRE runs only on the first INCR; subsequent calls within the
+        window leave TTL alone. Without this property an attacker could
+        keep their counter alive indefinitely by pacing requests just
+        under the limit each window. A regression that moves EXPIRE
+        outside the ``count == 1`` branch in the Lua script would refresh
+        TTL on every hit — this test catches that.
+        """
+        @security_rate_limit(limit=10, seconds=60)
+        def test_function():
+            return "success"
+
+        test_function()
+        namespaced_key = frappe.cache.make_key(
+            f"security_rate_limit:{frappe.session.user}:test_function"
+        )
+        ttl_after_first = frappe.cache.ttl(namespaced_key)
+        self.assertGreater(
+            ttl_after_first, 55,
+            f"Expected TTL near 60s after first INCR, got {ttl_after_first}"
+        )
+
+        time.sleep(2.1)
+        test_function()
+        ttl_after_second = frappe.cache.ttl(namespaced_key)
+        self.assertLess(
+            ttl_after_second, ttl_after_first - 1,
+            f"TTL slid: first={ttl_after_first}, second={ttl_after_second}. "
+            f"EXPIRE must not refresh on subsequent INCRs."
         )
 
 

--- a/verenigingen/tests/security/test_security_setup.py
+++ b/verenigingen/tests/security/test_security_setup.py
@@ -118,18 +118,86 @@ class TestSecurityRateLimit(VereningingenTestCase):
         @security_rate_limit(limit=1, seconds=1)  # 1 second expiration
         def test_function():
             return "success"
-        
+
         # Hit limit
         test_function()
         with self.assertRaises(frappe.RateLimitExceededError):
             test_function()
-        
+
         # Wait for expiration
         time.sleep(1.1)
-        
+
         # Should work again
         result = test_function()
         self.assertEqual(result, "success")
+
+    def test_rate_limit_concurrent_requests_respect_limit(self):
+        """TOCTOU regression: concurrent calls must not exceed the configured limit.
+
+        Pre-fix: ``security_rate_limit`` was check-then-set
+        (``get_value`` → branch → ``set_value``). N workers reading the
+        same count below ``limit`` simultaneously all proceeded — effective
+        ceiling became ``limit + (N-1)``. This test fires ``n_threads``
+        workers through a barrier and asserts exactly ``limit`` succeed.
+        With atomic INCR semantics this is guaranteed; with the old code
+        the assertion fails almost every run.
+        """
+        import threading
+
+        limit = 5
+        n_threads = 40
+        test_user = "concurrent_test@example.com"
+
+        @security_rate_limit(limit=limit, seconds=60)
+        def test_function():
+            return "success"
+
+        # frappe.local is per-thread (werkzeug.local.Local). frappe.init()
+        # is the canonical way to populate the conf/flags/message_log/lang
+        # set that frappe.throw + msgprint touch. Workers without it raise
+        # RuntimeError('object is not bound') from LocalProxy on access
+        # instead of the expected RateLimitExceededError.
+        site = frappe.local.site
+
+        barrier = threading.Barrier(n_threads)
+        results_lock = threading.Lock()
+        results = {"success": 0, "rate_limited": 0, "errors": []}
+
+        def worker():
+            frappe.init(site=site, force=True)
+            frappe.local.session = frappe._dict(user=test_user)
+            try:
+                barrier.wait(timeout=5)
+                test_function()
+                with results_lock:
+                    results["success"] += 1
+            except frappe.RateLimitExceededError:
+                with results_lock:
+                    results["rate_limited"] += 1
+            except Exception as exc:
+                with results_lock:
+                    results["errors"].append(repr(exc))
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(
+            results["errors"], [],
+            f"Unexpected worker errors: {results['errors'][:3]}"
+        )
+        self.assertEqual(
+            results["success"], limit,
+            f"TOCTOU regression: expected exactly {limit} successes under "
+            f"concurrent load of {n_threads} workers, got {results['success']}. "
+            f"Atomic INCR semantics required."
+        )
+        self.assertEqual(
+            results["rate_limited"], n_threads - limit,
+            f"Expected {n_threads - limit} rate-limited responses, got {results['rate_limited']}"
+        )
 
 
 class TestCSRFValidation(VereningingenTestCase):

--- a/verenigingen/tests/security_property_tests.py
+++ b/verenigingen/tests/security_property_tests.py
@@ -37,9 +37,16 @@ class SecurityPropertyTestCase(VereningingenTestCase):
         frappe.session.user = "test_security@example.com"
         # For admin tools security testing, we need Administrator permissions in setUp
         frappe.set_user("Administrator")  # VereningingenTestCase allows this in setUp
-    
+        # Rate-limit property tests all share the inner ``test_function`` name
+        # and ``Administrator`` as user, so they collide on the same counter
+        # key. Pre-existing failure (test_rate_limit_invariant_under_limit
+        # has been failing at Call 4 since the counter starts non-zero);
+        # mirrors the cleanup TestSecurityRateLimit already does.
+        frappe.cache.delete_keys("security_rate_limit:")
+
     def tearDown(self):
         frappe.session.user = self.original_user
+        frappe.cache.delete_keys("security_rate_limit:")
         super().tearDown()
 
 


### PR DESCRIPTION
## Summary

Closes the TOCTOU race both reviewers explicitly flagged on PR #104 (rate-limit follow-up from the prior session's handoff).

The previous `security_rate_limit` decorator was check-then-set: `get_value → branch on count < limit → set_value(count + 1)`. Under concurrent load, N workers reading the same sub-limit count all proceeded — effective ceiling became `limit + (N - 1)`. Concrete scenario: `@security_rate_limit(limit=3, seconds=300)` on `enable_csrf_protection` could be hit ~9+ times in a 5-min window from 3 parallel workers.

The fix runs `INCR + EXPIRE` server-side in Redis via a small Lua script. INCR is atomic; EXPIRE is guarded by `count == 1` so the **fixed window doesn't slide forward on every hit** — the prior `set_value` path was silently refreshing TTL on every successful increment, which let an attacker keep their counter alive indefinitely by pacing requests just under the limit each window.

## Implementation notes

- `frappe.cache` is `RedisWrapper(redis.Redis)`, so the inherited `eval()` runs Lua server-side
- Bypasses `set_value`/`get_value` because their pickling is incompatible with raw `INCR` (`pickle.dumps(1)` is not parseable as an integer by Redis)
- Namespacing is preserved by calling `frappe.cache.make_key()` explicitly — `delete_keys('security_rate_limit:*')` cleanup paths still match (verified in `redis_wrapper.py:128-140`)
- Transition guard: a one-time `ResponseError` from a pre-existing pickled value gets caught, the stale key dropped, INCR retried once. After `seconds` of clean traffic the branch is unreachable

## Behavioral change worth flagging

Under the old code, a throw branch did NOT increment the counter — the count plateaued at exactly `limit` and stayed there until TTL expired. Under the new code, throws DO increment (count grows past limit during throttle). The user-visible effect is identical: requests fail while throttled, work again after TTL. But it does change shared-key test semantics, which is why `security_property_tests.py` needed cleanup added (see below).

## Test plan

- [x] New regression test `test_rate_limit_concurrent_requests_respect_limit` (40 threads through a barrier, limit=5)
  - Pre-fix: fails with 40 successes (race confirmed)
  - Post-fix: passes with exactly 5 successes / 35 rate-limited
- [x] `bench --site veg11.veganisme.org run-tests --app verenigingen --module verenigingen.tests.security.test_security_setup` → **Ran 31 tests in 19.345s, OK (skipped=1)**
- [x] `bench --site veg11.veganisme.org run-tests --app verenigingen --module verenigingen.tests.security_property_tests` → **Ran 11 tests in 16.256s, OK** — also fixes a pre-existing failure in `test_rate_limit_invariant_under_limit` (was failing pre-change at "Call 4" due to missing cross-test cache cleanup; mirrors what `TestSecurityRateLimit.setUp` already does)

## Out of scope (deferred)

- `PermissionError` hierarchy mismatch in `utils/error_handling.py:200` (other follow-up from PR #104) — needs design pass across ~17 catch sites before touching