### PR TITLE
fix(error-handling): correct PermissionError hierarchy (HTTP 403 + isinstance)

### DIFF
--- a/verenigingen/tests/test_error_handling_hierarchy.py
+++ b/verenigingen/tests/test_error_handling_hierarchy.py
@@ -110,6 +110,46 @@ class TestPermissionErrorHierarchy(VereningingenTestCase):
         with self.assertRaises(frappe.ValidationError):
             raise VPermissionError("denied")
 
+    def test_handle_api_error_routes_through_verenigingen_branch(self):
+        """``handle_api_error`` (error_handling.py:480) catches
+        ``VerenigingenException`` BEFORE ``frappe.PermissionError``. Our
+        ``VPermissionError`` matches both, but Python evaluates except
+        clauses in order — so it still hits the VerenigingenException
+        branch, preserving the structured-error metadata path
+        (``error_code``, ``http_status`` instance attr, ``details``).
+        Without this test, a future refactor that reorders the except
+        clauses could silently change the response shape for our
+        permission errors. Senior reviewer's M2.
+        """
+        from verenigingen.utils.error_handling import handle_api_error
+
+        @handle_api_error
+        def raises_perm():
+            raise VPermissionError(
+                "Insufficient permissions",
+                error_code="MEMBER_MERGE_PERM",
+                details={"member": "MEM-001"},
+            )
+
+        result = raises_perm()
+        # OperationResult shape from the VerenigingenException branch:
+        # message = str(exc), error_code = exc.error_code (preserved),
+        # http_status = exc.http_status (403 via __init__), details
+        # carried over. NOT the generic "Access denied: ..." prefix
+        # that the frappe.PermissionError branch would inject.
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_code, "MEMBER_MERGE_PERM")
+        self.assertEqual(result.http_status, 403)
+        # The VerenigingenException branch tags errors with the actual
+        # class name. The frappe.PermissionError branch would tag
+        # ["PermissionError"] (Frappe's, not ours).
+        self.assertEqual(result.errors, ["PermissionError"])
+        # Verify the message is the raw exception text, not the
+        # "Access denied: {0}" prefix the frappe.PermissionError branch
+        # would have wrapped it in.
+        self.assertNotIn("Access denied:", result.error_message)
+        self.assertIn("Insufficient permissions", result.error_message)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/verenigingen/tests/test_error_handling_hierarchy.py
+++ b/verenigingen/tests/test_error_handling_hierarchy.py
@@ -1,0 +1,115 @@
+"""
+Regression tests for the verenigingen exception hierarchy
+=========================================================
+
+Specifically guards the ``PermissionError`` fix that closes the
+hierarchy + HTTP status mismatch documented in PR #104 / follow-up
+PR for issue 2 of the rate-limit handoff:
+
+1. The previous ``PermissionError(VerenigingenException)`` inherited
+   ``http_status_code = 417`` from ``frappe.ValidationError`` and
+   ``isinstance(e, frappe.PermissionError)`` returned False.
+2. ``self.http_status = 403`` on the instance was dead — Frappe reads
+   the class attribute ``http_status_code`` via ``app.py:346``.
+
+The fix multi-inherits from ``frappe.PermissionError`` and sets the
+class attribute. These tests pin both properties so a future refactor
+of the hierarchy can't silently regress either.
+"""
+
+import unittest
+
+import frappe
+
+from verenigingen.tests.utils.base import VereningingenTestCase
+from verenigingen.utils.error_handling import (
+    ConfigurationError,
+    PermissionError as VPermissionError,
+    ValidationError as VValidationError,
+    VerenigingenException,
+)
+
+
+class TestPermissionErrorHierarchy(VereningingenTestCase):
+    """Pins the PermissionError MRO so the HTTP status + isinstance
+    contracts can't silently regress."""
+
+    def test_http_status_code_is_403_not_417(self):
+        """Frappe reads exc.http_status_code (class attribute) via
+        ``apps/frappe/frappe/app.py:346`` — must be 403, not the 417
+        inherited via frappe.ValidationError."""
+        exc = VPermissionError("Access denied")
+        # Class attribute, matching what Frappe's getattr() reads.
+        self.assertEqual(exc.http_status_code, 403)
+        # Also accessible via the class itself (no instance needed).
+        self.assertEqual(VPermissionError.http_status_code, 403)
+
+    def test_isinstance_frappe_permission_error_true(self):
+        """except frappe.PermissionError sites (Frappe core uses this
+        in client.py:488, permissions.py:892; this codebase has 24+
+        such sites) must now catch our exception."""
+        exc = VPermissionError("Access denied")
+        self.assertIsInstance(exc, frappe.PermissionError)
+
+    def test_isinstance_frappe_validation_error_still_true(self):
+        """Back-compat: existing ``except frappe.ValidationError`` sites
+        that previously caught our PermissionError (via
+        VerenigingenException → frappe.ValidationError) must continue to.
+        We don't want silent breakage of broad catch sites."""
+        exc = VPermissionError("Access denied")
+        self.assertIsInstance(exc, frappe.ValidationError)
+
+    def test_isinstance_verenigingen_exception_still_true(self):
+        """Back-compat: ``except VerenigingenException`` at
+        error_handling.py:455 (and aliases like VPermissionError /
+        VerenigingenPermissionError used across security modules) must
+        keep catching."""
+        exc = VPermissionError("Access denied")
+        self.assertIsInstance(exc, VerenigingenException)
+
+    def test_other_subclasses_still_417(self):
+        """Targeted fix: only PermissionError gets 403. ValidationError
+        and other VerenigingenException subclasses must keep their
+        inherited 417 from frappe.ValidationError."""
+        # ValidationError and ConfigurationError both inherit http_status_code
+        # from frappe.ValidationError (the base of VerenigingenException).
+        self.assertEqual(VValidationError("x").http_status_code, 417)
+        self.assertEqual(ConfigurationError("x").http_status_code, 417)
+
+    def test_validation_error_is_not_frappe_permission_error(self):
+        """Targeted fix: only PermissionError gains the
+        frappe.PermissionError lineage. ValidationError stays a pure
+        ValidationError so its catch-routing doesn't change."""
+        exc = VValidationError("x")
+        self.assertNotIsInstance(exc, frappe.PermissionError)
+
+    def test_metadata_attributes_preserved(self):
+        """The fix must not break the structured-error metadata that
+        VerenigingenException provides (error_code, http_status,
+        details). These power the API response and audit logging
+        layers."""
+        exc = VPermissionError(
+            message="Cannot edit national board",
+            error_code="CHAPTER_BOARD_NATIONAL",
+            details={"user": "test@example.com", "chapter": "national"},
+        )
+        self.assertEqual(exc.error_code, "CHAPTER_BOARD_NATIONAL")
+        self.assertEqual(exc.http_status, 403)  # instance attr, separate from http_status_code
+        self.assertEqual(exc.details, {"user": "test@example.com", "chapter": "national"})
+
+    def test_raise_and_catch_via_frappe_permission_error(self):
+        """End-to-end: raising VPermissionError and catching as
+        frappe.PermissionError works. This is the primary behavior
+        change the fix enables."""
+        with self.assertRaises(frappe.PermissionError):
+            raise VPermissionError("denied")
+
+    def test_raise_and_catch_via_frappe_validation_error_back_compat(self):
+        """End-to-end back-compat: existing catch-as-ValidationError
+        sites still fire."""
+        with self.assertRaises(frappe.ValidationError):
+            raise VPermissionError("denied")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verenigingen/utils/error_handling.py
+++ b/verenigingen/utils/error_handling.py
@@ -197,8 +197,33 @@ class ChapterError(VerenigingenException):
         )
 
 
