### PR TITLE
fix(tests): stop builtins.open mock from hanging shard 1 (mimetypes OOM)

### DIFF
--- a/verenigingen/tests/backend/components/test_payment_processing_api.py
+++ b/verenigingen/tests/backend/components/test_payment_processing_api.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 import frappe
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
 from frappe.utils import today, add_days
 
@@ -303,35 +303,31 @@ class TestPaymentProcessingAPI(EnhancedTestCase):
 
     def test_export_overdue_payments_success_real_logic(self):
         """Test successful payment data export using REAL business logic"""
-        # Mock only infrastructure (physical file operations) - not business logic
-        with patch("builtins.open", create=True) as mock_open:
-            with patch("csv.DictWriter") as mock_csv_writer:
-                # Use REAL overdue payment data from our test setup
-                # Let the export function handle file creation naturally
-                result = export_overdue_payments(
-                    filters=json.dumps({"chapter": "Amsterdam"})
-                )
+        # Do NOT mock builtins.open. The export creates a File document whose before_insert
+        # calls mimetypes.guess_type(); under a global open() mock, mimetypes.readfp() loops
+        # forever on a truthy MagicMock, ballooning memory until the CI runner is killed
+        # (SIGTERM 143). Let the export write a real CSV to a tempdir (cheap, real).
+        result = export_overdue_payments(
+            filters=json.dumps({"chapter": "Amsterdam"})
+        )
 
-                # Verify successful export with real data
-                if result.get("success"):
-                    self.assertGreaterEqual(result["count"], 1)  # Should find our test member
-                    self.assertIn("Export completed", result["message"])
-                    self.assertIn("file_url", result)
-                    # Verify infrastructure mocks were called (CSV writing)
-                    mock_open.assert_called()
-                    mock_csv_writer.assert_called()
-                else:
-                    # Real business logic may return different messages for no data
-                    message = result.get("message", result.get("error", {}).get("message", ""))
-                    # Accept various real business logic responses for no data
-                    is_valid_no_data = (
-                        "no data" in message.lower() or
-                        "export" in message.lower() or
-                        "invalid" in message.lower() or
-                        message == ""
-                    )
-                    self.assertTrue(is_valid_no_data or not result.get("success", True),
-                                  f"Real business logic should handle no data appropriately, got: {message}")
+        # Verify successful export with real data
+        if result.get("success"):
+            self.assertGreaterEqual(result["count"], 1)  # Should find our test member
+            self.assertIn("Export completed", result["message"])
+            self.assertIn("file_url", result)
+        else:
+            # Real business logic may return different messages for no data
+            message = result.get("message", result.get("error", {}).get("message", ""))
+            # Accept various real business logic responses for no data
+            is_valid_no_data = (
+                "no data" in message.lower() or
+                "export" in message.lower() or
+                "invalid" in message.lower() or
+                message == ""
+            )
+            self.assertTrue(is_valid_no_data or not result.get("success", True),
+                          f"Real business logic should handle no data appropriately, got: {message}")
 
     def test_export_overdue_payments_no_data_real_logic(self):
         """Test export with no data using REAL business logic"""

--- a/verenigingen/tests/backend/components/test_payment_processing_api_real.py
+++ b/verenigingen/tests/backend/components/test_payment_processing_api_real.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 import frappe
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from verenigingen.tests.fixtures.enhanced_test_factory import EnhancedTestCase
 from frappe.utils import today, add_days
 
@@ -234,33 +234,36 @@ class TestPaymentProcessingAPIReal(EnhancedTestCase):
             custom_member=self.overdue_member.name
         )
         
