### PR TITLE
fix(payment): flatten critical_api nested envelope so report buttons work

### DIFF
--- a/verenigingen/api/payment_processing.py
+++ b/verenigingen/api/payment_processing.py
@@ -92,52 +92,70 @@ from verenigingen.utils.validation.api_validators import (
 )
 
 
-def _operation_result_to_response(result: Any) -> Any:
-    """Serialize an OperationResult into a flat, JSON-serializable dict for HTTP.
+def _flatten_api_response(result: Any) -> Any:
+    """Flatten the nested OperationResult envelope into the flat shape callers read.
 
-    A raw OperationResult is a @dataclass with no ``__json__``; Frappe's
-    ``json_handler`` cannot serialize it and raises TypeError (HTTP 500) when a
-    whitelisted endpoint returns one. Both callers of these endpoints — the
-    overdue-payments report JS (reads ``r.message.file_url`` / ``r.message.count``)
-    and the test-suite — expect the success payload's keys at the TOP level, so we
-    flatten ``data`` rather than nesting it under a ``data`` key (which is what
-    ``OperationResult.to_dict()`` would do). Business logic and payloads are
-    unchanged; only the return *type* is converted.
+    These endpoints return an OperationResult, and ``@critical_api`` serializes it
+    with ``OperationResult.to_dict(scrub_sensitive=True)`` (default ``nested=True``)
+    BEFORE this runs, producing::
+
+        {"success": True, "timestamp": ..., "data": {...}, "meta": {...}}          # ok
+        {"success": False, "timestamp": ..., "error": {"message": ...}, "meta": {...}}  # fail
+
+    But the overdue-payments report JS reads ``r.message.file_url`` / ``r.message.count``
+    and the test-suite reads ``result["count"]`` / ``result["message"]`` — i.e. flat,
+    top-level keys. Against the nested shape those are ``undefined`` (the export button
+    is broken). This lifts ``data`` / ``error`` / ``meta`` to the top level. It also
+    defensively serializes a raw OperationResult (in case ``@critical_api`` is absent)
+    and passes anything else through unchanged. No business logic or payload changes.
     """
-    if not isinstance(result, OperationResult):
+    # Defensive: serialize a raw OperationResult if @critical_api did not already.
+    if isinstance(result, OperationResult):
+        result = result.to_dict(scrub_sensitive=True)
+    if not isinstance(result, dict):
         return result
-    response: Dict[str, Any] = {"success": result.success}
-    if result.success:
-        if isinstance(result.data, dict):
-            response.update(result.data)
-        elif result.data is not None:
-            response["data"] = result.data
-    else:
-        response["message"] = result.error_message
-        if result.errors:
-            response["errors"] = result.errors
-        if result.error_code:
-            response["error_code"] = result.error_code
-        if result.http_status:
-            response["http_status"] = result.http_status
-    # Surface metadata (e.g. the success ``message=``) at the top level without
-    # clobbering data keys already set above.
-    for key, value in (result.metadata or {}).items():
-        response.setdefault(key, value)
-    return response
+    # Only transform the nested OperationResult envelope; leave plain dicts alone.
+    if "data" not in result and "error" not in result and "meta" not in result:
+        return result
+
+    flat: Dict[str, Any] = {k: v for k, v in result.items() if k not in ("data", "error", "meta")}
+
+    data = result.get("data")
+    if isinstance(data, dict):
+        flat.update(data)
+    elif data is not None:
+        flat["data"] = data
+
+    error = result.get("error")
+    if isinstance(error, dict):
+        flat.setdefault("message", error.get("message"))
+        if error.get("errors"):
+            flat.setdefault("errors", error["errors"])
+        if error.get("code"):
+            flat.setdefault("error_code", error["code"])
+    elif error is not None:
+        flat.setdefault("message", error)
+
+    meta = result.get("meta")
+    if isinstance(meta, dict):
+        # e.g. the success ``message=``; don't clobber data keys lifted above.
+        for key, value in meta.items():
+            flat.setdefault(key, value)
+
+    return flat
 
 
 def _flatten_operation_result(func):
-    """Convert an endpoint's OperationResult return into a flat JSON-serializable dict.
+    """Flatten an endpoint's nested OperationResult envelope into a flat dict.
 
-    Must sit INSIDE ``@frappe.whitelist()`` so the registered (outermost) object is
-    still the whitelisted one. Only transforms *returned* OperationResults; raised
-    exceptions propagate untouched to Frappe's error handling.
+    Sits INSIDE ``@frappe.whitelist()`` but OUTSIDE ``@critical_api`` — it must run
+    AFTER critical_api's ``to_dict`` serialization, on the nested dict that produces.
+    Only transforms the *returned* value; raised exceptions propagate untouched.
     """
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        return _operation_result_to_response(func(*args, **kwargs))
+        return _flatten_api_response(func(*args, **kwargs))
 
     return wrapper
 

