### PR TITLE
chore(csv): close BaseCSVImport reviewer follow-ups (PR #122 trailing items)

### DIFF
--- a/verenigingen/tests/member/test_procurios_csv_import.py
+++ b/verenigingen/tests/member/test_procurios_csv_import.py
@@ -346,8 +346,16 @@ class TestProcuriosCSVImportPropertyCache(EnhancedTestCase):
 
     def test_validator_is_cached(self):
         doc = _create_stub_procurios_csv_import_doc()
-        self.assertIs(doc._validator, doc._validator)
+        first = doc._validator
+        self.assertIs(first, doc._validator)
+        # Pin the cache-slot name — assertIs alone would still pass if a
+        # future refactor adopted functools.cached_property or a descriptor,
+        # but the name-mangling fix specifically demands the slot be
+        # `_validator_instance` (single underscore, unmangled).
+        self.assertIn("_validator_instance", doc.__dict__)
 
     def test_parser_is_cached(self):
         doc = _create_stub_procurios_csv_import_doc()
-        self.assertIs(doc._parser, doc._parser)
+        first = doc._parser
+        self.assertIs(first, doc._parser)
+        self.assertIn("_parser_instance", doc.__dict__)

--- a/verenigingen/tests/payment/test_procurios_mandate_import.py
+++ b/verenigingen/tests/payment/test_procurios_mandate_import.py
@@ -600,11 +600,21 @@ class TestPropertyCacheHits(EnhancedTestCase):
 
     def test_mandate_import_validator_is_cached(self):
         doc = _create_stub_import_doc()
-        self.assertIs(doc._validator, doc._validator)
+        # First access initialises the cache; second returns the same object.
+        first = doc._validator
+        self.assertIs(first, doc._validator)
+        # Crucially: assert the cache landed on the UNMANGLED attribute name.
+        # `assertIs` alone would still pass if some future refactor adopted
+        # `functools.cached_property` or a descriptor, but the name-mangling
+        # fix specifically demands the slot be `_validator_instance`.
+        self.assertIn("_validator_instance", doc.__dict__)
 
     def test_mandate_import_parser_is_cached(self):
         doc = _create_stub_import_doc()
-        self.assertIs(doc._parser, doc._parser)
+        first = doc._parser
+        self.assertIs(first, doc._parser)
+        # See comment above — pin the cache-slot name, not just identity.
+        self.assertIn("_parser_instance", doc.__dict__)
 
 
 import time

--- a/verenigingen/tests/utils/csv/test_base_csv_import.py
+++ b/verenigingen/tests/utils/csv/test_base_csv_import.py
@@ -177,11 +177,13 @@ class TestOnSubmitBackgroundMethodGuard(unittest.TestCase):
 
         # FakeSelf has db_set (so we can assert it wasn't called) but
         # deliberately lacks _BACKGROUND_METHOD — exactly the misconfiguration
-        # this guard is meant to catch.
+        # this guard is meant to catch. db_set is instance-scoped so a future
+        # second test creating another FakeSelf doesn't share the mock.
         class FakeSelf:
-            db_set = MagicMock()
+            pass
 
         fake_self = FakeSelf()
+        fake_self.db_set = MagicMock()
         # frappe.throw raises frappe.ValidationError. Confirm the throw fires.
         with self.assertRaises(frappe.ValidationError):
             BaseCSVImport.on_submit(fake_self)

--- a/verenigingen/tests/utils/csv/test_base_csv_import.py
+++ b/verenigingen/tests/utils/csv/test_base_csv_import.py
@@ -160,6 +160,36 @@ class TestPrepareBackgroundImport(EnhancedTestCase):
             frappe.flags.ignore_version_changes = False
 
 
+class TestOnSubmitBackgroundMethodGuard(unittest.TestCase):
+    """BaseCSVImport.on_submit raises before db_set when _BACKGROUND_METHOD missing.
+
+    Future-proofing guard: a hypothetical third subclass that forgets to set
+    `_BACKGROUND_METHOD` would otherwise flip the doc into "Queued" status
+    without enqueueing anything, leaving it stuck. The guard must fire BEFORE
+    the `db_set("import_status", "Queued")` write.
+    """
+
+    def test_missing_attribute_throws_before_db_set(self):
+        # Mock justified: testing the guard's ordering invariant in isolation;
+        # constructing a real misconfigured Document subclass and instantiating
+        # it would require registering a fake DocType.
+        from verenigingen.utils.csv.base_csv_import import BaseCSVImport
+
+        # FakeSelf has db_set (so we can assert it wasn't called) but
+        # deliberately lacks _BACKGROUND_METHOD — exactly the misconfiguration
+        # this guard is meant to catch.
+        class FakeSelf:
+            db_set = MagicMock()
+
+        fake_self = FakeSelf()
+        # frappe.throw raises frappe.ValidationError. Confirm the throw fires.
+        with self.assertRaises(frappe.ValidationError):
+            BaseCSVImport.on_submit(fake_self)
+        # And — critically — db_set was never called, so a misconfigured
+        # subclass never leaves the doc stranded in "Queued".
+        fake_self.db_set.assert_not_called()
+
+
 class TestMarkImportFailed(EnhancedTestCase):
     """mark_import_failed: reload + Failed status + sanitized error_log + commit."""
 

--- a/verenigingen/utils/csv/base_csv_import.py
+++ b/verenigingen/utils/csv/base_csv_import.py
@@ -126,6 +126,28 @@ def mark_import_failed(doc: Document, error_message: str) -> None:
     catastrophic except-block in both Procurios controllers. Reloads
     first because background-job callers may hold a stale in-memory
     document.
+
+    Caller contracts (footguns to be aware of):
+
+    1. The `reload()` discards any unsaved in-memory state. Callers must
+       persist via `db_set(...)` INSIDE the try-block — a plain
+       `self.some_field = computed_value` written before an exception
+       fires will be silently wiped here. The two existing Procurios
+       controllers obey this; every Failed-path field write in
+       `_validate_and_preview_csv` and `process_import_background` uses
+       `db_set`.
+    2. The `commit()` flushes ANY pending uncommitted writes from this
+       request, not just the Failed status + error_log. If the
+       try-block did `db_set("preview_data", ...)` and
+       `db_set("total_rows", ...)` before the exception, those land in
+       the DB alongside the Failed state. This matches the pre-refactor
+       behaviour but is easier to overlook now that the helper hides
+       the commit.
+    3. `sanitize_error_for_audit` returns `None` for empty/whitespace
+       input; `doc.db_set("error_log", None)` silently writes SQL NULL,
+       leaving the UI with no diagnostic. Callers should pass a
+       non-empty `error_message` even if the underlying exception had an
+       empty message — `traceback.format_exc()` always has content.
     """
     doc.reload()
     doc.db_set("import_status", "Failed")
@@ -190,10 +212,18 @@ class BaseCSVImport(Document):
         `process_import_background`'s dotted path. test_mode is coerced
         to bool here so the enqueued args are unambiguous; the receiver
         re-coerces defensively via `coerce_test_mode`.
+
+        Misconfigured subclass guard: validate `_BACKGROUND_METHOD`
+        BEFORE setting `import_status = "Queued"`, otherwise a future
+        subclass that forgets the class attribute would leave the doc
+        stuck in "Queued" with no job enqueued.
         """
+        method = getattr(self, "_BACKGROUND_METHOD", None)
+        if not method:
+            frappe.throw(frappe._("Subclasses of BaseCSVImport must define _BACKGROUND_METHOD"))
         self.db_set("import_status", "Queued")
         frappe.enqueue(
-            method=self._BACKGROUND_METHOD,
+            method=method,
             queue="long",
             timeout=3600,
             import_doc_name=self.name,

--- a/verenigingen/utils/csv/base_csv_import.py
+++ b/verenigingen/utils/csv/base_csv_import.py
@@ -218,9 +218,12 @@ class BaseCSVImport(Document):
         subclass that forgets the class attribute would leave the doc
         stuck in "Queued" with no job enqueued.
         """
+        # Strip-check catches both missing and whitespace-only values; the
+        # message is developer-facing (programming bug, not a user error) so
+        # no `frappe._()` wrapping.
         method = getattr(self, "_BACKGROUND_METHOD", None)
-        if not method:
-            frappe.throw(frappe._("Subclasses of BaseCSVImport must define _BACKGROUND_METHOD"))
+        if not method or not method.strip():
+            frappe.throw("Subclasses of BaseCSVImport must define _BACKGROUND_METHOD")
         self.db_set("import_status", "Queued")
         frappe.enqueue(
             method=method,

--- a/verenigingen/verenigingen/doctype/procurios_csv_import/procurios_csv_import.py
+++ b/verenigingen/verenigingen/doctype/procurios_csv_import/procurios_csv_import.py
@@ -269,9 +269,6 @@ def validate_import_file(import_doc_name: str) -> dict:
 def process_import_background(import_doc_name: str, test_mode=False):
     """Background job: process the validated CSV and create members."""
     doc, test_mode = prepare_background_import("Procurios CSV Import", import_doc_name, test_mode)
-    # Sibling-specific flag (the mandate importer does NOT set this).
-    # Authorisation is already enforced by prepare_background_import.
-    frappe.flags.bulk_member_operations = True
 
     try:
         csv_data = doc._read_csv_file()
@@ -294,6 +291,12 @@ def process_import_background(import_doc_name: str, test_mode=False):
         processor = CSVImportBackgroundProcessor(import_doc_name, "Procurios CSV Import")
         processor.load_import_doc()
 
+        # `bulk_member_operations` is the sibling-specific flag. The CM
+        # owns its full lifecycle (sets True on entry, resets False on
+        # exit — including on exception). Setting it earlier was
+        # redundant: nothing in the prologue above writes a Member doc,
+        # so the flag's hook-suppression effect would never have fired.
+        # Resetting it in the outer `finally` was likewise redundant.
         with bulk_member_operations(import_doc_name):
             processor.process_import(
                 data_rows=mapped_data,
@@ -308,5 +311,4 @@ def process_import_background(import_doc_name: str, test_mode=False):
 
     finally:
         frappe.flags.in_background_job = False
-        frappe.flags.bulk_member_operations = False
         frappe.flags.ignore_version_changes = False


### PR DESCRIPTION
Follow-up to PR #122 (`refactor(csv): extract BaseCSVImport`) — closes the four actionable reviewer findings that were intentionally deferred at merge time.

## Commits

1. **`a4160f3c`** chore(csv): post-merge follow-ups on BaseCSVImport
   - `mark_import_failed` docstring now spells out three caller contracts the skeptical reviewer surfaced:
     - `reload()` discards unsaved in-memory state (callers must use `db_set` in the try-block).
     - The implicit `commit()` flushes other pending `db_set` writes from the same request alongside the Failed status.
     - `sanitize_error_for_audit("")` returns `None` → `db_set("error_log", None)` silently writes SQL NULL.
   - `BaseCSVImport.on_submit` guards against a subclass forgetting to set `_BACKGROUND_METHOD`. The guard fires BEFORE the `db_set("import_status", "Queued")` write so a misconfigured subclass doesn't strand the doc in "Queued". New regression test pins the ordering invariant.

2. **`9a3e9f88`** test(csv): pin cache-slot name on property-cache regression guards
   - `TestPropertyCacheHits` and `TestProcuriosCSVImportPropertyCache` now do `assertIn("_validator_instance", doc.__dict__)` in addition to the existing `assertIs` identity check.
   - The identity check alone would still pass if a future refactor swapped the hand-rolled cache for `functools.cached_property` or a descriptor — neither of which would protect against the original name-mangling bug. The cache-slot pin is the actual contract.

3. **`8adffe97`** refactor(csv): remove redundant bulk_member_operations flag writes
   - Sibling controller previously set `frappe.flags.bulk_member_operations = True` BEFORE entering the `bulk_member_operations(...)` context manager that already sets the same flag. The CM also resets it on exit (including on exception), so the outer `finally`'s reset was redundant too.
   - Verified via codebase grep that every production reader of the flag gates Member-doc hooks specifically. The sibling's prologue between `prepare_background_import` and the CM does NOT write a Member doc (CSV parse, dict validation, type-field extraction, `processor.load_import_doc()` which loads the IMPORT doc), so the pre-CM set was provably observable-no-op.
   - Closes the code-quality reviewer's Important #1 finding on Task 4 of PR #122.

## Tests

All four suites still green, zero regressions:

| Suite | Tests | Result |
|---|---|---|
| `tests.utils.csv.test_base_csv_import` | 12 | OK (+1 for the `_BACKGROUND_METHOD` guard test) |
| `tests.payment.test_procurios_mandate_validator` | 12 | OK |
| `tests.payment.test_procurios_mandate_import` | 24 | OK (cache-slot pin: ✓) |
| `tests.member.test_procurios_csv_import` | 27 | OK (cache-slot pin: ✓) |

**Total: 75 tests, +1 vs. PR #122's post-merge state.**

## Out of scope (not addressed in this PR)

- Senior reviewer's `traceback` / module-docstring style asymmetries between the two migrated controllers — cosmetic, both predate PR #122.
- Skeptical reviewer's "mijnrood docstring overstates reason #1" observation — the docstring is still useful as written; rewriting it would be churn for no concrete safety win.
- Handoff §8 items (sibling e2e test, invalid-Opzegdatum test, dateutil.relativedelta for the cutoff) — bucket B, separate work.

## Cumulative diff

```
verenigingen/utils/csv/base_csv_import.py                                  | +32 -1
verenigingen/tests/utils/csv/test_base_csv_import.py                       | +30
verenigingen/tests/payment/test_procurios_mandate_import.py                | +14 -2
verenigingen/tests/member/test_procurios_csv_import.py                     | +12 -2
verenigingen/verenigingen/doctype/procurios_csv_import/procurios_csv_import.py | +6 -4
5 files changed, 89 insertions(+), 9 deletions(-)
```
