### PR TITLE
fix(tests): drain ALL committed inserts in tearDown (order-independence)

### DIFF
--- a/verenigingen/tests/fixtures/enhanced_test_factory.py
+++ b/verenigingen/tests/fixtures/enhanced_test_factory.py
@@ -1546,6 +1546,106 @@ class EnhancedTestCase(FrappeTestCase):
         # RATE LIMIT MOCKING: Bypass rate limiting in tests using proper mocking
         self._setup_rate_limit_mocking()
 
+        # GLOBAL INSERT CAPTURE: record every document inserted from here on, so
+        # tearDown can drain committed survivors the factory tracker misses —
+        # raw `frappe.get_doc(...).insert()` + `frappe.db.commit()` in test bodies
+        # are the dominant source of order-dependent cross-test pollution (a record
+        # leaked by an earlier test fails a later one depending on shard/order).
+        # Installed AFTER shared master-data setup above so that data is NOT
+        # captured/drained (it must persist across methods). addCleanup guarantees
+        # the patch is removed even if the test errors.
+        self._captured_inserts = []
+        self._install_insert_capture()
+        self.addCleanup(self._uninstall_insert_capture)
+
+    def _install_insert_capture(self):
+        """Monkey-patch Document.db_insert to record (doctype, name) of every insert.
+
+        Bulletproof: the real insert runs first and its result is returned
+        unconditionally; capture is best-effort in a try/except so a capture bug
+        can never break an insert (this wrapper runs for EVERY insert in the test).
+        """
+        import frappe.model.document as _docmod
+
+        self._orig_db_insert = _docmod.Document.db_insert
+        captured = self._captured_inserts
+        orig = self._orig_db_insert
+
+        def _capturing_db_insert(doc, *args, **kwargs):
+            result = orig(doc, *args, **kwargs)
+            try:
+                if doc.doctype and doc.name:
+                    captured.append((doc.doctype, doc.name))
+            except Exception:
+                pass
+            return result
+
+        _docmod.Document.db_insert = _capturing_db_insert
+
+    def _uninstall_insert_capture(self):
+        try:
+            import frappe.model.document as _docmod
+
+            if getattr(self, "_orig_db_insert", None) is not None:
+                _docmod.Document.db_insert = self._orig_db_insert
+                self._orig_db_insert = None
+        except Exception:
+            pass
+
+    def _drain_captured_inserts(self):
+        """Delete committed records captured by the insert hook that the factory
+        tracker did not already drain. Mirrors _drain_tracked_documents' safety:
+        rollback first, force-delete each (swallowing per-doc errors), commit so
+        the deletions persist. Deletes in REVERSE creation order so dependents go
+        before their dependencies (e.g. Customer before its Member).
+        """
+        captured = getattr(self, "_captured_inserts", None)
+        if not captured:
+            return
+
+        # Reverse creation order, deduped, preserving first (latest) occurrence.
+        seen = set()
+        ordered = []
+        for key in reversed(captured):
+            if key in seen:
+                continue
+            seen.add(key)
+            ordered.append(key)
+
+        # Clear immediately so a partial failure can't re-drive the same set.
+        self._captured_inserts = []
+
+        try:
+            frappe.db.rollback()
+        except Exception as e:
+            frappe.logger().warning(f"Captured-insert drain pre-rollback failed (skipping): {e}")
+            return
+
+        delete_failures = 0
+        for doctype, name in ordered:
+            try:
+                if not frappe.db.exists(doctype, name):
+                    continue
+                frappe.delete_doc(doctype, name, force=True, ignore_permissions=True)
+            except frappe.DoesNotExistError:
+                pass
+            except Exception:
+                # Most leftovers (links, docstatus, before_delete hooks) are handled
+                # by the broader factory drain or simply persist as today; don't let
+                # one failure abort the rest or break tearDown.
+                delete_failures += 1
+
+        try:
+            frappe.db.commit()
+        except Exception as e:
+            frappe.logger().warning(f"Captured-insert drain commit failed: {e}")
+
+        if delete_failures:
+            frappe.logger().warning(
+                f"Captured-insert drain: {delete_failures} record(s) could not be deleted "
+                f"(may persist as orphans; usually link/docstatus constraints)."
+            )
+
     def tearDown(self):
         """
         Clean up test environment with per-method transaction rollback.
@@ -1610,6 +1710,15 @@ class EnhancedTestCase(FrappeTestCase):
             self._drain_tracked_documents()
         except Exception as e:
             frappe.logger().warning(f"Tracked doc drain failed in tearDown: {e}")
+
+        # DRAIN CAPTURED INSERTS: catch committed records the factory tracker missed
+        # (raw frappe inserts / production-code inserts). This is what makes failures
+        # order-INDEPENDENT — without it a leaked record fails a later test depending
+        # on shard split / execution order.
+        try:
+            self._drain_captured_inserts()
+        except Exception as e:
+            frappe.logger().warning(f"Captured-insert drain failed in tearDown: {e}")
 
         # SETTINGS RESTORATION: Restore Verenigingen Settings to original values
         # This undoes changes made by _ensure_verenigingen_settings() which commits

--- a/verenigingen/tests/fixtures/enhanced_test_factory.py
+++ b/verenigingen/tests/fixtures/enhanced_test_factory.py
@@ -1564,6 +1564,20 @@ class EnhancedTestCase(FrappeTestCase):
         Bulletproof: the real insert runs first and its result is returned
         unconditionally; capture is best-effort in a try/except so a capture bug
         can never break an insert (this wrapper runs for EVERY insert in the test).
+
+        Scope/limits (this SUBSTANTIALLY REDUCES, but does not fully guarantee,
+        order-independence):
+        - Does NOT capture rows created via frappe.db.bulk_insert, raw
+          frappe.db.sql("INSERT ..."), or Singles writes (update_single via
+          set_value/.save() — those don't go through Document.db_insert).
+        - Captures only inserts AFTER install (end of setUp), so shared
+          master/setup data created earlier (incl. setUpClass) is preserved.
+        - Over-deletion caveat: a record created by PRODUCTION code inside a test
+          body that is meant to be shared/persistent would also be force-deleted at
+          tearDown. This is inherent to "drain everything inserted"; the proper
+          long-term fix is for tests to create such records via the tracked factory
+          rather than raw inserts. Deletions swallow all errors and never fail
+          tearDown.
         """
         import frappe.model.document as _docmod
 