--- a/verenigingen/api/payment_processing.py
+++ b/verenigingen/api/payment_processing.py
@@ -60,6 +60,7 @@ Author: Verenigingen Development Team
 License: MIT
 """
 
+import functools
 import os
 import tempfile
 import traceback
@@ -91,7 +92,58 @@ from verenigingen.utils.validation.api_validators import (
 )
 
 
+def _operation_result_to_response(result: Any) -> Any:
+    """Serialize an OperationResult into a flat, JSON-serializable dict for HTTP.
+
+    A raw OperationResult is a @dataclass with no ``__json__``; Frappe's
+    ``json_handler`` cannot serialize it and raises TypeError (HTTP 500) when a
+    whitelisted endpoint returns one. Both callers of these endpoints — the
+    overdue-payments report JS (reads ``r.message.file_url`` / ``r.message.count``)
+    and the test-suite — expect the success payload's keys at the TOP level, so we
+    flatten ``data`` rather than nesting it under a ``data`` key (which is what
+    ``OperationResult.to_dict()`` would do). Business logic and payloads are
+    unchanged; only the return *type* is converted.
+    """
+    if not isinstance(result, OperationResult):
+        return result
+    response: Dict[str, Any] = {"success": result.success}
+    if result.success:
+        if isinstance(result.data, dict):
+            response.update(result.data)
+        elif result.data is not None:
+            response["data"] = result.data
+    else:
+        response["message"] = result.error_message
+        if result.errors:
+            response["errors"] = result.errors
+        if result.error_code:
+            response["error_code"] = result.error_code
+        if result.http_status:
+            response["http_status"] = result.http_status
+    # Surface metadata (e.g. the success ``message=``) at the top level without
+    # clobbering data keys already set above.
+    for key, value in (result.metadata or {}).items():
+        response.setdefault(key, value)
+    return response
+
+
+def _flatten_operation_result(func):
+    """Convert an endpoint's OperationResult return into a flat JSON-serializable dict.
+
+    Must sit INSIDE ``@frappe.whitelist()`` so the registered (outermost) object is
+    still the whitelisted one. Only transforms *returned* OperationResults; raised
+    exceptions propagate untouched to Frappe's error handling.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return _operation_result_to_response(func(*args, **kwargs))
+
+    return wrapper
+
+
 @frappe.whitelist(methods=["POST"])
+@_flatten_operation_result
 @critical_api(operation_type=OperationType.FINANCIAL)
 @handle_api_error
 @performance_monitor(threshold_ms=2000)