-        # Mock only file system operations (infrastructure)
-        with patch("builtins.open", create=True) as mock_open:
-            with patch("csv.DictWriter") as mock_csv_writer:
-                # Use REAL file document creation instead of mocking frappe.get_doc
-                try:
-                    # Create real file document in database
-                    file_doc = frappe.get_doc({
-                        "doctype": "File",
-                        "file_name": f"test_export_{frappe.utils.random_string(6)}.csv",
-                        "is_private": 0,
-                        "content": "test,content"  # Minimal content for testing
-                    })
-                    file_doc.insert()
-                    
-                    # Test export with real business logic and real file document
-                    result = export_overdue_payments(
-                        filters=json.dumps({"chapter": "Amsterdam"})
-                    )
-                    
-                    # Verify real business logic created real file
-                    self.assertIsInstance(result, dict, "Should return result from real business logic")
-                    if result.get("success"):
-                        self.assertIn("file_url", result, "Should include real file URL")
-                        
-                except Exception as e:
-                    # If file creation fails, test should handle gracefully
-                    self.assertTrue(True, f"Real business logic handled file creation appropriately: {str(e)}")
+        # Do NOT mock builtins.open here. Creating a File document (below and inside the
+        # export) runs File.before_insert -> set_file_type -> mimetypes.guess_type(), which
+        # lazily open()s the system mime DB. Under a global open() mock, mimetypes.readfp()
+        # ("while 1: line = fp.readline(); if not line: break") never terminates because the
+        # MagicMock readline() is always truthy -> infinite loop that balloons memory until
+        # the CI runner is reclaimed (SIGTERM 143). A "real business logic" test must use
+        # real file I/O (a small CSV in a tempdir); it is cheap.
+        try:
+            # Create real file document in database
+            file_doc = frappe.get_doc({
+                "doctype": "File",
+                "file_name": f"test_export_{frappe.utils.random_string(6)}.csv",
+                "is_private": 0,
+                "content": "test,content"  # Minimal content for testing
+            })
+            file_doc.insert()
+
+            # Test export with real business logic and real file document
+            result = export_overdue_payments(
+                filters=json.dumps({"chapter": "Amsterdam"})
+            )
+
+            # Verify real business logic created real file
+            self.assertIsInstance(result, dict, "Should return result from real business logic")
+            if result.get("success"):
+                self.assertIn("file_url", result, "Should include real file URL")
+
+        except Exception as e:
+            # If file creation fails, test should handle gracefully
+            self.assertTrue(True, f"Real business logic handled file creation appropriately: {str(e)}")
 
     def test_export_overdue_payments_file_error_real_logic(self):
         """Test export with file errors using REAL business logic"""

--- a/verenigingen/tests/backend/integration/test_payment_report_integration.py
+++ b/verenigingen/tests/backend/integration/test_payment_report_integration.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import frappe
 from frappe.utils import add_days, today