-class PermissionError(VerenigingenException):
-    """Raised when user lacks required permissions"""
+class PermissionError(VerenigingenException, frappe.PermissionError):
+    """Raised when user lacks required permissions.
+
+    Multi-inherits from both:
+      * ``VerenigingenException`` — for structured error metadata + the
+        existing ``except VerenigingenException`` catch site at
+        ``error_handling.py:455``.
+      * ``frappe.PermissionError`` — so ``except frappe.PermissionError``
+        (used in Frappe core at ``client.py:488``, ``permissions.py:892``
+        and 6+ sites in this codebase) actually catches our exception.
+        Previously only inherited from ``frappe.ValidationError`` via
+        ``VerenigingenException``, which routed permission denials to
+        the wrong branch and wrong HTTP status.
+
+    The explicit ``http_status_code = 403`` overrides the 417 inherited
+    via ``VerenigingenException → frappe.ValidationError``. Frappe's
+    request handler (``apps/frappe/frappe/app.py:346``) reads the class
+    attribute via ``getattr(e, "http_status_code", 500)`` to set the
+    response code. The previous ``self.http_status = 403`` (instance
+    attribute, different name) was dead code — Frappe never reads it.
+
+    Catches ``isinstance(e, frappe.ValidationError)`` is still True via
+    the MRO, so ``except frappe.ValidationError`` sites that previously
+    caught us continue to do so unchanged.
+    """
+
+    http_status_code = 403
 
     def __init__(
         self,

--- a/verenigingen/utils/error_handling.py
+++ b/verenigingen/utils/error_handling.py
@@ -202,25 +202,32 @@ class PermissionError(VerenigingenException, frappe.PermissionError):
 
     Multi-inherits from both:
       * ``VerenigingenException`` — for structured error metadata + the
-        existing ``except VerenigingenException`` catch site at
-        ``error_handling.py:455``.
+        existing ``except VerenigingenException`` catch site in
+        ``handle_api_error`` (``error_handling.py:480``).
       * ``frappe.PermissionError`` — so ``except frappe.PermissionError``
         (used in Frappe core at ``client.py:488``, ``permissions.py:892``
         and 6+ sites in this codebase) actually catches our exception.
         Previously only inherited from ``frappe.ValidationError`` via
         ``VerenigingenException``, which routed permission denials to
-        the wrong branch and wrong HTTP status.
+        the wrong branch and wrong HTTP status at the transport layer.
+
+    Both parents have empty ``__init__`` (just bare ``pass``), so there
+    is no cooperative-inheritance hazard — ``super().__init__()`` chains
+    cleanly through ``VerenigingenException`` to ``Exception``.
 
     The explicit ``http_status_code = 403`` overrides the 417 inherited
     via ``VerenigingenException → frappe.ValidationError``. Frappe's
     request handler (``apps/frappe/frappe/app.py:346``) reads the class
     attribute via ``getattr(e, "http_status_code", 500)`` to set the
     response code. The previous ``self.http_status = 403`` (instance
-    attribute, different name) was dead code — Frappe never reads it.
+    attribute, *different name*) was never read by Frappe — it was only
+    consumed inside ``handle_api_error`` below. Both attributes coexist
+    and both now resolve to 403; the class attribute is what fixes the
+    HTTP response on uncaught raises.
 