@@ -1665,6 +1679,12 @@ class EnhancedTestCase(FrappeTestCase):
         The class-level cleanup (_cleanup_stale_test_data) still runs to catch any
         records that escaped rollback due to explicit db.commit() calls in code.
         """
+        # Stop capturing FIRST, so the drains below (rollback/delete/commit) and any
+        # framework bookkeeping they emit (e.g. "Deleted Document" rows, which are
+        # meant to persist) are not captured. addCleanup also calls this as an
+        # idempotent backstop.
+        self._uninstall_insert_capture()
+
         # EMAIL MOCKING CLEANUP: Stop all email patches
         try:
             # Stop comprehensive email patches

--- a/verenigingen/tests/test_enhanced_test_factory_drain.py
+++ b/verenigingen/tests/test_enhanced_test_factory_drain.py
@@ -155,3 +155,38 @@ class TestDrainTrackedDocuments(EnhancedTestCase):
             d for d in self.factory.core.created_records
             if not (d['doctype'] == "ToyDoc" and d['name'] == "X")
         ]
+
+
+class TestCapturedInsertDrain(EnhancedTestCase):
+    """Regression: committed records created via RAW frappe inserts (not the
+    factory) must be drained at tearDown, so they don't leak into later tests
+    and cause order-dependent failures. See
+    docs/plans/2026-05-29-server-tests-red-baseline-triage.md (isolation root cause).
+    """
+
+    def test_raw_committed_insert_is_captured_and_drained(self):
+        import frappe
+
+        name = f"Drain Probe Customer {self.uid}"
+        # Raw insert + COMMIT — bypasses factory tracking and survives rollback.
+        cust = frappe.get_doc(
+            {"doctype": "Customer", "customer_name": name, "customer_type": "Individual"}
+        )
+        cust.insert(ignore_permissions=True)
+        frappe.db.commit()
+        created = cust.name
+
+        self.assertTrue(frappe.db.exists("Customer", created), "precondition: customer committed")
+        self.assertIn(
+            ("Customer", created),
+            self._captured_inserts,
+            "raw insert should be captured by the global insert hook",
+        )
+
+        # Invoke the drain directly (tearDown runs it too).
+        self._drain_captured_inserts()
+
+        self.assertFalse(
+            frappe.db.exists("Customer", created),
+            "captured committed record must be drained (else it leaks into later tests)",
+        )

--- a/verenigingen/tests/test_enhanced_test_factory_drain.py
+++ b/verenigingen/tests/test_enhanced_test_factory_drain.py
@@ -190,3 +190,15 @@ class TestCapturedInsertDrain(EnhancedTestCase):
             frappe.db.exists("Customer", created),
             "captured committed record must be drained (else it leaks into later tests)",
         )
+
+    def test_singles_setvalue_is_not_captured(self):
+        # Documents the known limit: Singles writes (update_single via set_value)
+        # don't go through Document.db_insert, so they're neither captured nor
+        # drained — correct, since Settings must persist / are restored separately.
+        # Guards against a future change that would wrongly drain them.
+        import frappe
+
+        before = list(self._captured_inserts)
+        frappe.db.set_value("System Settings", "System Settings", "language", "en")
+        new = [k for k in self._captured_inserts if k not in before]
+        self.assertEqual(new, [], "Singles set_value must not be captured as an insert")


### PR DESCRIPTION
## Root cause (the bedrock both #113 and #114 hit)

The Server Tests suite's failures are **order/split-dependent**: a record leaked by one test fails a later test, and *which* tests collide changes whenever the per-file shard split changes (e.g. adding a test file). PR #114's own CI proved this — adding one test file produced 322 false "NEW" failures. This sinks both the bucket-sweep (#113) and the no-new gate (#114).

## Why the existing drain (PR #79) wasn't enough

It only deletes **factory-tracked** documents. But cascade test files create records via raw `frappe.get_doc().insert()` + `frappe.db.commit()` and via production code paths — those aren't tracked, survive rollback, and pollute later tests.

## Fix

`EnhancedTestCase` now captures **every** document inserted during a test via a bulletproof `Document.db_insert` wrapper (installed after shared master-data setup so that data persists; uninstalled at the start of tearDown + `addCleanup` backstop), and drains the committed survivors at tearDown — rollback → force-delete in reverse creation order → commit — mirroring `_drain_tracked_documents`' safety (all errors swallowed; never breaks tearDown).

The wrapper runs the real insert first and returns it unconditionally; capture is best-effort in try/except, so it can never break an insert.

## Scope / limits (substantially reduces, doesn't fully guarantee, order-independence)

Does not capture `frappe.db.bulk_insert`, raw `INSERT` SQL, or Singles (`update_single`/`set_value`) writes. Over-deletion caveat: a record created by production code *inside a test body* that's meant to be shared would also be drained — proper long-term fix is using the tracked factory. Both documented in code.

## Review & verification

Skeptical-reviewed; addressed all findings (drain-time-capture aliasing fixed by uninstalling before drain; claims softened; uncaptured paths + over-deletion documented; negative test added). Verified locally: a raw+committed Customer is captured and drained; **all 7 drain-module tests pass** (existing factory-drain behavior intact, no double-delete).

**Aggregate effect (does the suite's failure set shrink + become order-stable?) is validated in CI** via union `comm`-diff vs develop — this branch only modifies existing files, so the shard split matches develop, making the comparison clean.