@@ -288,48 +288,42 @@ class TestPaymentReportIntegration(EnhancedTestCase):
         """
         from verenigingen.api.payment_processing import export_overdue_payments
         
-        # Mock file operations (infrastructure - keeping file system mocks)
-        with patch("builtins.open", create=True) as mock_open:
-            with patch("csv.DictWriter") as mock_csv_writer:
-                # Test export with real database operations - no frappe.get_doc mocking
-                # Create real file document for export testing if needed
-                test_file_doc = None
-                try:
-                    # Only create file doc if export function actually needs it
-                    # This tests real file creation workflow without mocking database operations
-                    test_file_doc = frappe.get_doc({
-                        "doctype": "File",
-                        "file_name": "payment_export_test.csv",
-                        "file_url": "/files/payment_export_test.csv",
-                        "is_private": 0
-                    })
-                    test_file_doc.insert()
-                    self.track_doc("File", test_file_doc.name)
-                except Exception as e:
-                    # If File DocType creation fails, continue without it
-                    # The export function should handle missing file docs gracefully
-                    print(f"Note: Could not create test File doc: {e}")
-                    
-                # Execute export workflow with REAL database operations
-                result = export_overdue_payments(
-                    filters={},  # No specific filters - tests real data retrieval
-                    format="CSV"
-                )
+        # Do NOT mock builtins.open. Creating a File document (here and inside the export)
+        # runs File.before_insert -> mimetypes.guess_type(), which loops forever under a
+        # global open() mock (truthy MagicMock readline()), ballooning memory until the CI
+        # runner is killed (SIGTERM 143). Exercise the real file-creation workflow.
+        test_file_doc = None
+        try:
+            # Only create file doc if export function actually needs it
+            # This tests real file creation workflow without mocking database operations
+            test_file_doc = frappe.get_doc({
+                "doctype": "File",
+                "file_name": "payment_export_test.csv",
+                "file_url": "/files/payment_export_test.csv",
+                "is_private": 0
+            })
+            test_file_doc.insert()
+            self.track_doc("File", test_file_doc.name)
+        except Exception as e:
+            # If File DocType creation fails, continue without it
+            # The export function should handle missing file docs gracefully
+            print(f"Note: Could not create test File doc: {e}")
 
-                # Verify export completion with real business logic
-                self.assertIsInstance(result, dict)
-                self.assertTrue("success" in result)
-                self.assertTrue("count" in result)
+        # Execute export workflow with REAL database operations
+        result = export_overdue_payments(
+            filters={},  # No specific filters - tests real data retrieval
+            format="CSV"
+        )
 
-                if result["success"]:
-                    print(f"✅ Real export workflow successful - {result['count']} records exported")
+        # Verify export completion with real business logic
+        self.assertIsInstance(result, dict)
+        self.assertTrue("success" in result)
+        self.assertTrue("count" in result)
 
-                    # Verify file operations with real data
-                    if result["count"] > 0:
-                        # CSV writer should be called with real payment data
-                        self.assertTrue(mock_csv_writer.called or mock_open.called)
-                else:
-                    print("ℹ️ Export found no data - may be expected with test scenarios")
+        if result["success"]:
+            print(f"✅ Real export workflow successful - {result['count']} records exported")
+        else:
+            print("ℹ️ Export found no data - may be expected with test scenarios")
 
     @patch("frappe.sendmail")  # Mock justified: External Service - email infrastructure, not business logic
     def test_complete_bulk_action_workflow_real_business_logic(self, mock_sendmail):


### PR DESCRIPTION
## Problem
Server Tests **shard 1** has been dying every run since the #113/#114/#115 merges — `Run Tests` step killed with **exit 143 (SIGTERM), "the runner has received a shutdown signal"** at ~8.5–14 min, which skips the gate and blocks the baseline regeneration. It looked like random GitHub-hosted-runner infra flakiness, but it is **deterministic**.

## Root cause (found via faulthandler stack-dump repro)
Three payment-export tests wrap a `File.insert` / `export_overdue_payments` call in a global `patch("builtins.open", create=True)`. The chain:

```
File.insert → before_insert → set_file_type → mimetypes.guess_type()
  → mimetypes.init() → read() → readfp()   ← while 1: line = fp.readline(); if not line: break
```

`mimetypes.readfp()` reads the system mime DB via `open()`. Under the mock, `fp.readline()` returns a **truthy MagicMock**, so `if not line: break` never fires → **infinite loop** spawning a new child MagicMock each iteration → memory balloons until the runner VM is reclaimed (SIGTERM 143). `|| true` can't catch it because the *runner itself* is killed.

**Why now / why shard 1:** `mimetypes` caches after first `init()`, so the hang only fires when *no earlier test in the shard* initialized it. The merges shifted Frappe's per-file split so this module landed on shard 1 where it wasn't pre-initialized. Same "split-dependent" theme as the isolation work — but a memory cliff, not record pollution. Wall-clock varied (8 vs 14 min) while the death *position* was identical — the signature of a memory-bound infinite loop, not a time-based lease.

## Decisive experiment
Reproduced locally: `File.insert()` under `patch("builtins.open")` hangs indefinitely (killed at 75 s); the faulthandler dump pinned it to `mimetypes.readfp`. With the mock removed, the path is the normal production path — no hang.

## Fix
Remove the `builtins.open` / `csv.DictWriter` mocks (infrastructure mocking the repo's own `block-inappropriate-mocks` hook forbids) and let the exports do real file I/O (a small CSV in a tempdir — cheap). The tests **remain pre-existing baseline failures** (they assert `result` is a `dict`, but the endpoints return an `OperationResult`) — but now **fail fast instead of hanging**, so shard 1 completes and the baseline can be regenerated.

The two *safe* `builtins.open` patterns elsewhere are intentionally left alone: `side_effect=Exception` (open raises immediately) and `new_callable=mock_open` (behaves like an empty file → loop breaks).

## ⚠️ Separate, higher-stakes bug found (not fixed here — needs its own verifiable PR)
The same whitelisted endpoints (`export_overdue_payments`, `send_overdue_payment_reminders`, `execute_bulk_payment_action`) **return a raw `OperationResult` dataclass**, which Frappe's `json_handler` cannot serialize (no `__json__`) → **HTTP 500**. The overdue-payments **export button (`overdue_member_payments.js`) is broken in the browser**, and this is the root of ~40 baseline test failures. Fix belongs on the source side (`.to_dict(nested=False)` / flat dict) with HTTP verification.

## Verification
Root cause reproduced locally (stack dump). Full-suite verification is via CI: **shard 1 should now complete (sentinel present) instead of SIGTERM-143.**