-    Catches ``isinstance(e, frappe.ValidationError)`` is still True via
-    the MRO, so ``except frappe.ValidationError`` sites that previously
-    caught us continue to do so unchanged.
+    ``isinstance(e, frappe.ValidationError)`` is still True via the MRO,
+    so ``except frappe.ValidationError`` sites that previously caught
+    us continue to do so unchanged.
     """
 
     http_status_code = 403

--- a/verenigingen/utils/exceptions.py
+++ b/verenigingen/utils/exceptions.py
@@ -165,6 +165,20 @@ class PermissionError(VerenigingenError):
     Examples:
         >>> raise PermissionError("approve_application", "Member")
         >>> raise PermissionError("delete", "Chapter", user=current_user)
+
+    FIXME: This class has the same hierarchy bugs that PR #107 fixed in
+    ``verenigingen.utils.error_handling.PermissionError`` — it extends
+    ``VerenigingenError(Exception)`` directly, so ``isinstance(e,
+    frappe.PermissionError)`` is False, and ``http_status_code = 403``
+    is set as an instance attribute (Frappe's transport layer reads
+    the class attribute via ``app.py:346``). Currently zero production
+    callers import this class, so the bugs are latent. If a caller is
+    ever added, also multi-inherit from ``frappe.PermissionError`` and
+    promote ``http_status_code`` to a class attribute. Separate
+    constructor signature (``(operation, resource)`` vs ``(message,
+    error_code, ...)``) and separate ``VerenigingenError`` root mean
+    consolidating with ``error_handling.PermissionError`` is its own
+    refactor — out of scope for #107.
     """
 
     def __init__(self, operation: str, resource: str, **kwargs: Any):