@@ -289,6 +341,7 @@ def send_overdue_payment_reminders(
 
 
 @frappe.whitelist()
+@_flatten_operation_result
 @critical_api(operation_type=OperationType.FINANCIAL)
 @handle_api_error
 @performance_monitor(threshold_ms=5000)
@@ -380,6 +433,7 @@ def export_overdue_payments(filters=None, format="CSV") -> OperationResult[Dict[
 
 
 @frappe.whitelist()
+@_flatten_operation_result
 @critical_api(operation_type=OperationType.FINANCIAL)
 @handle_api_error
 @performance_monitor(threshold_ms=10000)

--- a/verenigingen/tests/backend/components/test_payment_response_serialization.py
+++ b/verenigingen/tests/backend/components/test_payment_response_serialization.py
@@ -1,0 +1,58 @@
+"""Unit tests for the OperationResult -> flat HTTP response serializer.
+
+Guards the fix for the bug where whitelisted payment endpoints returned a raw
+OperationResult dataclass, which Frappe's json_handler cannot serialize (HTTP
+500), and whose nested to_dict() shape did not match the flat keys the report JS
+(`r.message.file_url` / `r.message.count`) and the test-suite read.
+
+Plain unittest.TestCase (no DB) — the serializer is a pure function.
+"""
+import json
+import unittest
+
+from verenigingen.api.payment_processing import _operation_result_to_response
+from verenigingen.utils.operation_result import OperationResult
+
+
+class TestPaymentResponseSerialization(unittest.TestCase):
+    def test_success_payload_is_flattened_to_top_level(self):
+        result = OperationResult.ok(
+            data={"count": 3, "file_url": "/files/x.csv", "file_name": "x.csv"},
+            message="Export completed successfully",
+        )
+        response = _operation_result_to_response(result)
+        self.assertIs(response["success"], True)
+        self.assertEqual(response["count"], 3)
+        self.assertEqual(response["file_url"], "/files/x.csv")
+        self.assertEqual(response["file_name"], "x.csv")
+        self.assertEqual(response["message"], "Export completed successfully")
+        # data must NOT be nested under a "data" key — the JS reads r.message.file_url
+        self.assertNotIn("data", response)
+
+    def test_no_data_success(self):
+        result = OperationResult.ok(data={"count": 0}, message="No data to export")
+        response = _operation_result_to_response(result)
+        self.assertEqual(response, {"success": True, "count": 0, "message": "No data to export"})
+
+    def test_failure_payload(self):
+        result = OperationResult.fail("You don't have permission", http_status_code=403)
+        response = _operation_result_to_response(result)
+        self.assertIs(response["success"], False)
+        self.assertEqual(response["message"], "You don't have permission")
+
+    def test_response_is_json_serializable(self):
+        # The actual production bug: a raw OperationResult is not JSON-serializable,
+        # so a whitelisted endpoint returning one 500s during response serialization.
+        for result in (
+            OperationResult.ok(data={"count": 1, "file_url": "/f"}, message="ok"),
+            OperationResult.fail("nope", http_status_code=500),
+        ):
+            json.dumps(_operation_result_to_response(result))  # must not raise
+
+    def test_non_operation_result_passes_through(self):
+        self.assertEqual(_operation_result_to_response({"a": 1}), {"a": 1})
+        self.assertIsNone(_operation_result_to_response(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verenigingen/tests/backend/components/test_payment_response_serialization.py
+++ b/verenigingen/tests/backend/components/test_payment_response_serialization.py
@@ -1,57 +1,88 @@
-"""Unit tests for the OperationResult -> flat HTTP response serializer.
+"""Unit tests for the flat-API-response helper on the payment endpoints.
 
-Guards the fix for the bug where whitelisted payment endpoints returned a raw
-OperationResult dataclass, which Frappe's json_handler cannot serialize (HTTP
-500), and whose nested to_dict() shape did not match the flat keys the report JS
-(`r.message.file_url` / `r.message.count`) and the test-suite read.
+In production, ``@critical_api`` serializes the endpoint's OperationResult with
+``OperationResult.to_dict(scrub_sensitive=True)`` (nested) BEFORE the
+``_flatten_operation_result`` decorator runs, so the decorator receives a NESTED
+dict ``{success, timestamp, data, meta}`` — NOT a raw OperationResult. The
+overdue-payments report JS and the test-suite read flat top-level keys
+(``r.message.file_url`` / ``r.message.count``), so the helper must flatten that
+nested envelope. These tests feed it the exact ``to_dict`` output critical_api
+produces, so they guard the real runtime path.
 
-Plain unittest.TestCase (no DB) — the serializer is a pure function.
+Plain unittest.TestCase (no DB) — the helper is a pure function.
 """
 import json
 import unittest
 
-from verenigingen.api.payment_processing import _operation_result_to_response
+from verenigingen.api.payment_processing import _flatten_api_response
 from verenigingen.utils.operation_result import OperationResult
 
 
+def _as_critical_api_emits(result: OperationResult) -> dict:
+    """Reproduce exactly what @critical_api returns: to_dict(scrub_sensitive=True)."""
+    return result.to_dict(scrub_sensitive=True)
+
+
 class TestPaymentResponseSerialization(unittest.TestCase):
-    def test_success_payload_is_flattened_to_top_level(self):
-        result = OperationResult.ok(
-            data={"count": 3, "file_url": "/files/x.csv", "file_name": "x.csv"},
-            message="Export completed successfully",
+    def test_success_envelope_is_flattened_to_top_level(self):
+        envelope = _as_critical_api_emits(
+            OperationResult.ok(
+                data={"count": 3, "file_url": "/files/x.csv", "file_name": "x.csv"},
+                message="Export completed successfully",
+            )
         )
-        response = _operation_result_to_response(result)
-        self.assertIs(response["success"], True)
-        self.assertEqual(response["count"], 3)
-        self.assertEqual(response["file_url"], "/files/x.csv")
-        self.assertEqual(response["file_name"], "x.csv")
-        self.assertEqual(response["message"], "Export completed successfully")
-        # data must NOT be nested under a "data" key — the JS reads r.message.file_url
-        self.assertNotIn("data", response)
+        # Precondition: the envelope really is nested (the bug the JS hits).
+        self.assertIn("data", envelope)
+        self.assertIsNone(envelope.get("file_url"))
+
+        flat = _flatten_api_response(envelope)
+        self.assertIs(flat["success"], True)
+        self.assertEqual(flat["count"], 3)
+        self.assertEqual(flat["file_url"], "/files/x.csv")
+        self.assertEqual(flat["file_name"], "x.csv")
+        self.assertEqual(flat["message"], "Export completed successfully")
+        # data/meta envelope keys must be gone (JS reads r.message.file_url, not .data.file_url)
+        self.assertNotIn("data", flat)
+        self.assertNotIn("meta", flat)
 
     def test_no_data_success(self):
-        result = OperationResult.ok(data={"count": 0}, message="No data to export")
-        response = _operation_result_to_response(result)
-        self.assertEqual(response, {"success": True, "count": 0, "message": "No data to export"})
+        envelope = _as_critical_api_emits(
+            OperationResult.ok(data={"count": 0}, message="No data to export")
+        )
+        flat = _flatten_api_response(envelope)
+        self.assertIs(flat["success"], True)
+        self.assertEqual(flat["count"], 0)
+        self.assertEqual(flat["message"], "No data to export")
 
-    def test_failure_payload(self):
-        result = OperationResult.fail("You don't have permission", http_status_code=403)
-        response = _operation_result_to_response(result)
-        self.assertIs(response["success"], False)
-        self.assertEqual(response["message"], "You don't have permission")
+    def test_failure_envelope_is_flattened(self):
+        envelope = _as_critical_api_emits(
+            OperationResult.fail("You don't have permission", http_status_code=403)
+        )
+        self.assertIn("error", envelope)  # precondition: nested error object
+        flat = _flatten_api_response(envelope)
+        self.assertIs(flat["success"], False)
+        self.assertEqual(flat["message"], "You don't have permission")
+        self.assertNotIn("error", flat)
 
     def test_response_is_json_serializable(self):
-        # The actual production bug: a raw OperationResult is not JSON-serializable,
-        # so a whitelisted endpoint returning one 500s during response serialization.
         for result in (
             OperationResult.ok(data={"count": 1, "file_url": "/f"}, message="ok"),
             OperationResult.fail("nope", http_status_code=500),
         ):
-            json.dumps(_operation_result_to_response(result))  # must not raise
+            json.dumps(_flatten_api_response(_as_critical_api_emits(result)))  # must not raise
 
-    def test_non_operation_result_passes_through(self):
-        self.assertEqual(_operation_result_to_response({"a": 1}), {"a": 1})
-        self.assertIsNone(_operation_result_to_response(None))
+    def test_raw_operation_result_is_serialized_defensively(self):
+        # If @critical_api is ever absent, a raw OperationResult must still flatten.
+        flat = _flatten_api_response(
+            OperationResult.ok(data={"count": 2, "file_url": "/g"}, message="ok")
+        )
+        self.assertEqual(flat["count"], 2)
+        self.assertEqual(flat["file_url"], "/g")
+        self.assertNotIn("data", flat)
+
+    def test_plain_dict_and_non_dict_pass_through(self):
+        self.assertEqual(_flatten_api_response({"already": "flat"}), {"already": "flat"})
+        self.assertIsNone(_flatten_api_response(None))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reopens #118 (auto-closed when its stacked base #117 merged + branch deleted). Rebased onto develop; contains only the 2 payment commits.

## Problem (real product bug, confirmed by runtime trace)
`export_overdue_payments`, `send_overdue_payment_reminders`, `execute_bulk_payment_action` are HTTP-only `@frappe.whitelist()` endpoints. `@critical_api` serializes their `OperationResult` via `result.to_dict(scrub_sensitive=True)` (`api_security_framework.py:937-938`, nested=True), producing a **nested** envelope:
```json
{"success": true, "timestamp": "...", "data": {"count": 3, "file_url": "..."}, "meta": {"message": "..."}}
```
But the overdue-payments report JS reads flat `r.message.file_url` / `r.message.count` (`overdue_member_payments.js:266,352,424`) → `undefined` → **export / reminder / bulk-action buttons broken in the browser**. (NOT a 500 — an earlier diagnosis said 500; corrected after review.)

## Fix
`@_flatten_operation_result` decorator (inside `@frappe.whitelist()`, **outside** `@critical_api` so it runs on critical_api's serialized output) → `_flatten_api_response` lifts `data`/`error`/`meta` to the top level (data-first precedence; defensively serializes a raw OperationResult; passes plain dicts through). No business-logic/payload change. No internal Python callers (HTTP-only) → zero internal blast radius.

## Verification (DB-free)
`test_payment_response_serialization.py` (6 tests) feeds the helper critical_api's exact `to_dict(scrub_sensitive=True)` envelope (precondition-asserts it's nested), confirms flat output + JSON-serializable. Runtime: `to_dict → flatten` yields `r.message.file_url='/files/x.csv'`, `count=3`. Two skeptical reviews (first caught a no-op; second APPROVE on the corrected version — security not bypassed, `_security_protected` propagates). Full-stack integration test deferred (needs DB; CI exercises the endpoints).

Does NOT attempt to fix the ~40 pre-existing payment-test baseline failures (separate test-quality pass).