### PR DESCRIPTION
## Summary

Closes the second follow-up from PR #104's review (the first was the rate-limit TOCTOU race, merged as #106). Fixes two related bugs in ``verenigingen.utils.error_handling.PermissionError``:

1. **HTTP 417 → 403.** Frappe's request handler reads ``getattr(e, ""http_status_code"", 500)`` (`apps/frappe/frappe/app.py:346`) to set the response code. Our ``PermissionError`` inherited 417 from ``frappe.ValidationError`` via ``VerenigingenException`` and never overrode it. The existing ``self.http_status = 403`` was dead — wrong attribute name (``http_status`` vs ``http_status_code``).
2. **isinstance hierarchy.** ``isinstance(e, frappe.PermissionError)`` was False. ``except frappe.PermissionError`` catch sites in Frappe core (`client.py:488`, `permissions.py:892`) and 24+ sites in this codebase silently missed our exception.

## Fix

Multi-inherit from ``frappe.PermissionError`` (in addition to the existing ``frappe.ValidationError`` lineage via ``VerenigingenException``) and add ``http_status_code = 403`` as an explicit class attribute.

```python
class PermissionError(VerenigingenException, frappe.PermissionError):
    http_status_code = 403  # overrides 417 inherited via VerenigingenException
    ...
```

``isinstance(e, frappe.ValidationError)`` stays True via MRO, so existing back-compat is preserved.

## Cascade audit

Audited all 18 production files that catch ``frappe.PermissionError`` or ``frappe.ValidationError``:

- **TYPE 2 (routing-change)**: 4 files. All route our exception from a generic ValidationError branch into a dedicated PermissionError branch — strictly more semantically correct labeling.
- **TYPE 3 (improvement)**: 6 files. ``except frappe.PermissionError`` blocks that previously missed our exception now catch correctly.
- **TYPE 1 (unchanged)**: 8 files. ValidationError catches first or PermissionError is absent.
- **TYPE 4 (tuple)**: 3 files. Already caught both.

**No catch-site adjustments required** — all routing changes are improvements.

## Test plan

- [x] 9 new regression tests in ``test_error_handling_hierarchy.py`` pin the contract:
  - ``http_status_code == 403`` (class attribute, what Frappe reads)
  - ``isinstance(exc, frappe.PermissionError)`` — True (new contract)
  - ``isinstance(exc, frappe.ValidationError)`` — True (back-compat)
  - ``isinstance(exc, VerenigingenException)`` — True (back-compat)
  - ``ValidationError`` and ``ConfigurationError`` stay at 417 (targeted fix)
  - ``ValidationError`` is **NOT** a ``frappe.PermissionError`` (targeted fix)
  - Metadata (``error_code``, ``http_status`` instance attr, ``details``) preserved
  - End-to-end raise + catch via ``frappe.PermissionError`` works
  - End-to-end raise + catch via ``frappe.ValidationError`` back-compat works
- [x] Tests verified against pre-fix code: 2 failures + 1 error (the exact contracts the fix introduces)
- [x] ``bench run-tests --module verenigingen.tests.test_error_handling_hierarchy``: **Ran 9, OK**
- [x] ``bench run-tests --module verenigingen.tests.security.test_security_setup`` (imports ``VPermissionError``): **Ran 33, OK skipped=1**
- [x] ``bench run-tests --module verenigingen.tests.security_property_tests``: **Ran 11, OK**

### Note on broader test runs

Some other test modules locally fail with a pre-existing ``ImportError: Module import failed for BOM Secondary Item`` during ERPNext test record creation. This affects ``test_member_merge``, ``test_security_modules``, etc., and is unrelated to this PR (PR #106 had the same issue locally but CI passed). Relying on CI to exercise the broader suite.

## Out of scope (separately ticketable)

- ``verenigingen/utils/exceptions.py`` defines a SECOND parallel ``PermissionError`` class (``VerenigingenError → Exception`` root). Same conceptual debt but separate hierarchy.