### PR TITLE
security: API-middleware audit fixes + endpoint coverage sweep (audit #10)

### DIFF
--- a/scripts/monitoring/zabbix_integration.py
+++ b/scripts/monitoring/zabbix_integration.py
@@ -21,8 +21,6 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, cint, cstr, flt, get_datetime, now_datetime
 
-from verenigingen.utils.security.api_security_framework import OperationType, development_only_api
-
 
 class ZabbixIntegration:
     """Main Zabbix integration class supporting both legacy and 7.0 features"""
@@ -689,19 +687,21 @@ def health_check():
     }
 
 
-@frappe.whitelist()
-@development_only_api(operation_type=OperationType.UTILITY)
+@frappe.whitelist(allow_guest=True)
 def zabbix_webhook_receiver():
     """
     Enhanced webhook receiver supporting both legacy and Zabbix 7.0 formats
     Handles alerts, creates issues, and supports auto-remediation
     """
     try:
-        # Validate signature if configured
-        if frappe.conf.get("zabbix_webhook_secret"):
-            if not validate_webhook_signature():
-                frappe.response["http_status_code"] = 401
-                return {"status": "error", "message": "Invalid signature"}
+        # Auto-remediation can flush the cache, fail RQ jobs and restart Redis, so
+        # this endpoint MUST authenticate. Require a valid HMAC signature over the
+        # request body; validate_webhook_signature() fails closed when no
+        # zabbix_webhook_secret is configured, so an unconfigured site rejects all
+        # calls rather than executing remediation from an unauthenticated request.
+        if not validate_webhook_signature():
+            frappe.response["http_status_code"] = 401
+            return {"status": "error", "message": "Invalid or missing webhook signature"}
 
         # Get webhook data
         data = frappe.request.get_json()
@@ -815,17 +815,27 @@ def is_valid_zabbix_request():
 
 
 def validate_webhook_signature():
-    """Validate Zabbix webhook signature"""
+    """Validate the Zabbix webhook HMAC signature.
+
+    Fails CLOSED: returns False when no ``zabbix_webhook_secret`` is configured,
+    when there is no request, or when the signature header is missing/incorrect.
+    The secret guards a dangerous auto-remediation endpoint, so "no secret" must
+    mean "reject", never "allow".
+    """
     secret = frappe.conf.get("zabbix_webhook_secret")
     if not secret:
-        return True
+        return False
+
+    request = getattr(frappe.local, "request", None)
+    if request is None:
+        return False
 
     signature = frappe.get_request_header("X-Zabbix-Signature")
     if not signature:
         return False
 
     # Calculate expected signature
-    body = frappe.request.get_data()
+    body = request.get_data()
     expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
     return hmac.compare_digest(signature, expected)
@@ -1078,7 +1088,9 @@ def process_legacy_webhook(data):
         "trigger_name": data.get("trigger"),
         "severity": data.get("severity"),
         "host": data.get("host"),
-        "timestamp": data.get("timestamp", now_datetime()),
+        # Default to an ISO string, not a datetime object: the alert dict is later
+        # json.dumps()'d in log_alert(), which would raise on a raw datetime.
+        "timestamp": data.get("timestamp", now_datetime().isoformat()),
         "value": data.get("value"),
         "operational_data": {},
         "tags": [],

--- a/scripts/monitoring/zabbix_integration.py
+++ b/scripts/monitoring/zabbix_integration.py
@@ -11,25 +11,22 @@ This module:
 4. Includes auto-remediation capabilities
 """
 
-import json
-import time
 import hashlib
 import hmac
+import json
+import time
 from datetime import datetime, timedelta
 
 import frappe
 from frappe import _
-from frappe.utils import (
-    now_datetime, get_datetime, add_days,
-    cint, flt, cstr
-)
+from frappe.utils import add_days, cint, cstr, flt, get_datetime, now_datetime
 
 from verenigingen.utils.security.api_security_framework import OperationType, development_only_api
 
 
 class ZabbixIntegration:
     """Main Zabbix integration class supporting both legacy and 7.0 features"""
-    
+
     def __init__(self):
         self.zabbix_url = frappe.conf.get("zabbix_url", "http://zabbix.example.com")
         self.zabbix_user = frappe.conf.get("zabbix_user")
@@ -37,7 +34,7 @@ class ZabbixIntegration:
         self.zabbix_token = frappe.conf.get("zabbix_api_token")  # For Zabbix 7.0
         self.host_name = frappe.conf.get("zabbix_host_name", "frappe-production")
         self.webhook_secret = frappe.conf.get("zabbix_webhook_secret", "")
-        
+
     def authenticate(self):
         """Authenticate with Zabbix API (supports both token and user/pass)"""
         # Implementation depends on Zabbix version
@@ -50,22 +47,22 @@ def get_metrics_for_zabbix():
     Main metrics endpoint for Zabbix monitoring
     Consolidates all metrics from different implementations
     """
-    # For now, allow all calls - we'll add authentication back later
-    # if not is_valid_request():
-    #     frappe.response["http_status_code"] = 403
-    #     return {"error": "Unauthorized"}
-    
+    # Guest-reachable endpoint: authenticate the caller (X-Zabbix-Token header /
+    # IP allow-list) before exposing business, financial and system metrics.
+    if not is_valid_request():
+        raise frappe.PermissionError(_("Unauthorized Zabbix metrics request"))
+
     metrics = {}
-    
+
     # Business Metrics
     metrics.update(get_business_metrics())
-    
+
     # Financial Metrics (from main implementation)
     metrics.update(get_financial_metrics())
-    
+
     # System Health Metrics
     metrics.update(get_system_metrics())
-    
+
     # Dues Schedule and Invoice Metrics (updated for new system)
     metrics.update(get_dues_schedule_metrics())  # Renamed for clarity
 
@@ -76,37 +73,36 @@ def get_metrics_for_zabbix():
     if frappe.conf.get("enable_advanced_metrics", False):
         metrics.update(get_performance_percentiles())
         metrics.update(get_error_breakdown_metrics())
-    
+
     # Add metadata for Zabbix 7.0
     if frappe.conf.get("zabbix_version", "6") >= "7":
         return format_metrics_for_zabbix_v7(metrics)
-    
+
     return {"timestamp": now_datetime().isoformat(), "metrics": metrics}
 
 
 def get_business_metrics():
     """Get business-related metrics"""
     metrics = {}
-    
+
     # Member metrics
     metrics["frappe.members.active"] = frappe.db.count("Member", {"status": "Active"})
     metrics["frappe.members.total"] = frappe.db.count("Member")
-    
+
     # Calculate member metrics
     total_members = metrics["frappe.members.total"]
     if total_members > 0:
         # Churn rate calculation
-        terminated_last_month = frappe.db.count("Member", {
-            "status": "Terminated",
-            "modified": [">=", add_days(now_datetime(), -30)]
-        })
+        terminated_last_month = frappe.db.count(
+            "Member", {"status": "Terminated", "modified": [">=", add_days(now_datetime(), -30)]}
+        )
         metrics["frappe.member.churn_rate"] = round((terminated_last_month / total_members) * 100, 2)
     else:
         metrics["frappe.member.churn_rate"] = 0
-    
+
     # Volunteer metrics
     metrics["frappe.volunteers.active"] = frappe.db.count("Volunteer", {"status": "Active"})
-    
+
     # Volunteer engagement
     total_volunteers = frappe.db.count("Volunteer")
     if total_volunteers > 0:
@@ -121,36 +117,33 @@ def get_business_metrics():
         metrics["frappe.volunteer.engagement"] = round((active_volunteers / total_volunteers) * 100, 2)
     else:
         metrics["frappe.volunteer.engagement"] = 0
-    
+
     # Donation metrics
     today_start = datetime.combine(datetime.now().date(), datetime.min.time())
-    donations_today = frappe.db.get_value(
-        "Donation",
-        {"creation": [">=", today_start]},
-        "SUM(amount)"
-    ) or 0
+    donations_today = frappe.db.get_value("Donation", {"creation": [">=", today_start]}, "SUM(amount)") or 0
     metrics["frappe.donations.today"] = float(donations_today)
-    
+
     return metrics
 
 
 def get_financial_metrics():
     """Get financial and invoice metrics"""
     metrics = {}
-    
+
     # Invoice metrics for today
     today_start = datetime.combine(datetime.now().date(), datetime.min.time())
-    
+
     # Sales invoices
-    sales_invoices_today = frappe.db.count("Sales Invoice", {
-        "docstatus": 1,
-        "posting_date": [">=", today_start.date()]
-    })
+    sales_invoices_today = frappe.db.count(
+        "Sales Invoice", {"docstatus": 1, "posting_date": [">=", today_start.date()]}
+    )
     metrics["frappe.invoices.sales_today"] = sales_invoices_today
-    
+
     # Membership dues invoices (identified by link to dues schedules) - handle gracefully if column doesn't exist
     try:
-        membership_invoices_today = frappe.db.sql("""
+        membership_invoices_today = (
+            frappe.db.sql(
+                """
             SELECT COUNT(DISTINCT si.name)
             FROM `tabSales Invoice` si
             INNER JOIN `tabMember` m ON m.customer = si.customer
@@ -158,99 +151,113 @@ def get_financial_metrics():
             WHERE si.docstatus = 1 
             AND si.posting_date >= %s
             AND mds.status = 'Active'
-        """, (today_start.date(),))[0][0] or 0
+        """,
+                (today_start.date(),),
+            )[0][0]
+            or 0
+        )
         metrics["frappe.invoices.membership_dues_today"] = membership_invoices_today
     except Exception:
         metrics["frappe.invoices.membership_dues_today"] = 0
-    
+
     # Total invoices (both sales and purchase)
-    total_invoices_today = sales_invoices_today + frappe.db.count("Purchase Invoice", {
-        "docstatus": 1,
-        "posting_date": [">=", today_start.date()]
-    })
+    total_invoices_today = sales_invoices_today + frappe.db.count(
+        "Purchase Invoice", {"docstatus": 1, "posting_date": [">=", today_start.date()]}
+    )
     metrics["frappe.invoices.total_today"] = total_invoices_today
-    
+
     return metrics
 
 
 def get_system_metrics():
     """Get system health metrics"""
     metrics = {}
-    
+
     # Error logs
-    error_count = frappe.db.count("Error Log", {
-        "creation": [">=", add_days(now_datetime(), -1/24)]  # Last hour
-    })
+    error_count = frappe.db.count(
+        "Error Log", {"creation": [">=", add_days(now_datetime(), -1 / 24)]}  # Last hour
+    )
     metrics["frappe.error_logs.count"] = error_count
-    
+
     # Calculate error rate - handle gracefully if Activity Log doesn't exist
     try:
-        total_requests = frappe.db.get_value(
-            "Activity Log",
-            {"creation": [">=", add_days(now_datetime(), -1/24)]},
-            "COUNT(*)"
-        ) or 1  # Avoid division by zero
+        total_requests = (
+            frappe.db.get_value(
+                "Activity Log", {"creation": [">=", add_days(now_datetime(), -1 / 24)]}, "COUNT(*)"
+            )
+            or 1
+        )  # Avoid division by zero
         metrics["frappe.error.rate"] = round((error_count / total_requests) * 100, 2)
     except Exception:
         metrics["frappe.error.rate"] = 0
-    
+
     # Background jobs - RQ Job table doesn't exist in this installation
     # Setting default values instead of querying non-existent table
     metrics["frappe.queue.pending"] = 0
     metrics["frappe.queue.stuck_jobs"] = 0
-    
+
     # Database connections
-    db_connections = frappe.db.sql("""
+    db_connections = (
+        frappe.db.sql(
+            """
         SELECT COUNT(*) FROM information_schema.PROCESSLIST 
         WHERE db = %s
-    """, (frappe.conf.db_name,))[0][0] or 0
+    """,
+            (frappe.conf.db_name,),
+        )[0][0]
+        or 0
+    )
     metrics["frappe.db.connections"] = db_connections
-    
+
     # Response time (average from last 100 requests) - handle gracefully if column doesn't exist
     try:
-        avg_response_time = frappe.db.get_value(
-            "Activity Log",
-            {"creation": [">=", add_days(now_datetime(), -1/24)]},
-            "AVG(response_time)"
-        ) or 0
+        avg_response_time = (
+            frappe.db.get_value(
+                "Activity Log", {"creation": [">=", add_days(now_datetime(), -1 / 24)]}, "AVG(response_time)"
+            )
+            or 0
+        )
         metrics["frappe.response.time"] = round(avg_response_time, 2)
     except Exception:
         metrics["frappe.response.time"] = 0
-    
+
     # Volunteer expense status
     pending_expenses = frappe.db.count("Volunteer Expense", {"status": "Submitted"})
     metrics["frappe.expenses.pending"] = pending_expenses
-    
+
     return metrics
 
 
 def get_dues_schedule_metrics():
     """Get dues schedule and invoicing metrics (replaces old subscription metrics)"""
     metrics = {}
-    
+
     # Active dues schedules
     try:
         active_dues_schedules = frappe.db.count("Membership Dues Schedule", {"status": "Active"})
         metrics["frappe.dues_schedules.active"] = active_dues_schedules
-        
+
         # Total dues schedules
         total_dues_schedules = frappe.db.count("Membership Dues Schedule")
         metrics["frappe.dues_schedules.total"] = total_dues_schedules
-        
+
         # Dues schedules by billing frequency
-        frequency_counts = frappe.db.sql("""
+        frequency_counts = frappe.db.sql(
+            """
             SELECT billing_frequency, COUNT(*) as count
             FROM `tabMembership Dues Schedule`
             WHERE status = 'Active'
             GROUP BY billing_frequency
-        """, as_dict=True)
-        
+        """,
+            as_dict=True,
+        )
+
         for freq in frequency_counts:
             safe_key = freq.billing_frequency.lower().replace(" ", "_")
             metrics[f"frappe.dues_schedules.frequency.{safe_key}"] = freq.count
-            
+
         # NEW MONITORING METRICS REQUESTED
-        
+
         # Past next invoice dates (schedules with overdue next_invoice_date)
         past_invoice_dates = frappe.db.sql("""
             SELECT COUNT(*) 
@@ -260,7 +267,7 @@ def get_dues_schedule_metrics():
             AND next_invoice_date IS NOT NULL
         """)[0][0] or 0
         metrics["frappe.dues_schedules.past_invoice_dates"] = past_invoice_dates
-        
+
         # Members without membership (active members without active membership record)
         members_without_membership = frappe.db.sql("""
             SELECT COUNT(*) 
@@ -274,7 +281,7 @@ def get_dues_schedule_metrics():
             )
         """)[0][0] or 0
         metrics["frappe.members.without_membership"] = members_without_membership
-        
+
         # Members without billing dues schedule (active members without active dues schedule)
         members_without_dues_schedule = frappe.db.sql("""
             SELECT COUNT(*) 
@@ -287,25 +294,24 @@ def get_dues_schedule_metrics():
             )
         """)[0][0] or 0
         metrics["frappe.members.without_dues_schedule"] = members_without_dues_schedule
-            
+
     except Exception as e:
         frappe.log_error(f"Error getting dues schedule metrics: {str(e)}")
         metrics["frappe.dues_schedules.active"] = 0
         metrics["frappe.dues_schedules.past_invoice_dates"] = 0
         metrics["frappe.members.without_membership"] = 0
         metrics["frappe.members.without_dues_schedule"] = 0
-    
+
     # Invoices generated today
     try:
         today_start = datetime.combine(datetime.now().date(), datetime.min.time())
-        invoices_today = frappe.db.count("Sales Invoice", {
-            "creation": [">", today_start],
-            "docstatus": 1
-        })
+        invoices_today = frappe.db.count("Sales Invoice", {"creation": [">", today_start], "docstatus": 1})
         metrics["frappe.invoices.generated_today"] = invoices_today
-        
+
         # Membership invoices today (invoices linked to dues schedules)
-        membership_invoices_today = frappe.db.sql("""
+        membership_invoices_today = (
+            frappe.db.sql(
+                """
             SELECT COUNT(DISTINCT si.name)
             FROM `tabSales Invoice` si
             INNER JOIN `tabMembership Dues Schedule` mds ON mds.member = si.member
@@ -313,23 +319,24 @@ def get_dues_schedule_metrics():
             AND si.docstatus = 1
             AND mds.status = 'Active'
             AND si.member IS NOT NULL
-        """, (today_start,))[0][0] or 0
+        """,
+                (today_start,),
+            )[0][0]
+            or 0
+        )
         metrics["frappe.invoices.membership_today"] = membership_invoices_today
-        
+
     except Exception as e:
         frappe.log_error(f"Error getting invoice metrics: {str(e)}")
         metrics["frappe.invoices.generated_today"] = 0
         metrics["frappe.invoices.membership_today"] = 0
-    
+
     # Last invoice generation time
     try:
         last_invoice = frappe.db.get_value(
-            "Sales Invoice",
-            {"docstatus": 1},
-            "creation",
-            order_by="creation desc"
+            "Sales Invoice", {"docstatus": 1}, "creation", order_by="creation desc"
         )
-        
+
         if last_invoice:
             hours_since = (now_datetime() - get_datetime(last_invoice)).total_seconds() / 3600
             metrics["frappe.invoices.last_generated_hours_ago"] = round(hours_since, 2)
@@ -339,16 +346,13 @@ def get_dues_schedule_metrics():
             metrics["frappe.invoices.last_generated_hours_ago"] = NEVER_GENERATED_HOURS
     except Exception:
         metrics["frappe.invoices.last_generated_hours_ago"] = NEVER_GENERATED_HOURS
-    
+
     # Payment processing metrics
     try:
         # Overdue invoices
-        overdue_invoices = frappe.db.count("Sales Invoice", {
-            "status": "Overdue",
-            "docstatus": 1
-        })
+        overdue_invoices = frappe.db.count("Sales Invoice", {"status": "Overdue", "docstatus": 1})
         metrics["frappe.invoices.overdue"] = overdue_invoices
-        
+
         # Total outstanding amount
         outstanding_amount = frappe.db.sql("""
             SELECT SUM(outstanding_amount)
@@ -357,30 +361,27 @@ def get_dues_schedule_metrics():
             AND outstanding_amount > 0
         """)[0][0] or 0
         metrics["frappe.invoices.outstanding_amount"] = float(outstanding_amount)
-        
+
         # Payment success rate (last 30 days)
         thirty_days_ago = add_days(now_datetime(), -30)
-        total_invoices = frappe.db.count("Sales Invoice", {
-            "creation": [">", thirty_days_ago],
-            "docstatus": 1
-        })
-        paid_invoices = frappe.db.count("Sales Invoice", {
-            "creation": [">", thirty_days_ago],
-            "docstatus": 1,
-            "status": "Paid"
-        })
-        
+        total_invoices = frappe.db.count(
+            "Sales Invoice", {"creation": [">", thirty_days_ago], "docstatus": 1}
+        )
+        paid_invoices = frappe.db.count(
+            "Sales Invoice", {"creation": [">", thirty_days_ago], "docstatus": 1, "status": "Paid"}
+        )
+
         if total_invoices > 0:
             metrics["frappe.invoices.payment_success_rate"] = round((paid_invoices / total_invoices) * 100, 2)
         else:
             metrics["frappe.invoices.payment_success_rate"] = 0
-            
+
     except Exception as e:
         frappe.log_error(f"Error getting payment metrics: {str(e)}")
         metrics["frappe.invoices.overdue"] = 0
         metrics["frappe.invoices.outstanding_amount"] = 0
         metrics["frappe.invoices.payment_success_rate"] = 0
-    
+
     return metrics
 
 
@@ -401,7 +402,7 @@ def get_mollie_payment_metrics():
         settlements_client = SettlementsClient()
 
         # === Cache Performance Metrics ===
-        if balances_client.enable_cache and hasattr(balances_client, 'cache'):
+        if balances_client.enable_cache and hasattr(balances_client, "cache"):
             cache_stats = balances_client.cache.get_stats()
             metrics["frappe.mollie.cache.hits"] = cache_stats.get("hits", 0)
             metrics["frappe.mollie.cache.misses"] = cache_stats.get("misses", 0)
@@ -420,6 +421,7 @@ def get_mollie_payment_metrics():
         # === Balance Metrics ===
         # Measure API latency on the balance fetch (user-experienced latency)
         import time
+
         balance_start_time = time.time()
         primary_balance = None
 
@@ -429,7 +431,10 @@ def get_mollie_payment_metrics():
             balance_fetch_latency = (time.time() - balance_start_time) * 1000  # milliseconds
 
             # Extract amounts using PaymentDataExtractor
-            from verenigingen.verenigingen_payments.utils.payment_data_extractor import get_payment_data_extractor
+            from verenigingen.verenigingen_payments.utils.payment_data_extractor import (
+                get_payment_data_extractor,
+            )
+
             extractor = get_payment_data_extractor()
             amounts = extractor.extract_balance_amounts(primary_balance)
 
@@ -455,32 +460,32 @@ def get_mollie_payment_metrics():
         # === Settlement Metrics (Last 24 Hours) ===
         try:
             from datetime import datetime, timedelta
+
             yesterday = datetime.now() - timedelta(days=1)
 
             # Get recent settlements
             recent_settlements = settlements_client.list_settlements(
-                from_date=yesterday,
-                limit=100,
-                use_cache=True
+                from_date=yesterday, limit=100, use_cache=True
             )
 
             metrics["frappe.mollie.settlements.count_24h"] = len(recent_settlements)
 
             # Calculate total settled amount
             from verenigingen.verenigingen_payments.utils.payment_data_extractor import MollieObjectType
+
             total_settled = 0
             for settlement in recent_settlements:
                 amount = extractor.extract_amount(
-                    settlement,
-                    source_type=MollieObjectType.SETTLEMENT,
-                    allow_zero=True
+                    settlement, source_type=MollieObjectType.SETTLEMENT, allow_zero=True
                 )
                 total_settled += amount
 
             metrics["frappe.mollie.settlements.amount_24h"] = total_settled
 
         except Exception as e:
-            frappe.log_error(f"Error getting Mollie settlement metrics: {str(e)}", "Zabbix Mollie Settlement Error")
+            frappe.log_error(
+                f"Error getting Mollie settlement metrics: {str(e)}", "Zabbix Mollie Settlement Error"
+            )
             metrics["frappe.mollie.settlements.count_24h"] = -1
             metrics["frappe.mollie.settlements.amount_24h"] = -1
 
@@ -489,24 +494,25 @@ def get_mollie_payment_metrics():
             # Count balance transactions processed in last 24 hours
             yesterday_str = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
 
-            balance_transactions_24h = frappe.db.count("Bank Transaction", {
-                "reference_number": ["like", "baltr_%"],
-                "creation": [">=", yesterday_str]
-            })
+            balance_transactions_24h = frappe.db.count(
+                "Bank Transaction",
+                {"reference_number": ["like", "baltr_%"], "creation": [">=", yesterday_str]},
+            )
 
             metrics["frappe.mollie.bank_transactions.count_24h"] = balance_transactions_24h
 
             # Count unreconciled balance transactions
-            unreconciled = frappe.db.count("Bank Transaction", {
-                "reference_number": ["like", "baltr_%"],
-                "status": "Unreconciled"
-            })
+            unreconciled = frappe.db.count(
+                "Bank Transaction", {"reference_number": ["like", "baltr_%"], "status": "Unreconciled"}
+            )
 
             metrics["frappe.mollie.bank_transactions.unreconciled"] = unreconciled
 
             # Reconciliation health check
             if balance_transactions_24h > 0:
-                reconciliation_rate = ((balance_transactions_24h - unreconciled) / balance_transactions_24h) * 100
+                reconciliation_rate = (
+                    (balance_transactions_24h - unreconciled) / balance_transactions_24h
+                ) * 100
                 metrics["frappe.mollie.bank_transactions.reconciliation_rate"] = round(reconciliation_rate, 2)
 
                 if reconciliation_rate < 80:
@@ -521,7 +527,10 @@ def get_mollie_payment_metrics():
                 metrics["frappe.mollie.bank_transactions.health"] = -1  # Unknown state
 
         except Exception as e:
-            frappe.log_error(f"Error getting Mollie bank transaction metrics: {str(e)}", "Zabbix Mollie Bank Transaction Error")
+            frappe.log_error(
+                f"Error getting Mollie bank transaction metrics: {str(e)}",
+                "Zabbix Mollie Bank Transaction Error",
+            )
             metrics["frappe.mollie.bank_transactions.count_24h"] = -1
             metrics["frappe.mollie.bank_transactions.unreconciled"] = -1
             metrics["frappe.mollie.bank_transactions.health"] = -1
@@ -553,7 +562,7 @@ def get_mollie_payment_metrics():
             metrics.get("frappe.mollie.cache.status", -1),
             metrics.get("frappe.mollie.balance.health", -1),
             metrics.get("frappe.mollie.bank_transactions.health", -1),
-            metrics.get("frappe.mollie.api.health", -1)
+            metrics.get("frappe.mollie.api.health", -1),
         ]
 
         # Remove error states (-1) from health calculation
@@ -580,20 +589,24 @@ def get_mollie_payment_metrics():
 def get_performance_percentiles():
     """Get performance percentile metrics (from advanced implementation)"""
     metrics = {}
-    
+
     # Get response times from last hour
-    response_times = frappe.db.sql("""
+    response_times = frappe.db.sql(
+        """
         SELECT response_time 
         FROM `tabActivity Log`
         WHERE creation >= %s
         AND response_time IS NOT NULL
         ORDER BY response_time
-    """, (add_days(now_datetime(), -1/24),), as_list=True)
-    
+    """,
+        (add_days(now_datetime(), -1 / 24),),
+        as_list=True,
+    )
+
     if response_times:
         times = [r[0] for r in response_times]
         count = len(times)
-        
+
         # Calculate percentiles
         metrics["frappe.performance.response_time_p50"] = times[int(count * 0.5)]
         metrics["frappe.performance.response_time_p95"] = times[int(count * 0.95)]
@@ -602,16 +615,17 @@ def get_performance_percentiles():
         metrics["frappe.performance.response_time_p50"] = 0
         metrics["frappe.performance.response_time_p95"] = 0
         metrics["frappe.performance.response_time_p99"] = 0
-    
+
     return metrics
 
 
 def get_error_breakdown_metrics():
     """Get error breakdown by type (from advanced implementation)"""
     metrics = {}
-    
+
     # Get error breakdown
-    error_types = frappe.db.sql("""
+    error_types = frappe.db.sql(
+        """
         SELECT 
             CASE 
                 WHEN error LIKE '%PermissionError%' THEN 'permission'
@@ -625,50 +639,53 @@ def get_error_breakdown_metrics():
         FROM `tabError Log`
         WHERE creation >= %s
         GROUP BY error_type
-    """, (add_days(now_datetime(), -1/24),), as_dict=True)
-    
+    """,
+        (add_days(now_datetime(), -1 / 24),),
+        as_dict=True,
+    )
+
     for row in error_types:
         metrics[f"frappe.errors.{row.error_type}"] = row.count
-    
+
     return metrics
 
 
 @frappe.whitelist(allow_guest=True)
 def health_check():
     """Enhanced health check endpoint with detailed status"""
-    # For now, allow all calls - we'll add authentication back later
-    # if not is_valid_request():
-    #     frappe.response["http_status_code"] = 403
-    #     return {"error": "Unauthorized"}
-    
+    # Guest-reachable endpoint: this exposes DB/redis/scheduler/disk/financial
+    # internals, so require an authenticated/authorized caller.
+    if not is_valid_request():
+        raise frappe.PermissionError(_("Unauthorized Zabbix health-check request"))
+
     checks = {
         "database": check_database_health(),
         "redis": check_redis_health(),
         "scheduler": check_scheduler_health(),
         "disk_space": check_disk_space(),
         "dues_schedules": check_dues_schedule_health(),
-        "financial": check_financial_health()
+        "financial": check_financial_health(),
     }
-    
+
     # Calculate overall health score
     health_score = sum(1 for v in checks.values() if v.get("status") == "healthy") / len(checks) * 100
-    
+
     # Determine overall status - configurable thresholds for development
     PERFECT_HEALTH_THRESHOLD = 100
     DEGRADED_HEALTH_THRESHOLD = 80
-    
+
     if health_score == PERFECT_HEALTH_THRESHOLD:
         overall_status = "healthy"
     elif health_score >= DEGRADED_HEALTH_THRESHOLD:
         overall_status = "degraded"
     else:
         overall_status = "unhealthy"
-    
+
     return {
         "status": overall_status,
         "score": round(health_score, 2),
         "checks": checks,
-        "timestamp": now_datetime().isoformat()
+        "timestamp": now_datetime().isoformat(),
     }
 
 
@@ -685,16 +702,16 @@ def zabbix_webhook_receiver():
             if not validate_webhook_signature():
                 frappe.response["http_status_code"] = 401
                 return {"status": "error", "message": "Invalid signature"}
-        
+
         # Get webhook data
         data = frappe.request.get_json()
-        
+
         # Detect format (legacy vs 7.0)
         if "event_id" in data:
             alert = process_zabbix_v7_webhook(data)
         else:
             alert = process_legacy_webhook(data)
-        
+
         # Process based on severity and tags
         if should_auto_remediate(alert):
             result = handle_auto_remediation(alert)
@@ -702,13 +719,13 @@ def zabbix_webhook_receiver():
             result = create_issue_from_alert(alert)
         else:
             result = log_alert(alert)
-        
+
         return {
             "status": "success",
             "action_taken": result.get("action"),
-            "reference": result.get("reference")
+            "reference": result.get("reference"),
         }
-        
+
     except Exception as e:
         frappe.log_error(f"Zabbix webhook error: {str(e)}")
         frappe.response["http_status_code"] = 500
@@ -725,39 +742,59 @@ def format_metrics_for_zabbix_v7(metrics):
             "app_version": frappe.get_attr("verenigingen.__version__", "unknown"),
             "frappe_version": frappe.__version__,
             "site": frappe.local.site,
-            "environment": frappe.conf.get("environment", "production")
+            "environment": frappe.conf.get("environment", "production"),
         },
         "tags": {
             "app": "verenigingen",
             "type": "business",
             "region": frappe.conf.get("region", "eu-west"),
-            "tier": frappe.conf.get("tier", "production")
-        }
+            "tier": frappe.conf.get("tier", "production"),
+        },
     }
 
 
 # Helper functions
 def is_valid_request():
-    """Validate if request is from authorized source (Zabbix or internal dashboard)"""
-    # Allow logged-in users (internal dashboard calls)
-    if frappe.session.user != "Guest":
-        frappe.logger().debug(f"Allowing authenticated user: {frappe.session.user}")
+    """Validate that a monitoring request is from an authorized source.
+
+    Resolution order: authenticated (non-Guest) session > Bearer token
+    (constant-time compare against ``zabbix_api_token``) > source-IP allow-list
+    (``zabbix_allowed_ips``) > explicit ``zabbix_allow_guest`` opt-in.
+
+    Fails CLOSED: with no token configured, no IP allow-list and
+    ``zabbix_allow_guest`` unset, an anonymous request is denied. This is what
+    keeps the metrics/health endpoints from leaking to the public internet.
+    """
+    # Internal dashboard calls run as a logged-in user.
+    if frappe.session.user and frappe.session.user != "Guest":
         return True
-    
-    # Check API token for external calls
-    auth_header = frappe.get_request_header("Authorization")
-    if auth_header:
-        token = auth_header.replace("Bearer ", "")
-        return token == frappe.conf.get("zabbix_api_token")
-    
-    # Check IP whitelist
-    allowed_ips = frappe.conf.get("zabbix_allowed_ips", [])
-    if allowed_ips:
-        client_ip = frappe.request.environ.get("REMOTE_ADDR")
-        return client_ip in allowed_ips
-    
-    # Allow guest access if explicitly configured
-    return frappe.conf.get("zabbix_allow_guest", False)
+
+    # The remaining checks need an HTTP request; there is none for CLI/in-process
+    # calls, where the authenticated-user branch above already applied.
+    request = getattr(frappe.local, "request", None)
+
+    # External (Zabbix) calls authenticate with a shared token sent in the
+    # custom `X-Zabbix-Token` header. We deliberately do NOT use `Authorization:
+    # Bearer` — Frappe intercepts that header for its own API-key/OAuth auth and
+    # rejects a non-Frappe token with 401 before this endpoint runs. Compare in
+    # constant time, and only when a token is actually configured, so an unset
+    # token can never be matched by an empty/placeholder header.
+    configured_token = frappe.conf.get("zabbix_api_token")
+    if configured_token and request is not None:
+        presented = (frappe.get_request_header("X-Zabbix-Token") or "").strip()
+        if presented and hmac.compare_digest(presented, str(configured_token)):
+            return True
+
+    # Optional source-IP allow-list.
+    allowed_ips = frappe.conf.get("zabbix_allowed_ips") or []
+    if allowed_ips and request is not None:
+        client_ip = request.environ.get("REMOTE_ADDR")
+        if client_ip and client_ip in allowed_ips:
+            return True
+
+    # Explicit, deliberate opt-in for unauthenticated access (default: deny).
+    return bool(frappe.conf.get("zabbix_allow_guest", False))
+
 
 def is_valid_zabbix_request():
     """Validate if request is from authorized Zabbix server (legacy function)"""
@@ -766,13 +803,13 @@ def is_valid_zabbix_request():
     if auth_header:
         token = auth_header.replace("Bearer ", "")
         return token == frappe.conf.get("zabbix_api_token")
-    
+
     # Check IP whitelist
     allowed_ips = frappe.conf.get("zabbix_allowed_ips", [])
     if allowed_ips:
         client_ip = frappe.request.environ.get("REMOTE_ADDR")
         return client_ip in allowed_ips
-    
+
     # Allow guest access if explicitly configured
     return frappe.conf.get("zabbix_allow_guest", False)
 
@@ -782,19 +819,15 @@ def validate_webhook_signature():
     secret = frappe.conf.get("zabbix_webhook_secret")
     if not secret:
         return True
-    
+
     signature = frappe.get_request_header("X-Zabbix-Signature")
     if not signature:
         return False
-    
+
     # Calculate expected signature
     body = frappe.request.get_data()
-    expected = hmac.new(
-        secret.encode(),
-        body,
-        hashlib.sha256
-    ).hexdigest()
-    
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
     return hmac.compare_digest(signature, expected)
 
 
@@ -804,10 +837,10 @@ def check_database_health():
         start = time.time()
         frappe.db.sql("SELECT 1")
         response_time = (time.time() - start) * 1000
-        
+
         return {
             "status": "healthy" if response_time < 100 else "degraded",
-            "response_time_ms": round(response_time, 2)
+            "response_time_ms": round(response_time, 2),
         }
     except Exception as e:
         return {"status": "unhealthy", "error": str(e)}
@@ -824,18 +857,13 @@ def check_redis_health():
 
 def check_scheduler_health():
     """Check if scheduler is running properly"""
-    last_run = frappe.db.get_value(
-        "Scheduled Job Log",
-        {},
-        "creation",
-        order_by="creation desc"
-    )
-    
+    last_run = frappe.db.get_value("Scheduled Job Log", {}, "creation", order_by="creation desc")
+
     if not last_run:
         return {"status": "unhealthy", "error": "No scheduler runs found"}
-    
+
     minutes_since = (now_datetime() - get_datetime(last_run)).total_seconds() / 60
-    
+
     if minutes_since < 10:
         return {"status": "healthy", "last_run_minutes_ago": round(minutes_since, 2)}
     else:
@@ -845,21 +873,21 @@ def check_scheduler_health():
 def check_disk_space():
     """Check available disk space"""
     import shutil
-    
+
     stat = shutil.disk_usage("/")
     percent_used = (stat.used / stat.total) * 100
-    
+
     if percent_used < 80:
         status = "healthy"
     elif percent_used < 90:
         status = "degraded"
     else:
         status = "unhealthy"
-    
+
     return {
         "status": status,
         "percent_used": round(percent_used, 2),
-        "gb_free": round(stat.free / (1024**3), 2)
+        "gb_free": round(stat.free / (1024**3), 2),
     }
 
 
@@ -870,26 +898,26 @@ def check_dues_schedule_health():
         "Scheduled Job Log",
         {"scheduled_job_type": ["like", "%process_all_dues_schedule%"]},
         "creation",
-        order_by="creation desc"
+        order_by="creation desc",
     )
-    
+
     # Also check for dues schedule specific processing
     last_dues_run = frappe.db.get_value(
         "Scheduled Job Log",
         {"scheduled_job_type": ["like", "%dues_schedule%"]},
         "creation",
-        order_by="creation desc"
+        order_by="creation desc",
     )
-    
+
     # Use the more recent of the two
     if last_dues_run and (not last_run or get_datetime(last_dues_run) > get_datetime(last_run)):
         last_run = last_dues_run
-    
+
     if not last_run:
         return {"status": "unhealthy", "error": "Dues schedule processing never run"}
-    
+
     hours_since = (now_datetime() - get_datetime(last_run)).total_seconds() / 3600
-    
+
     if hours_since < 25:  # Should run daily
         return {"status": "healthy", "last_run_hours_ago": round(hours_since, 2)}
     else:
@@ -899,11 +927,10 @@ def check_dues_schedule_health():
 def check_financial_health():
     """Check financial processing health"""
     # Check for stuck invoices
-    stuck_invoices = frappe.db.count("Sales Invoice", {
-        "docstatus": 0,
-        "creation": ["<", add_days(now_datetime(), -1)]
-    })
-    
+    stuck_invoices = frappe.db.count(
+        "Sales Invoice", {"docstatus": 0, "creation": ["<", add_days(now_datetime(), -1)]}
+    )
+
     if stuck_invoices == 0:
         return {"status": "healthy"}
     elif stuck_invoices < 5:
@@ -917,46 +944,46 @@ def should_auto_remediate(alert):
     # Check for auto_remediate tag (Zabbix 7.0)
     if any(tag.get("tag") == "auto_remediate" for tag in alert.get("tags", [])):
         return True
-    
+
     # Check for specific trigger patterns
-    auto_remediate_triggers = [
-        "High memory usage",
-        "Stuck background jobs",
-        "Redis connection failed"
-    ]
-    
+    auto_remediate_triggers = ["High memory usage", "Stuck background jobs", "Redis connection failed"]
+
     return any(trigger in alert.get("trigger_name", "") for trigger in auto_remediate_triggers)
 
 
 def handle_auto_remediation(alert):
     """Handle auto-remediation for specific alerts"""
     trigger = alert.get("trigger_name", "")
-    
+
     if "High memory usage" in trigger:
         # Clear caches
         frappe.cache().delete_keys("*")
         return {"action": "cleared_cache", "reference": "Memory freed"}
-    
+
     elif "Stuck background jobs" in trigger:
         # Clear stuck jobs
-        frappe.db.sql("""
+        frappe.db.sql(
+            """
             UPDATE `tabRQ Job` 
             SET status = 'failed' 
             WHERE status = 'started' 
             AND started_at < %s
-        """, (add_days(now_datetime(), -30/1440),))  # 30 minutes old
+        """,
+            (add_days(now_datetime(), -30 / 1440),),
+        )  # 30 minutes old
         frappe.db.commit()
         return {"action": "cleared_stuck_jobs", "reference": "Jobs cleared"}
-    
+
     elif "Redis connection failed" in trigger:
         # Restart Redis (requires sudo permissions)
         import subprocess
+
         try:
             subprocess.run(["sudo", "systemctl", "restart", "redis"], check=True)
             return {"action": "restarted_redis", "reference": "Redis restarted"}
         except:
             return {"action": "failed", "reference": "Could not restart Redis"}
-    
+
     return {"action": "no_remediation", "reference": "No auto-remediation available"}
 
 
@@ -974,10 +1001,10 @@ def create_issue_from_alert(alert):
 **Additional Data:**
 {json.dumps(alert.get('operational_data', {}), indent=2)}
 """
-    issue.priority = "High" if alert.get('severity') == "Disaster" else "Medium"
+    issue.priority = "High" if alert.get("severity") == "Disaster" else "Medium"
     issue.issue_type = "System Alert"
     issue.insert(ignore_permissions=True)
-    
+
     # Send email notification via EmailService for central control
     recipients = frappe.conf.get("alert_recipients", [])
     if recipients:
@@ -1001,7 +1028,7 @@ def create_issue_from_alert(alert):
                 message=issue.description,
                 delayed=False,
             )
-    
+
     return {"action": "created_issue", "reference": issue.name}
 
 
@@ -1019,13 +1046,10 @@ def log_alert(alert):
             return {"action": "logged_alert", "reference": log.name}
     except:
         pass
-    
+
     # Fallback to error log
-    frappe.log_error(
-        f"Zabbix Alert: {alert.get('trigger_name')}",
-        json.dumps(alert, indent=2)
-    )
-    
+    frappe.log_error(f"Zabbix Alert: {alert.get('trigger_name')}", json.dumps(alert, indent=2))
+
     return {"action": "logged_to_error_log", "reference": "Error Log"}
 
 
@@ -1034,7 +1058,7 @@ def process_zabbix_v7_webhook(data):
     # Safe extraction of nested webhook data
     trigger_data = data.get("trigger")
     host_data = data.get("host")
-    
+
     return {
         "event_id": data.get("event_id"),
         "trigger_id": data.get("trigger_id"),
@@ -1044,7 +1068,7 @@ def process_zabbix_v7_webhook(data):
         "timestamp": data.get("timestamp"),
         "value": data.get("value"),
         "operational_data": data.get("operational_data", {}),
-        "tags": data.get("tags", []) + data.get("event_tags", [])
+        "tags": data.get("tags", []) + data.get("event_tags", []),
     }
 
 
@@ -1057,5 +1081,5 @@ def process_legacy_webhook(data):
         "timestamp": data.get("timestamp", now_datetime()),
         "value": data.get("value"),
         "operational_data": {},
-        "tags": []
+        "tags": [],
     }

--- a/verenigingen/api/get_user_chapters.py
+++ b/verenigingen/api/get_user_chapters.py
@@ -15,8 +15,8 @@ from verenigingen.utils.operation_result import OperationResult
 from verenigingen.utils.security.api_security_framework import OperationType, public_api
 
 
-@public_api(operation_type=OperationType.PUBLIC)  # Public chapter listing with user membership status
 @frappe.whitelist(allow_guest=True)
+@public_api(operation_type=OperationType.PUBLIC)  # Public chapter listing with user membership status
 def get_user_chapter_data() -> OperationResult[Dict[str, Any]]:
     """Get current user's chapter memberships"""
     try:

--- a/verenigingen/commands/performance_optimization.py
+++ b/verenigingen/commands/performance_optimization.py
@@ -30,9 +30,15 @@ import frappe
 from frappe import _
 
 from verenigingen.utils.constants import Roles
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    critical_api,
+    high_security_api,
+)
 
 
 @frappe.whitelist(allow_guest=False)
+@critical_api(operation_type=OperationType.ADMIN)
 def apply_optimizations():
     """Apply all performance optimizations to the database"""
 
@@ -71,6 +77,7 @@ def apply_optimizations():
 
 
 @frappe.whitelist(allow_guest=False)
+@high_security_api(operation_type=OperationType.ADMIN)
 def check_optimization_status():
     """Check the current status of performance optimizations"""
 
@@ -129,6 +136,7 @@ def check_optimization_status():
 
 
 @frappe.whitelist(allow_guest=False)
+@high_security_api(operation_type=OperationType.ADMIN)
 def analyze_query_performance():
     """Analyze current query performance and identify bottlenecks"""
 

--- a/verenigingen/e_boekhouden/doctype/e_boekhouden_account_mapping/e_boekhouden_account_mapping.py
+++ b/verenigingen/e_boekhouden/doctype/e_boekhouden_account_mapping/e_boekhouden_account_mapping.py
@@ -5,6 +5,12 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import now
 
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    high_security_api,
+    utility_api,
+)
+
 
 class EBoekhoudenAccountMapping(Document):
     def validate(self):
@@ -70,6 +76,7 @@ class EBoekhoudenAccountMapping(Document):
 
 
 @frappe.whitelist()
+@utility_api
 def get_mapping_for_mutation(account_code, description):
     """Get the appropriate mapping for a mutation based on account code and description"""
     # First try to find by account code
@@ -133,6 +140,7 @@ def get_mapping_for_mutation(account_code, description):
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def create_default_mappings():
     """Create default mappings based on common Dutch accounting patterns"""
     default_mappings = [

--- a/verenigingen/email/advanced_segmentation.py
+++ b/verenigingen/email/advanced_segmentation.py
@@ -15,6 +15,13 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, getdate, now_datetime
 
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    high_security_api,
+    standard_api,
+    utility_api,
+)
+
 
 class AdvancedSegmentationManager:
     """Manager for advanced member segmentation and targeting"""
@@ -647,6 +654,7 @@ class AdvancedSegmentationManager:
 
 # API Functions
 @frappe.whitelist()
+@utility_api
 def get_available_segments(chapter_name: str = None) -> Dict:
     """Get available segmentation options"""
     manager = AdvancedSegmentationManager()
@@ -666,6 +674,7 @@ def get_available_segments(chapter_name: str = None) -> Dict:
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def get_segment_recipients(segment_id: str, chapter_name: str = None, preview_only: bool = False) -> Dict:
     """
     Get recipients for a segment
@@ -701,6 +710,7 @@ def get_segment_recipients(segment_id: str, chapter_name: str = None, preview_on
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def create_segment_combination(
     segment_ids: str, operation: str = "intersection", chapter_name: str = None
 ) -> Dict:
@@ -732,6 +742,7 @@ def create_segment_combination(
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def analyze_segment_overlap(segment_ids: str, chapter_name: str = None) -> Dict:
     """
     Analyze overlap between segments
@@ -760,6 +771,7 @@ def analyze_segment_overlap(segment_ids: str, chapter_name: str = None) -> Dict:
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def get_segment_suggestions(chapter_name: str = None) -> Dict:
     """Get segment suggestions for a chapter"""
     # Check permissions

--- a/verenigingen/email/automated_campaigns.py
+++ b/verenigingen/email/automated_campaigns.py
@@ -16,6 +16,12 @@ from frappe import _
 from frappe.utils import add_days, add_months, formatdate, get_datetime, now_datetime
 
 from verenigingen.utils.constants import Roles
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    high_security_api,
+    standard_api,
+    utility_api,
+)
 
 
 class AutomatedCampaignManager:
@@ -424,6 +430,7 @@ class AutomatedCampaignManager:
 
 # API Functions
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def create_automated_campaign(
     campaign_type: str,
     chapter_name: str = None,
@@ -477,6 +484,7 @@ def create_automated_campaign(
 
 
 @frappe.whitelist()
+@utility_api
 def get_campaign_types() -> Dict:
     """Get available campaign types"""
     manager = AutomatedCampaignManager()
@@ -484,6 +492,7 @@ def get_campaign_types() -> Dict:
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def get_active_campaigns(chapter_name: str = None) -> Dict:
     """Get active campaigns for a chapter or organization"""
     filters = {"status": "In Progress"}  # Use actual field for filtering active campaigns
@@ -510,6 +519,7 @@ def get_active_campaigns(chapter_name: str = None) -> Dict:
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def trigger_campaign_test(campaign_id: str) -> Dict:
     """Trigger a test run of a campaign"""
     # Check permissions

--- a/verenigingen/email/validation_utils.py
+++ b/verenigingen/email/validation_utils.py
@@ -8,8 +8,11 @@ Simple validation utilities for the email system.
 
 import frappe
 
+from verenigingen.utils.security.api_security_framework import development_only_api
+
 
 @frappe.whitelist()
+@development_only_api()
 def validate_email_system_components():
     """Validate that email system components can be imported and instantiated"""
 

--- a/verenigingen/events/migration_helper.py
+++ b/verenigingen/events/migration_helper.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _
 
 from verenigingen.utils.constants import Roles
+from verenigingen.utils.security.api_security_framework import development_only_api
 
 
 def ensure_payment_history_current():
@@ -61,6 +62,7 @@ def ensure_payment_history_current():
 
 
 @frappe.whitelist()
+@development_only_api()
 def test_event_system():
     """Test function to verify the event system is working.
 

--- a/verenigingen/mijnrood_sync/doctype/mijnrood_sync_event/mijnrood_sync_event.py
+++ b/verenigingen/mijnrood_sync/doctype/mijnrood_sync_event/mijnrood_sync_event.py
@@ -3,9 +3,12 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import now_datetime
 
+from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
+
 
 class MijnRoodSyncEvent(Document):
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def approve(self):
         """Approve this sync event for application."""
         if self.status != "Pending":
@@ -17,6 +20,7 @@ class MijnRoodSyncEvent(Document):
         self.save()
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def reject(self):
         """Reject this sync event."""
         if self.status != "Pending":
@@ -28,6 +32,7 @@ class MijnRoodSyncEvent(Document):
         self.save()
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def ignore_event(self):
         """Ignore this sync event (acknowledged but not applied)."""
         if self.status != "Pending":
@@ -39,6 +44,7 @@ class MijnRoodSyncEvent(Document):
         self.save()
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def approve_and_apply(self):
         """Approve and immediately apply this sync event."""
         if self.status != "Pending":
@@ -57,6 +63,7 @@ class MijnRoodSyncEvent(Document):
         return service.apply_event(self.name)
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def apply_event(self):
         """Apply this approved sync event to Verenigingen data."""
         if self.status != "Approved":
@@ -70,12 +77,14 @@ class MijnRoodSyncEvent(Document):
         return service.apply_event(self.name)
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.MEMBER_DATA)
     def get_member_comparison_data(self):
         """Return current Frappe member field values for comparison with MijnRood data."""
         return _get_member_comparison_data(self.name)
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def get_member_comparison_data(event_name: str) -> dict:
     """Return current Frappe member field values for comparison with MijnRood data.
 

--- a/verenigingen/mijnrood_sync/doctype/mijnrood_sync_settings/mijnrood_sync_settings.py
+++ b/verenigingen/mijnrood_sync/doctype/mijnrood_sync_settings/mijnrood_sync_settings.py
@@ -4,11 +4,16 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from verenigingen.utils.security.api_security_framework import OperationType, standard_api
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    high_security_api,
+    standard_api,
+)
 
 
 class MijnRoodSyncSettings(Document):
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def test_connection(self):
         """Test SSH tunnel and database connectivity."""
         from verenigingen.mijnrood_sync.client import MijnRoodDatabaseClient
@@ -30,6 +35,7 @@ class MijnRoodSyncSettings(Document):
             return {"success": False, "message": error_msg}
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def diagnose_ssh_auth(self, attempt_handshake: bool = False):
         """Report which SSH auth path would fire and what key (if any) parses.
 
@@ -249,6 +255,7 @@ class MijnRoodSyncSettings(Document):
         return result
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def trigger_sync_now(self):
         """Enqueue an immediate sync job."""
         frappe.enqueue(
@@ -389,6 +396,7 @@ class MijnRoodSyncSettings(Document):
         frappe.cache.delete_value("mijnrood_role_mapping")
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def fetch_lidmaatschapstypes_from_mijnrood(self):
         """Fetch membership statuses from MijnRood's admin_membershipstatus table.
 
@@ -485,6 +493,7 @@ class MijnRoodSyncSettings(Document):
         return {"success": True, "message": message}
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def populate_default_status_mapping(self):
         """Load default status mapping values into the child table.
 
@@ -522,6 +531,7 @@ class MijnRoodSyncSettings(Document):
         }
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def populate_default_role_mapping(self):
         """Load default role mapping values into the child table.
 
@@ -565,6 +575,7 @@ class MijnRoodSyncSettings(Document):
         }
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def first_time_setup(self):
         """One-click initial configuration for a fresh MijnRood Sync install.
 
@@ -663,6 +674,7 @@ class MijnRoodSyncSettings(Document):
         return {purpose: spec["name"] for purpose, spec in teams.items()}
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def auto_classify_folders(self):
         """Auto-classify document_type and chapter on folder mapping rows.
 
@@ -678,6 +690,7 @@ class MijnRoodSyncSettings(Document):
         return service.auto_classify_folder_mappings()
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def fetch_document_folders(self):
         """Fetch document folders from MijnRood and populate the mapping table.
 
@@ -702,6 +715,7 @@ class MijnRoodSyncSettings(Document):
         return result
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.ADMIN)
     def import_documents(self):
         """Enqueue a background job to import documents from MijnRood.
 

--- a/verenigingen/monitoring/zabbix_integration.py
+++ b/verenigingen/monitoring/zabbix_integration.py
@@ -12,6 +12,7 @@ import os
 import sys
 
 import frappe
+from frappe import _
 
 from verenigingen.utils.security.api_security_framework import OperationType, webhook_api
 
@@ -28,21 +29,39 @@ def _import_monitoring_functions():
         from monitoring.zabbix_integration import (  # noqa: E402  # noqa: E402
             get_metrics_for_zabbix as _get_metrics_for_zabbix,
             health_check as _health_check,  # noqa: E402
+            is_valid_request as _is_valid_request,
             zabbix_webhook_receiver as _zabbix_webhook_receiver,
         )
 
-        return _get_metrics_for_zabbix, _health_check, _zabbix_webhook_receiver
+        return _get_metrics_for_zabbix, _health_check, _zabbix_webhook_receiver, _is_valid_request
     except ImportError as e:
         frappe.log_error(f"Failed to import monitoring functions: {str(e)}")
-        return None, None, None
+        return None, None, None, None
 
 
-_get_metrics_for_zabbix, _health_check, _zabbix_webhook_receiver = _import_monitoring_functions()
+(
+    _get_metrics_for_zabbix,
+    _health_check,
+    _zabbix_webhook_receiver,
+    _is_valid_request,
+) = _import_monitoring_functions()
+
+
+def _require_zabbix_auth():
+    """Deny the request unless it is an authorized monitoring caller.
+
+    Enforced here (before the swallowing try/except below) so an unauthenticated
+    request gets a clean 403 instead of a 200 error envelope. Fails CLOSED if the
+    scripts implementation could not be imported.
+    """
+    if _is_valid_request is None or not _is_valid_request():
+        raise frappe.PermissionError(_("Unauthorized monitoring request"))
 
 
 @frappe.whitelist(allow_guest=True)
 def get_metrics_for_zabbix():
     """Get metrics for Zabbix monitoring."""
+    _require_zabbix_auth()
     try:
         # Debug: Log the current user
         frappe.logger().info(f"get_metrics_for_zabbix called by user: {frappe.session.user}")
@@ -63,6 +82,7 @@ def get_metrics_for_zabbix():
 @frappe.whitelist(allow_guest=True)
 def health_check():
     """Health check endpoint for monitoring."""
+    _require_zabbix_auth()
     try:
         return _health_check()
     except Exception as e:

--- a/verenigingen/monitoring/zabbix_integration.py
+++ b/verenigingen/monitoring/zabbix_integration.py
@@ -13,6 +13,8 @@ import sys
 
 import frappe
 
+from verenigingen.utils.security.api_security_framework import OperationType, webhook_api
+
 # Add the scripts directory to the Python path
 scripts_dir = os.path.join(os.path.dirname(__file__), "..", "..", "scripts")
 if scripts_dir not in sys.path:
@@ -70,6 +72,7 @@ def health_check():
 
 
 @frappe.whitelist()
+@webhook_api(operation_type=OperationType.WEBHOOK_PROCESSING)
 def zabbix_webhook_receiver():
     """Receive webhooks from Zabbix for auto-remediation."""
     return _zabbix_webhook_receiver()

--- a/verenigingen/monitoring/zabbix_integration.py
+++ b/verenigingen/monitoring/zabbix_integration.py
@@ -14,8 +14,6 @@ import sys
 import frappe
 from frappe import _
 
-from verenigingen.utils.security.api_security_framework import OperationType, webhook_api
-
 # Add the scripts directory to the Python path
 scripts_dir = os.path.join(os.path.dirname(__file__), "..", "..", "scripts")
 if scripts_dir not in sys.path:
@@ -91,8 +89,15 @@ def health_check():
         return {"status": "unhealthy", "error": str(e), "timestamp": frappe.utils.now_datetime().isoformat()}
 
 
-@frappe.whitelist()
-@webhook_api(operation_type=OperationType.WEBHOOK_PROCESSING)
+@frappe.whitelist(allow_guest=True)
 def zabbix_webhook_receiver():
-    """Receive webhooks from Zabbix for auto-remediation."""
+    """Receive webhooks from Zabbix for auto-remediation.
+
+    Guest-reachable but authenticated inside the scripts implementation via an
+    HMAC signature over the request body (``zabbix_webhook_secret`` +
+    ``X-Zabbix-Signature``). Auto-remediation is dangerous (cache flush / RQ-job
+    failure / Redis restart), so the signature is mandatory and fails closed when
+    no secret is configured. Not gated by the shared read token used for
+    metrics/health — remediation requires its own dedicated secret.
+    """
     return _zabbix_webhook_receiver()

--- a/verenigingen/permissions.py
+++ b/verenigingen/permissions.py
@@ -65,8 +65,11 @@ from verenigingen.utils.member_utils import (
     get_member_name_for_user,
     get_volunteer_for_member,
 )
-from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
-from verenigingen.utils.security_decorators import development_only
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    development_only_api,
+    high_security_api,
+)
 from verenigingen.utils.validation_utilities import DocumentExistenceValidator
 
 # Permission Caching System
@@ -178,7 +181,7 @@ def can_access_termination_functions_api():
 
 
 @frappe.whitelist()
-@development_only()
+@development_only_api()
 def test_team_member_access(team_name: str | None = None):
     """Test function to verify team member access permissions"""
     user = frappe.session.user

--- a/verenigingen/services/document/document_portal_service.py
+++ b/verenigingen/services/document/document_portal_service.py
@@ -30,7 +30,7 @@ from frappe.utils import today
 
 from verenigingen.services.infrastructure.base_service import StatelessService
 from verenigingen.utils.constants import Roles
-from verenigingen.utils.document_categories import get_category_icon, get_document_category_options
+from verenigingen.utils.document_categories import _format_category_options, get_category_icon
 
 
 @dataclass
@@ -179,7 +179,7 @@ class DocumentPortalService(StatelessService):
                 ]
 
             # Get document categories
-            categories_raw = get_document_category_options()
+            categories_raw = _format_category_options()
             categories = [
                 {"name": cat, "icon": get_category_icon(cat)} for cat in categories_raw.split("\n") if cat
             ]

--- a/verenigingen/services/member/testing/member_debug_tools.py
+++ b/verenigingen/services/member/testing/member_debug_tools.py
@@ -38,6 +38,7 @@ from frappe.utils import now_datetime, today
 
 from verenigingen.services.infrastructure.base_service import StatelessService
 from verenigingen.utils.operation_result import OperationResult
+from verenigingen.utils.security.api_security_framework import development_only_api
 
 
 class MemberDebugToolsService(StatelessService):
@@ -54,6 +55,7 @@ def _get_service() -> MemberDebugToolsService:
 
 
 @frappe.whitelist()
+@development_only_api()
 def debug_button_conditions(member_name) -> OperationResult[Dict[str, Any]]:
     """Debug what buttons should appear for a member.
 
@@ -125,6 +127,7 @@ def debug_button_conditions(member_name) -> OperationResult[Dict[str, Any]]:
 
 
 @frappe.whitelist()
+@development_only_api()
 def debug_member_id_assignment(member_name) -> OperationResult[Dict[str, Any]]:
     """Debug why member ID assignment is failing.
 
@@ -183,6 +186,7 @@ def debug_member_id_assignment(member_name) -> OperationResult[Dict[str, Any]]:
 
 
 @frappe.whitelist()
+@development_only_api()
 def debug_member_status(member_name) -> OperationResult[Dict[str, Any]]:
     """Debug member status for button investigation.
 

--- a/verenigingen/services/termination/termination_utils.py
+++ b/verenigingen/services/termination/termination_utils.py
@@ -2,11 +2,17 @@ import frappe
 from frappe.utils import add_days, getdate, today
 
 from verenigingen.utils.constants import Roles
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    high_security_api,
+    standard_api,
+)
 
 # ===== Your existing functions from paste.txt go here =====
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def validate_termination_readiness(member_name: str):
     """
     Validate if a member is ready for termination and return impact assessment
@@ -191,6 +197,7 @@ def validate_termination_readiness(member_name: str):
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def get_termination_impact_summary(member_name: str):
     """
     Get a summary of what will be affected by member termination
@@ -435,6 +442,7 @@ def generate_weekly_termination_report():
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def get_termination_statistics():
     """
     Get overall termination statistics for dashboard

--- a/verenigingen/services/volunteer/native_expense_helpers.py
+++ b/verenigingen/services/volunteer/native_expense_helpers.py
@@ -6,7 +6,7 @@ Replaces the complex department hierarchy with simple role-based approvals
 import frappe
 
 from verenigingen.utils.secure_operations import secure_document_operation
-from verenigingen.utils.security.api_security_framework import OperationType, critical_api
+from verenigingen.utils.security.api_security_framework import OperationType, critical_api, high_security_api
 
 
 def get_volunteer_expense_approver(volunteer_name):
@@ -74,6 +74,7 @@ def update_employee_approver(volunteer_doc=None, method=None):
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def refresh_all_expense_approvers():
     """Refresh expense approvers for all volunteers with employee records"""
     updated_count = 0

--- a/verenigingen/setup/public_document_creator_setup.py
+++ b/verenigingen/setup/public_document_creator_setup.py
@@ -136,6 +136,12 @@ def generate_public_creator_email():
         # making user creation — and thus the whole setup — fail. Only underscores
         # (illegal in a hostname) need sanitising.
         clean_site = site_name.replace("_", "-")
+        # A dotless domain is not a valid email address. Production site names are
+        # FQDNs (they have a dot), but a bare site name such as the CI "test_site"
+        # sanitises to "test-site" with no TLD and would fail User email validation
+        # — and thus the whole setup. Fall back to a .local TLD in that case.
+        if "." not in clean_site:
+            clean_site = f"{clean_site}.local"
         user_email = f"public-creator@{clean_site}"
 
         counter = 1

--- a/verenigingen/setup/webhook_user_setup.py
+++ b/verenigingen/setup/webhook_user_setup.py
@@ -159,6 +159,22 @@ def assign_webhook_roles(webhook_email):
         )
         if not has_role_profile:
             user_doc.append("role_profiles", {"role_profile": "Verenigingen Webhook User"})
+
+        # Ensure the Module Profile exists before linking it. In production the
+        # v2_1 sync_module_profiles patch creates it during migrate, but on a fresh
+        # site (or a test DB where this setup runs before that patch) the record is
+        # absent and assigning a non-existent Module Profile fails User validation.
+        # Create it idempotently, mirroring the patch's in_install flag handling
+        # (its Module Profile on_update queues a locked background job otherwise).
+        if not frappe.db.exists("Module Profile", "Verenigingen Webhook User"):
+            from verenigingen.patches.v2_1.sync_module_profiles_safely import sync_module_profiles
+
+            original_in_install = frappe.flags.in_install
+            frappe.flags.in_install = True
+            try:
+                sync_module_profiles()
+            finally:
+                frappe.flags.in_install = original_in_install
         user_doc.module_profile = "Verenigingen Webhook User"
 
         user_doc.save(ignore_permissions=True)

--- a/verenigingen/templates/pages/board/document_browser.py
+++ b/verenigingen/templates/pages/board/document_browser.py
@@ -12,7 +12,7 @@ import frappe
 from frappe import _
 
 from verenigingen.services.document.document_portal_service import get_document_portal_service
-from verenigingen.utils.document_categories import get_category_icon, get_document_category_options
+from verenigingen.utils.document_categories import _format_category_options, get_category_icon
 from verenigingen.utils.member_utils import require_login
 
 
@@ -62,7 +62,7 @@ def get_context(context):
     context.documents = serialize_dates(browse_result.get("documents", []))
 
     # Get document categories for filter dropdown
-    categories_raw = get_document_category_options()
+    categories_raw = _format_category_options()
     context.categories = [
         {"name": cat, "icon": get_category_icon(cat)} for cat in categories_raw.split("\n") if cat
     ]

--- a/verenigingen/templates/pages/brand_css.py
+++ b/verenigingen/templates/pages/brand_css.py
@@ -4,6 +4,7 @@ import frappe
 from frappe.utils import now
 
 from verenigingen.utils.brand_css_generator import get_brand_css_file_path
+from verenigingen.utils.security.api_security_framework import public_api
 
 
 def get_context(context):
@@ -41,6 +42,7 @@ def get_context(context):
 
 
 @frappe.whitelist(allow_guest=True)
+@public_api
 def serve_brand_css():
     """Serve brand CSS with proper MIME type"""
     try:

--- a/verenigingen/templates/pages/membership_application.py
+++ b/verenigingen/templates/pages/membership_application.py
@@ -90,6 +90,7 @@ def get_membership_type_details(membership_type_name: str):
 
 
 @frappe.whitelist(allow_guest=True)
+@public_api
 def get_dues_schedules_for_membership_type(membership_type_name: str):
     """Get all dues schedule templates for a specific membership type.
 

--- a/verenigingen/templates/pages/personal_details.py
+++ b/verenigingen/templates/pages/personal_details.py
@@ -12,6 +12,7 @@ from frappe.utils import cint, today
 
 from verenigingen.utils.member_portal_utils import setup_portal_context
 from verenigingen.utils.member_utils import get_current_user_member_name
+from verenigingen.utils.security.api_security_framework import OperationType, self_service_api
 
 
 def get_context(context):
@@ -97,6 +98,7 @@ def has_website_permission(doc, ptype, user, verbose=False):
 
 
 @frappe.whitelist(allow_guest=False, methods=["POST"])
+@self_service_api(operation_type=OperationType.MEMBER_DATA, implicit_allowed=True)
 def update_personal_details():
     """Handle personal details form submission"""
 

--- a/verenigingen/templates/pages/volunteer/expenses.py
+++ b/verenigingen/templates/pages/volunteer/expenses.py
@@ -24,7 +24,11 @@ from verenigingen.services.volunteer.volunteer_expense_portal_utils import (
     validate_expense_data,
 )
 from verenigingen.utils.member_utils import get_member_name_for_user, get_volunteer_for_current_user
-from verenigingen.utils.security.api_security_framework import high_security_api, standard_api
+from verenigingen.utils.security.api_security_framework import (
+    high_security_api,
+    self_service_api,
+    standard_api,
+)
 from verenigingen.utils.security.types import OperationType
 
 
@@ -236,6 +240,7 @@ def submit_expense(expense_data=None, additional_expenses=None):
 
 
 @frappe.whitelist(allow_guest=False)
+@self_service_api(operation_type=OperationType.FINANCIAL, implicit_allowed=True)
 def submit_multiple_expenses(expenses):
     """Submit multiple expenses from the portal at once.
 
@@ -414,6 +419,7 @@ def get_expense_details(expense_name: str):
 
 
 @frappe.whitelist(allow_guest=False)
+@self_service_api(operation_type=OperationType.MEMBER_DATA, implicit_allowed=True)
 def get_volunteer_expense_context():
     """Get context data for the expense claim form (API endpoint)."""
     try:

--- a/verenigingen/tests/backend/components/test_chapter_dashboard_page.py
+++ b/verenigingen/tests/backend/components/test_chapter_dashboard_page.py
@@ -38,6 +38,11 @@ class TestChapterDashboardPage(VereningingenTestCase):
         self.board_user = self.create_test_user(
             self.board_email, roles=["Verenigingen Chapter Board Member"]
         )
+        # Post the Rule-5 cap, the dashboard endpoint (@high_security_api) needs an
+        # assigned role PROFILE, not a bare Chapter Board Member role.
+        from verenigingen.tests.fixtures.role_profile_helper import grant_matching_role_profiles
+
+        grant_matching_role_profiles(self.board_email, "Verenigingen Chapter Board Member")
         self.board_member = self.create_test_member(
             chapter=self.chapter.name, email=self.board_email
         )

--- a/verenigingen/tests/backend/components/test_membership_analytics_permissions.py
+++ b/verenigingen/tests/backend/components/test_membership_analytics_permissions.py
@@ -60,10 +60,17 @@ class TestMembershipAnalyticsPermissions(BaseTestCase):
         # Add specified roles
         for role in roles:
             user.append("roles", {"role": role})
-        
+
         user.save()  # VereningingenTestCase (via BaseTestCase) handles permissions appropriately
         frappe.db.commit()
-        
+
+        # Post the audit #2 Rule-5 cap, HIGH/CRITICAL access needs an assigned role
+        # PROFILE; assign the profile matching each role so admin/staff/board users
+        # clear the analytics endpoints' gate (Member/no-role stay denied).
+        from verenigingen.tests.fixtures.role_profile_helper import grant_matching_role_profiles
+
+        grant_matching_role_profiles(email, roles)
+
         return email
     
     def setUp(self):
@@ -585,7 +592,13 @@ class TestMembershipAnalyticsDataSecurity(BaseTestCase):
         user.roles = []
         user.append("roles", {"role": "Verenigingen Staff"})
         user.save()  # VereningingenTestCase (via BaseTestCase) handles permissions appropriately
-        
+
+        # Post the Rule-5 cap, the analytics endpoints (@high_security_api) require an
+        # assigned role PROFILE, not a bare Staff role. Grant the matching profile.
+        from verenigingen.tests.fixtures.role_profile_helper import grant_matching_role_profiles
+
+        grant_matching_role_profiles(email, "Verenigingen Staff")
+
         # Link user to chapter via Member if one exists for this user
         # Note: Chapter Member requires a Member reference, not User
         member_name = frappe.db.get_value("Member", {"user": email}, "name")

--- a/verenigingen/tests/backend/unit/services/test_member_debug_tools_api.py
+++ b/verenigingen/tests/backend/unit/services/test_member_debug_tools_api.py
@@ -4,12 +4,13 @@
 """
 Unit tests for Member Debug Tools API
 
-Tests member debugging utility API endpoints with OperationResult pattern.
-Focus on type-safe error handling for member debugging operations.
+Tests member debugging utility API endpoints.
 
-Migration Status: ✅ COMPLETE (2025-11-25)
-- All tests use OperationResult API
-- Proper assertions for .success, .data, .error_message
+These endpoints are whitelisted and wrapped by @development_only_api, whose shared
+decorator serializes the OperationResult return via to_dict(scrub_sensitive=True)
+at the API boundary. So callers (including these in-process tests) receive the
+nested dict schema: {"success", "timestamp", "data"|"error": {"message","errors"},
+"meta"} -- not the OperationResult object. Assertions read those dict keys.
 """
 
 import frappe
@@ -40,21 +41,21 @@ class TestMemberDebugToolsAPI(EnhancedTestCase):
 
         # OperationResult pattern
         self.assertIsNotNone(result)
-        self.assertIsNotNone(result.success)
+        self.assertIsNotNone(result["success"])
 
-        if result.success:
-            self.assertIsInstance(result.data, dict)
-            self.assertIn("has_customer", result.data)
-            self.assertIn("has_user", result.data)
-            self.assertIn("debug_completed", result.data)
+        if result["success"]:
+            self.assertIsInstance(result["data"], dict)
+            self.assertIn("has_customer", result["data"])
+            self.assertIn("has_user", result["data"])
+            self.assertIn("debug_completed", result["data"])
 
     def test_debug_button_conditions_with_invalid_member(self):
         """Test debug_button_conditions with non-existent member"""
         result = debug_button_conditions("INVALID_MEMBER_NAME")
 
         # Should fail gracefully
-        self.assertFalse(result.success)
-        self.assertIsNotNone(result.error_message)
+        self.assertFalse(result["success"])
+        self.assertIsNotNone(result["error"]["message"])
 
     def test_debug_member_id_assignment_returns_operation_result(self):
         """Test debug_member_id_assignment returns OperationResult"""
@@ -62,21 +63,21 @@ class TestMemberDebugToolsAPI(EnhancedTestCase):
 
         # OperationResult pattern
         self.assertIsNotNone(result)
-        self.assertIsNotNone(result.success)
+        self.assertIsNotNone(result["success"])
 
-        if result.success:
-            self.assertIsInstance(result.data, dict)
-            self.assertIn("member_name", result.data)
-            self.assertIn("has_member_id", result.data)
-            self.assertIn("can_assign_id", result.data)
+        if result["success"]:
+            self.assertIsInstance(result["data"], dict)
+            self.assertIn("member_name", result["data"])
+            self.assertIn("has_member_id", result["data"])
+            self.assertIn("can_assign_id", result["data"])
 
     def test_debug_member_id_assignment_with_invalid_member(self):
         """Test debug_member_id_assignment with non-existent member"""
         result = debug_member_id_assignment("INVALID_MEMBER_NAME")
 
         # Should fail gracefully
-        self.assertFalse(result.success)
-        self.assertIsNotNone(result.error_message)
+        self.assertFalse(result["success"])
+        self.assertIsNotNone(result["error"]["message"])
 
     def test_debug_member_status_returns_operation_result(self):
         """Test debug_member_status returns OperationResult"""
@@ -84,21 +85,21 @@ class TestMemberDebugToolsAPI(EnhancedTestCase):
 
         # OperationResult pattern
         self.assertIsNotNone(result)
-        self.assertIsNotNone(result.success)
+        self.assertIsNotNone(result["success"])
 
-        if result.success:
-            self.assertIsInstance(result.data, dict)
-            self.assertIn("name", result.data)
-            self.assertIn("status", result.data)
-            self.assertIn("docstatus", result.data)
+        if result["success"]:
+            self.assertIsInstance(result["data"], dict)
+            self.assertIn("name", result["data"])
+            self.assertIn("status", result["data"])
+            self.assertIn("docstatus", result["data"])
 
     def test_debug_member_status_with_invalid_member(self):
         """Test debug_member_status with non-existent member"""
         result = debug_member_status("INVALID_MEMBER_NAME")
 
         # Should fail gracefully
-        self.assertFalse(result.success)
-        self.assertIsNotNone(result.error_message)
+        self.assertFalse(result["success"])
+        self.assertIsNotNone(result["error"]["message"])
 
     def test_debug_apis_never_throw_exceptions(self):
         """Test that debug APIs never throw exceptions"""
@@ -115,7 +116,7 @@ class TestMemberDebugToolsAPI(EnhancedTestCase):
         for api_func, args in apis_to_test:
             result = api_func(*args)
             self.assertIsNotNone(result, f"{api_func.__name__} returned None")
-            self.assertIsNotNone(result.success, f"{api_func.__name__} missing success attribute")
+            self.assertIsNotNone(result["success"], f"{api_func.__name__} missing success attribute")
 
     def test_api_results_contain_proper_metadata(self):
         """Test that API results contain expected metadata structure"""
@@ -123,17 +124,17 @@ class TestMemberDebugToolsAPI(EnhancedTestCase):
 
         # Check OperationResult structure
         self.assertIsNotNone(result)
-        if result.success:
-            self.assertIsInstance(result.data, dict)
+        if result["success"]:
+            self.assertIsInstance(result["data"], dict)
         else:
-            self.assertIsNotNone(result.error_message)
-            self.assertIsInstance(result.errors, list)
+            self.assertIsNotNone(result["error"]["message"])
+            self.assertIsInstance(result["error"]["errors"], list)
 
     def test_debug_button_conditions_contains_all_flags(self):
         """Test that debug_button_conditions returns all expected flags"""
         result = debug_button_conditions(self.test_member.name)
 
-        if result.success:
+        if result["success"]:
             expected_flags = [
                 "has_customer",
                 "has_user",
@@ -144,7 +145,7 @@ class TestMemberDebugToolsAPI(EnhancedTestCase):
                 "debug_completed",
             ]
             for flag in expected_flags:
-                self.assertIn(flag, result.data)
+                self.assertIn(flag, result["data"])
 
 
 def run_tests():

--- a/verenigingen/tests/fixtures/enhanced_test_factory.py
+++ b/verenigingen/tests/fixtures/enhanced_test_factory.py
@@ -1546,6 +1546,7 @@ class EnhancedTestDataFactory:
 
         # Check if user already exists
         if frappe.db.exists("User", admin_email):
+            self._ensure_admin_role_profile(admin_email)
             return frappe.get_doc("User", admin_email)
 
         # Create test admin user with full permissions
@@ -1571,8 +1572,21 @@ class EnhancedTestDataFactory:
         admin_user.append("roles", {"role": "System Manager"})
         admin_user.append("roles", {"role": "Verenigingen Administrator"})
         admin_user.save()
+        self._ensure_admin_role_profile(admin_email)
 
         return admin_user
+
+    def _ensure_admin_role_profile(self, admin_email):
+        """Give the shared test-admin user the Verenigingen Administrator role profile.
+
+        After the audit #2 Rule-5 cap, HIGH/CRITICAL API access requires an assigned
+        role PROFILE (Rule 4), not a bare role -- so without this the "admin" user
+        this factory hands out is denied every secured endpoint. Its sole purpose is
+        a fully-privileged admin, so the profile is exactly right.
+        """
+        from verenigingen.tests.fixtures.role_profile_helper import grant_matching_role_profiles
+
+        grant_matching_role_profiles(admin_email, "Verenigingen Administrator")
 
     def create_team(self, **kwargs):
         """Create team with validation and improved isolation"""
@@ -1831,11 +1845,18 @@ class EnhancedTestDataFactory:
 
         scenario = {"authorized_users": [], "unauthorized_users": []}
 
+        from verenigingen.tests.fixtures.role_profile_helper import grant_matching_role_profiles
+
         # Create authorized users
         for role in authorized_roles:
             user = self.create_user_with_roles(
                 email=self.generate_test_email(f"auth_{role.lower().replace(' ', '_')}"), roles=[role]
             )
+            # Post the audit #2 Rule-5 cap, HIGH/CRITICAL access needs the assigned
+            # role PROFILE (Rule 4), not just the role -- assign it so "authorized"
+            # users actually clear the tier gate. Unauthorized users below are left
+            # profileless (or with only a low-tier profile) so they stay denied.
+            grant_matching_role_profiles(user.email, role)
             scenario["authorized_users"].append(user)
 
         # Create unauthorized users

--- a/verenigingen/tests/fixtures/enhanced_test_factory.py
+++ b/verenigingen/tests/fixtures/enhanced_test_factory.py
@@ -4903,15 +4903,28 @@ class EnhancedTestCase(ErrorLogGuardMixin, FrappeTestCase):
                 ...
         """
         if isinstance(role_or_roles, str):
-            if frappe.db.exists("Role Profile", role_or_roles):
-                roles = [r.role for r in frappe.get_doc("Role Profile", role_or_roles).roles]
-                key = f"profile-{role_or_roles}"
-            else:
-                roles = [role_or_roles]
-                key = role_or_roles
+            names = [role_or_roles]
+            key = f"profile-{role_or_roles}" if frappe.db.exists("Role Profile", role_or_roles) else role_or_roles
         else:
-            roles = list(role_or_roles)
-            key = "_".join(sorted(roles))
+            names = list(role_or_roles)
+            key = "_".join(sorted(names))
+
+        # A requested name that matches a Role Profile grants its security tier via
+        # the role-profile authorization table (Rule 4). After the audit #2 Rule-5
+        # cap, HIGH/CRITICAL access requires the assigned PROFILE, not the bare role
+        # -- a scratch user given only roles is capped at MEDIUM and denied
+        # HIGH/CRITICAL endpoints. So collect the matching profile(s) and assign them
+        # too, alongside each profile's constituent roles (Frappe DocPerm checks
+        # still need the raw roles).
+        roles = []
+        profiles = []
+        for name in names:
+            if frappe.db.exists("Role Profile", name):
+                profiles.append(name)
+                roles.extend(r.role for r in frappe.get_doc("Role Profile", name).roles)
+            else:
+                roles.append(name)
+        roles = list(dict.fromkeys(roles))  # dedupe, preserve order
 
         if not email:
             # Deterministic, reusable scratch user per role-set + test run
@@ -4921,7 +4934,37 @@ class EnhancedTestCase(ErrorLogGuardMixin, FrappeTestCase):
 
         # create_test_user reuses existing User if present and resets roles each call
         self.create_test_user(email, roles=roles)
+
+        if profiles:
+            self._assign_role_profiles(email, profiles)
+
         return self.as_user(email)
+
+    def _assign_role_profiles(self, email, profiles):
+        """Assign role profile(s) to a scratch user so the security framework's
+        role-profile authorization (Rule 4) grants the intended HIGH/CRITICAL tier.
+
+        get_user_role_profiles reads both User.role_profile_name and the
+        role_profiles child table, so populate both; then invalidate the auth
+        engine's per-user cache so the assignment is visible immediately.
+        """
+        original_user = frappe.session.user
+        frappe.set_user("Administrator")
+        try:
+            user = frappe.get_doc("User", email)
+            user.set("role_profiles", [{"role_profile": p} for p in profiles])
+            user.role_profile_name = profiles[0]
+            user.save(ignore_permissions=True)
+        finally:
+            frappe.set_user(original_user)
+
+        try:
+            from verenigingen.utils.security.api_security_framework import get_security_framework
+
+            get_security_framework().auth_engine.invalidate_user_cache(email)
+        except Exception:
+            # Cache invalidation is best-effort; the 5-min TTL bounds staleness.
+            pass
 
     def as_staff(self, **kwargs):
         """Shortcut: run as a scratch user with Verenigingen Staff role only.

--- a/verenigingen/tests/fixtures/role_profile_helper.py
+++ b/verenigingen/tests/fixtures/role_profile_helper.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, Verenigingen and Contributors
+# See license.txt
+"""Test helper: assign role profiles to scratch users for security-gated endpoints.
+
+After the audit #2 Rule-5 cap, HIGH/CRITICAL API access is granted only through an
+assigned role PROFILE (Rule 4 in authorization_policy); a bare role -- even System
+Manager -- caps at MEDIUM. Tests that create a user with roles but no profile are
+therefore denied HIGH/CRITICAL endpoints. Assigning the profile whose name matches
+the role restores the tier the role name implies, while low-tier roles (e.g.
+"Verenigingen Member") map to a LOW/MEDIUM profile and stay correctly denied -- so
+permission-tier and denial assertions are preserved.
+"""
+
+import frappe
+
+
+def grant_matching_role_profiles(email, roles):
+    """Assign the Role Profile(s) whose name matches the given role name(s).
+
+    Args:
+        email: User to assign profiles to.
+        roles: A role name (str) or iterable of role names. Names without a
+            same-named Role Profile are ignored.
+    """
+    names = [roles] if isinstance(roles, str) else list(roles)
+    profiles = [r for r in names if frappe.db.exists("Role Profile", r)]
+    if not profiles:
+        return
+
+    original_user = frappe.session.user
+    frappe.set_user("Administrator")
+    try:
+        user = frappe.get_doc("User", email)
+        user.set("role_profiles", [{"role_profile": p} for p in profiles])
+        user.role_profile_name = profiles[0]
+        user.save(ignore_permissions=True)
+    finally:
+        frappe.set_user(original_user)
+
+    try:
+        from verenigingen.utils.security.api_security_framework import get_security_framework
+
+        get_security_framework().auth_engine.invalidate_user_cache(email)
+    except Exception:
+        # Cache invalidation is best-effort; the 5-minute TTL bounds staleness.
+        pass

--- a/verenigingen/tests/integration/test_membership_approval.py
+++ b/verenigingen/tests/integration/test_membership_approval.py
@@ -140,6 +140,12 @@ class TestMembershipApprovalRealIntegration(EnhancedTestCase):
             email=f"approval.admin.{admin_unique_id}@example.com",
             roles=["System Manager", "Verenigingen Administrator"]
         )
+        # Post the Rule-5 cap, HIGH/CRITICAL access needs an assigned role PROFILE.
+        # Grant the admin the matching profile so approval endpoints admit it; the
+        # limited Member user created per-test keeps no profile and stays denied.
+        from verenigingen.tests.fixtures.role_profile_helper import grant_matching_role_profiles
+
+        grant_matching_role_profiles(self.admin_user.email, "Verenigingen Administrator")
 
     def test_complete_membership_approval_workflow(self):
         """Test end-to-end membership approval workflow with real database operations"""

--- a/verenigingen/tests/security/test_admin_tools_security.py
+++ b/verenigingen/tests/security/test_admin_tools_security.py
@@ -19,6 +19,30 @@ from verenigingen.templates.pages.admin_tools import (
     get_context,
     json_encode_args
 )
+from verenigingen.utils.security.api_security_framework import get_security_framework
+
+
+def _grant_admin_critical(test_case):
+    """Let execute_admin_tool's @critical_api gate pass so tests reach its logic.
+
+    execute_admin_tool is wrapped with @critical_api. After the audit #2 Rule-5
+    cap, CRITICAL access is granted ONLY through an assigned role PROFILE (Rule 4);
+    a bare role and even System Manager cap at MEDIUM. The test DB's Administrator
+    carries no role profile, so without this the decorator denies the call before
+    the tool's own allow-list / argument / audit logic (the boundary under test)
+    ever runs. Run as Administrator and grant a CRITICAL-tier profile for the test.
+    """
+    frappe.set_user("Administrator")
+    engine = get_security_framework().auth_engine
+
+    def _profiles(user=None):
+        resolved = user or frappe.session.user
+        return ["Verenigingen System Administrator"] if resolved == "Administrator" else []
+
+    # Mock justified: Infrastructure - role-profile resolution, not the boundary under test
+    patcher = patch.object(engine, "get_user_role_profiles", side_effect=_profiles)
+    patcher.start()
+    test_case.addCleanup(patcher.stop)
 
 
 class TestAdminToolsSecurity(VereningingenTestCase):
@@ -28,8 +52,9 @@ class TestAdminToolsSecurity(VereningingenTestCase):
         """Set up test environment"""
         super().setUp()
         self.original_user = frappe.session.user
-        # Set admin user for security testing
-        # VereningingenTestCase handles permissions automatically
+        # Run as Administrator with a CRITICAL role profile so execute_admin_tool's
+        # @critical_api gate passes and tests exercise the tool's own logic.
+        _grant_admin_critical(self)
         
     def tearDown(self):
         """Clean up after tests"""
@@ -443,8 +468,9 @@ class TestRCEPrevention(VereningingenTestCase):
         """Set up test environment"""
         super().setUp()
         self.original_user = frappe.session.user
-        # Set admin user for security testing
-        # VereningingenTestCase handles permissions automatically
+        # Run as Administrator with a CRITICAL role profile so execute_admin_tool's
+        # @critical_api gate passes and tests exercise the tool's own logic.
+        _grant_admin_critical(self)
         
     def tearDown(self):
         """Clean up after tests"""
@@ -518,8 +544,9 @@ class TestAdminToolsIntegration(VereningingenTestCase):
         """Set up test environment"""
         super().setUp()
         self.original_user = frappe.session.user
-        # Set admin user for security testing
-        # VereningingenTestCase handles permissions automatically
+        # Run as Administrator with a CRITICAL role profile so execute_admin_tool's
+        # @critical_api gate passes and tests exercise the tool's own logic.
+        _grant_admin_critical(self)
         
     def tearDown(self):
         """Clean up after tests"""

--- a/verenigingen/tests/security/test_api_security_decorators.py
+++ b/verenigingen/tests/security/test_api_security_decorators.py
@@ -63,6 +63,38 @@ class TestAPISecurityDecorators(EnhancedTestCase):
             )
         }
 
+        self._grant_tier_role_profiles()
+
+    def _grant_tier_role_profiles(self):
+        """Map test users to role PROFILES so HIGH/CRITICAL gates can pass.
+
+        After the audit #2 Rule-5 cap, HIGH and CRITICAL are PROFILE_ONLY_LEVELS:
+        a bare role (even System Manager) caps at MEDIUM, and access to those tiers
+        is granted only through an assigned role profile (see
+        authorization_policy.ROLE_PROFILE_SECURITY_MAPPING). The decorator resolves
+        profiles via the auth engine's get_user_role_profiles, so mock that here to
+        give each test user the profile matching the tier its bare roles used to
+        imply. MEDIUM/LOW are NOT profile-only, so auditor/member keep working off
+        their bare roles (empty profile list) — preserving the denial assertions.
+        """
+        profiles_by_user = {
+            self.test_users['admin'].email: ["Verenigingen System Administrator"],  # CRITICAL
+            self.test_users['manager'].email: ["Verenigingen Staff"],  # HIGH
+        }
+
+        def _resolve_profiles(user=None):
+            resolved = user or frappe.session.user
+            return profiles_by_user.get(resolved, [])
+
+        # Mock justified: Infrastructure - role-profile resolution, not the boundary under test
+        patcher = patch.object(
+            self.security_framework.auth_engine,
+            "get_user_role_profiles",
+            side_effect=_resolve_profiles,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_standard_api_decorator_patterns(self):
         """Test all usage patterns of @standard_api decorator"""
         

--- a/verenigingen/tests/security/test_api_security_framework.py
+++ b/verenigingen/tests/security/test_api_security_framework.py
@@ -97,13 +97,20 @@ class TestAPISecurityFramework(VereningingenTestCase):
             with self.assertRaises(Exception):
                 self.framework.validate_authentication(profile)
 
-        # Test authenticated user acceptance
+        # Test authenticated user acceptance. HIGH access requires an assigned
+        # role PROFILE (Rule 4) — a bare role no longer grants HIGH (audit #2),
+        # so mock the role-profile resolution, not just frappe.get_roles.
         # Mock justified: Infrastructure - external dependency, not the boundary under test
         with patch("frappe.session", MagicMock(user="test@example.com")):
             # Mock justified: Infrastructure - external dependency, not the boundary under test
             with patch("frappe.get_roles", return_value=["Verenigingen Administrator"]):
-                result = self.framework.validate_authentication(profile)
-                self.assertTrue(result)
+                with patch.object(
+                    self.framework.auth_engine,
+                    "get_user_role_profiles",
+                    return_value=["Verenigingen Administrator"],
+                ):
+                    result = self.framework.validate_authentication(profile)
+                    self.assertTrue(result)
 
     def test_request_method_validation(self):
         """Test HTTP method validation"""
@@ -188,14 +195,20 @@ class TestSecurityDecorators(VereningingenTestCase):
         self.assertTrue(hasattr(test_function, "_security_protected"))
         self.assertEqual(test_function._security_level, SecurityLevel.HIGH)
 
-        # Test function execution with valid parameters
+        # Test function execution with valid parameters. HIGH requires a role
+        # profile (Rule 4) post audit #2, so mock the profile resolution too.
         # Mock justified: Infrastructure - external dependency, not the boundary under test
         with patch("frappe.session", MagicMock(user="test@example.com")):
             # Mock justified: Infrastructure - external dependency, not the boundary under test
             with patch("frappe.get_roles", return_value=["Verenigingen Administrator"]):
-                result = test_function("value1", param2="value2")
-                self.assertEqual(result["param1"], "value1")
-                self.assertEqual(result["param2"], "value2")
+                with patch.object(
+                    get_security_framework().auth_engine,
+                    "get_user_role_profiles",
+                    return_value=["Verenigingen Administrator"],
+                ):
+                    result = test_function("value1", param2="value2")
+                    self.assertEqual(result["param1"], "value1")
+                    self.assertEqual(result["param2"], "value2")
 
     def test_frappe_dict_result_serialised_as_is(self):
         """Regression: a frappe._dict return value must NOT crash the wrapper.
@@ -582,16 +595,23 @@ class TestIntegrationSecurity(VereningingenTestCase):
         def test_secured_endpoint(member_id, **data):
             return {"success": True, "member_id": member_id, "data": data}
 
-        # Mock user session
+        # Mock user session. HIGH requires a role profile (Rule 4) post audit #2.
         # Mock justified: Infrastructure - external dependency, not the boundary under test
         with patch("frappe.session", MagicMock(user="test@example.com")):
             # Mock justified: Infrastructure - external dependency, not the boundary under test
             with patch("frappe.get_roles", return_value=["Verenigingen Administrator"]):
-                # Test successful execution
-                result = test_secured_endpoint("TEST-001", name="Test Member", email="test@example.com")
+                with patch.object(
+                    get_security_framework().auth_engine,
+                    "get_user_role_profiles",
+                    return_value=["Verenigingen Administrator"],
+                ):
+                    # Test successful execution
+                    result = test_secured_endpoint(
+                        "TEST-001", name="Test Member", email="test@example.com"
+                    )
 
-                self.assertTrue(result["success"])
-                self.assertEqual(result["member_id"], "TEST-001")
+                    self.assertTrue(result["success"])
+                    self.assertEqual(result["member_id"], "TEST-001")
 
     def test_security_failure_handling(self):
         """Test security failure handling and error responses"""
@@ -804,11 +824,14 @@ class TestScopedRateLimiting(VereningingenTestCase):
             self.assertEqual(saved_cor.rate_limit_scope, "global")
             self.assertEqual(saved_cor.batch_rate_limit_calls, 100)
 
-            # Verify the expected cache key structure
-            expected_cache_key = f"cor_rate_limit:interactive:{unique_op}"
+            # Verify the expected cache key structure (site-namespaced, audit #7).
+            expected_cache_key = self.framework.rate_limiter._build_cache_key(
+                unique_op, "global", "interactive"
+            )
             self.assertIn("cor_rate_limit", expected_cache_key)
             self.assertIn("interactive", expected_cache_key)
             self.assertIn(unique_op, expected_cache_key)
+            self.assertIn(frappe.local.site, expected_cache_key)
 
             # Verify context detection works
             with patch.object(self.framework, '_detect_execution_context', return_value=ExecutionContext.INTERACTIVE):

--- a/verenigingen/tests/security/test_authorization_coverage.py
+++ b/verenigingen/tests/security/test_authorization_coverage.py
@@ -442,3 +442,68 @@ class TestGlobalAuthManager(AuthorizationTestBase):
     def test_get_auth_manager_is_singleton(self):
         self.assertIs(get_auth_manager(), get_auth_manager())
         self.assertIsInstance(get_auth_manager(), SEPAAuthorizationManager)
+
+
+class TestContextualRestrictionsFailClosed(AuthorizationTestBase):
+    """Audit review #2: _check_ip_restrictions / _check_business_hours must fail
+    CLOSED (deny) when a configured restriction cannot be evaluated, rather than
+    silently allowing the operation.
+    """
+
+    def test_ip_restriction_off_when_no_allowlist(self):
+        self.manager.allowed_ips = []
+        self.assertTrue(self.manager._check_ip_restrictions())
+
+    def test_ip_restriction_not_applied_to_non_http_context(self):
+        """Background/CLI/scheduler contexts have no source IP; an IP allowlist
+        governs HTTP origin only, so it does not apply here (test env has no
+        frappe.local.request)."""
+        self.manager.allowed_ips = ["203.0.113.5"]
+        original_request = getattr(frappe.local, "request", None)
+        frappe.local.request = None
+        try:
+            self.assertTrue(self.manager._check_ip_restrictions())
+        finally:
+            frappe.local.request = original_request
+
+    def _bind_request_ip(self, remote_addr):
+        """Bind a real (non-mock) request whose environ drives the actual
+        client_ip.get_client_ip() resolver. A public REMOTE_ADDR is not a trusted
+        proxy, so get_client_ip returns it verbatim -- exercising the real
+        integration rather than stubbing the resolver."""
+        from types import SimpleNamespace
+
+        frappe.local.request = SimpleNamespace(method="POST", environ={"REMOTE_ADDR": remote_addr})
+
+    def test_ip_restriction_denies_http_request_with_undeterminable_ip(self):
+        """An HTTP request under an active allowlist whose source IP cannot be
+        resolved must be denied (fail closed). An empty REMOTE_ADDR makes the real
+        get_client_ip() return 'unknown'."""
+        self.manager.allowed_ips = ["203.0.113.5"]
+        original_request = getattr(frappe.local, "request", None)
+        try:
+            self._bind_request_ip("")
+            self.assertFalse(self.manager._check_ip_restrictions())
+        finally:
+            frappe.local.request = original_request
+
+    def test_ip_restriction_allows_matching_and_denies_foreign_ip(self):
+        self.manager.allowed_ips = ["203.0.113.5"]
+        original_request = getattr(frappe.local, "request", None)
+        try:
+            self._bind_request_ip("203.0.113.5")
+            self.assertTrue(self.manager._check_ip_restrictions())
+            self._bind_request_ip("198.51.100.9")
+            self.assertFalse(self.manager._check_ip_restrictions())
+        finally:
+            frappe.local.request = original_request
+
+    def test_business_hours_off_when_disabled(self):
+        self.manager.business_hours = {"enabled": False}
+        self.assertTrue(self.manager._check_business_hours())
+
+    def test_business_hours_fails_closed_on_bad_config(self):
+        """An enabled business-hours restriction that can't be evaluated (invalid
+        timezone -> pytz raises) must deny, not allow."""
+        self.manager.business_hours = {"enabled": True, "timezone": "Not/A_Real_Zone"}
+        self.assertFalse(self.manager._check_business_hours())

--- a/verenigingen/tests/security/test_authorization_engine_policy_coverage.py
+++ b/verenigingen/tests/security/test_authorization_engine_policy_coverage.py
@@ -90,15 +90,44 @@ class TestAuthorizationPolicy(VereningingenTestCase):
         self.assertIn("Verenigingen Treasurer", result.auth_path)
 
     def test_rule_5_individual_role_matches_profile_name(self):
-        """No matching profile, but an individual role name matches a mapping key."""
+        """No matching profile, but an individual role name matches a mapping key.
+
+        Rule 5 is capped at MEDIUM (see below), so it grants MEDIUM but not HIGH.
+        """
         result = self.policy.decide(
-            required_level=SecurityLevel.HIGH,
+            required_level=SecurityLevel.MEDIUM,
             user_profiles=[],
             user_roles=["Verenigingen Staff"],
             is_authenticated=True,
         )
         self.assertTrue(result.granted)
         self.assertEqual(result.rule_matched, "rule_5_individual_role")
+
+    def test_rule_5_individual_role_cannot_reach_high(self):
+        """SECURITY: a bare role must NOT grant HIGH (member-data) access.
+
+        Staff maps to HIGH in the mapping, but without an assigned role profile
+        the HIGH tier requires Rule 4 — Rule 5 is capped at MEDIUM, so this denies.
+        """
+        result = self.policy.decide(
+            required_level=SecurityLevel.HIGH,
+            user_profiles=[],
+            user_roles=["Verenigingen Staff"],
+            is_authenticated=True,
+        )
+        self.assertFalse(result.granted)
+        self.assertEqual(result.rule_matched, "rule_7_deny")
+
+    def test_rule_5_individual_role_cannot_reach_critical(self):
+        """SECURITY: a bare admin role must NOT grant CRITICAL (financial/admin) access."""
+        result = self.policy.decide(
+            required_level=SecurityLevel.CRITICAL,
+            user_profiles=[],
+            user_roles=["Verenigingen Administrator"],
+            is_authenticated=True,
+        )
+        self.assertFalse(result.granted)
+        self.assertEqual(result.rule_matched, "rule_7_deny")
 
     def test_rule_6_system_manager_gets_medium(self):
         """System Manager has no profile mapping but is granted MEDIUM by rule 6."""

--- a/verenigingen/tests/security/test_authorization_engine_policy_coverage.py
+++ b/verenigingen/tests/security/test_authorization_engine_policy_coverage.py
@@ -238,6 +238,14 @@ class TestAuthorizationEngine(VereningingenTestCase):
             result = self.engine.authorize(None, SecurityLevel.HIGH)
         self.assertTrue(result.granted)
 
+    def test_authorize_administrator_break_glass(self):
+        """The literal Administrator bootstrap account is granted every level
+        (Rule 0) without any role profile -- break-glass / bootstrap identity."""
+        for level in (SecurityLevel.CRITICAL, SecurityLevel.HIGH, SecurityLevel.MEDIUM):
+            result = self.engine.authorize("Administrator", level)
+            self.assertTrue(result.granted, f"Administrator should be granted {level.value}")
+            self.assertEqual(result.rule_matched, "rule_0_administrator_break_glass")
+
     def test_authorize_guest_denied_for_low(self):
         """Guest is unauthenticated -> rule 2 denial even for LOW."""
         with self.as_user("Guest"):

--- a/verenigingen/tests/security/test_client_ip_coverage.py
+++ b/verenigingen/tests/security/test_client_ip_coverage.py
@@ -188,14 +188,19 @@ class TestClientIPCoverage(VereningingenTestCase):
         self._bind_request("10.0.0.5")
         self.assertEqual(get_client_ip(), "10.0.0.5")
 
-    def test_trusted_proxy_all_hops_trusted_returns_leftmost(self):
-        """If every hop in the chain is a trusted proxy, return the leftmost (per spec)."""
+    def test_trusted_proxy_all_hops_trusted_returns_remote_addr(self):
+        """If every hop in the chain is trusted, return the non-spoofable
+        connecting address, NOT the attacker-controllable leftmost XFF entry.
+
+        Security regression guard (audit #6): the leftmost XFF value can be
+        forged by any client, so returning it would let an attacker match a
+        private-IP allowlist or rotate per-IP rate-limit buckets.
+        """
         self._bind_request(
             "10.0.0.1",
             headers={"X-Forwarded-For": "192.168.1.1, 10.1.1.1, 10.0.0.1"},
         )
-        # All are private/trusted -> leftmost is returned.
-        self.assertEqual(get_client_ip(), "192.168.1.1")
+        self.assertEqual(get_client_ip(), "10.0.0.1")
 
     # ------------------------------------------------------------------
     # get_client_ip_with_info

--- a/verenigingen/tests/security/test_cor_rate_limiting.py
+++ b/verenigingen/tests/security/test_cor_rate_limiting.py
@@ -284,6 +284,62 @@ class TestCORRateLimitingEnforcement(EnhancedTestCase):
                     )
                     frappe.db.commit()
 
+    def test_maintenance_flags_bypass_rate_limit(self):
+        """Install/migrate/patch phases must skip the fail-closed COR lookup.
+
+        The COR fixture (_generic_api_fallback) is loaded by sync_fixtures, which
+        runs AFTER after_install hooks and after patches. A security-decorated
+        function reached from a lifecycle hook or patch would otherwise raise
+        "No rate limiting configuration found" and abort the install/migrate.
+        With no COR configured, each maintenance flag must yield an allowed
+        result rather than raising.
+        """
+        operation_name = "nonexistent_operation_during_setup"
+
+        with self.set_user("Administrator"):
+            original_in_test = getattr(frappe.flags, "in_test", False)
+            fallback_cor = None
+            fallback_was_enabled = False
+
+            try:
+                frappe.flags.in_test = False
+
+                # Disable the generic fallback so the fail-closed branch is the
+                # only thing that could stop us.
+                fallback_cor = frappe.db.get_value(
+                    "Critical Operation Rule",
+                    {"operation_name": "_generic_api_fallback"},
+                    "name",
+                )
+                if fallback_cor:
+                    fallback_was_enabled = frappe.db.get_value(
+                        "Critical Operation Rule", fallback_cor, "enabled"
+                    )
+                    frappe.db.set_value("Critical Operation Rule", fallback_cor, "enabled", 0)
+                    frappe.db.commit()
+
+                for flag in ("in_install", "in_migrate", "in_patch"):
+                    with mock_http_request():
+                        original_flag = getattr(frappe.flags, flag, False)
+                        try:
+                            setattr(frappe.flags, flag, True)
+                            result = self.framework.rate_limiter.check_rate_limit(
+                                operation_name,
+                                context=ExecutionContext.INTERACTIVE,
+                            )
+                            self.assertTrue(
+                                result.allowed,
+                                f"rate limit should be bypassed while frappe.flags.{flag} is set",
+                            )
+                        finally:
+                            setattr(frappe.flags, flag, original_flag)
+
+            finally:
+                frappe.flags.in_test = original_in_test
+                if fallback_cor and fallback_was_enabled:
+                    frappe.db.set_value("Critical Operation Rule", fallback_cor, "enabled", 1)
+                    frappe.db.commit()
+
     def test_cor_rate_limit_headers_generation(self):
         """Verify that rate limit headers are generated correctly"""
         operation_name = "test_rate_limit_headers"

--- a/verenigingen/tests/security/test_cor_rate_limiting.py
+++ b/verenigingen/tests/security/test_cor_rate_limiting.py
@@ -48,11 +48,13 @@ def _clear_all_test_rate_limit_counters():
         "test_global_scope",
         "nonexistent_operation_xyz",
     ]
+    site = frappe.local.site
     for op_name in test_operations:
-        # Clear per-user counters (use delete() for raw key deletion)
-        frappe.cache().delete(f"cor_rate_limit:interactive:{op_name}:Administrator")
+        # Clear per-user counters (use delete() for raw key deletion).
+        # Keys are site-namespaced (see RateLimitEngine._build_cache_key).
+        frappe.cache().delete(f"cor_rate_limit:{site}:interactive:{op_name}:Administrator")
         # Clear global counters
-        frappe.cache().delete(f"cor_rate_limit:interactive:{op_name}")
+        frappe.cache().delete(f"cor_rate_limit:{site}:interactive:{op_name}")
 
 
 @contextmanager
@@ -161,7 +163,7 @@ class TestCORRateLimitingEnforcement(EnhancedTestCase):
         Note: We use delete() instead of delete_value() because setex() uses raw keys
         while delete_value() transforms keys with make_key().
         """
-        cache_key = f"cor_rate_limit:interactive:{operation_name}:{user}"
+        cache_key = f"cor_rate_limit:{frappe.local.site}:interactive:{operation_name}:{user}"
         frappe.cache().delete(cache_key)
 
     def test_cor_rate_limit_enforces_after_max_calls(self):
@@ -213,7 +215,7 @@ class TestCORRateLimitingEnforcement(EnhancedTestCase):
 
         with self.set_user("Administrator"):
             self._clear_rate_limit_counter(operation_name)
-            cache_key = f"cor_rate_limit:interactive:{operation_name}:Administrator"
+            cache_key = f"cor_rate_limit:{frappe.local.site}:interactive:{operation_name}:Administrator"
 
             original_in_test = getattr(frappe.flags, "in_test", False)
             try:
@@ -383,7 +385,9 @@ class TestCORRateLimitingScopes(EnhancedTestCase):
         user1 = self.create_test_user("global_user1@test.com", roles=["Verenigingen Staff"])
         user2 = self.create_test_user("global_user2@test.com", roles=["Verenigingen Staff"])
 
-        frappe.cache().delete_value(f"cor_rate_limit:interactive:{operation_name}")
+        # Raw delete (not delete_value) to match the raw incrby key written by the
+        # engine; keys are site-namespaced. Global scope has no user/ip suffix.
+        frappe.cache().delete(f"cor_rate_limit:{frappe.local.site}:interactive:{operation_name}")
 
         original_in_test = getattr(frappe.flags, "in_test", False)
         try:
@@ -423,3 +427,27 @@ class TestCORRateLimitingScopes(EnhancedTestCase):
 
         finally:
             frappe.flags.in_test = original_in_test
+
+
+class TestRateLimitKeyNamespacing(EnhancedTestCase):
+    """Audit #7: rate-limit counter keys must be namespaced per site.
+
+    The engine reads/writes counters via raw redis ops (incrby/expire/get) that
+    bypass RedisWrapper.make_key, so without an explicit site prefix a shared
+    Redis would collapse counters across tenants. Guard the key format directly.
+    """
+
+    def test_build_cache_key_includes_site(self):
+        from verenigingen.utils.security.rate_limit_engine import get_rate_limit_engine
+
+        engine = get_rate_limit_engine()
+        site = frappe.local.site
+
+        global_key = engine._build_cache_key("some_op", "global", "interactive")
+        self.assertEqual(global_key, f"cor_rate_limit:{site}:interactive:some_op")
+
+        user_key = engine._build_cache_key("some_op", "per_user", "interactive")
+        self.assertTrue(user_key.startswith(f"cor_rate_limit:{site}:interactive:some_op:"))
+        # The site segment must sit between the prefix and the operation, so two
+        # different sites can never produce the same key for the same op/user.
+        self.assertIn(f":{site}:", user_key)

--- a/verenigingen/tests/security/test_csrf_ratelimit_cache_coverage.py
+++ b/verenigingen/tests/security/test_csrf_ratelimit_cache_coverage.py
@@ -148,6 +148,24 @@ class TestCSRFProtectionCoverage(VereningingenTestCase):
         self._bind_request(method="POST", headers={"X-Frappe-CSRF-Token": "good-token"})
         self.assertTrue(CSRFProtection.validate_request())
 
+    def test_validate_request_rejects_when_only_session_token_present(self):
+        """Security regression (audit #9): a request that omits the CSRF
+        header/field must be rejected even when the session holds a token.
+
+        Previously get_token_from_request fell back to the session's own token,
+        so validate_request compared it against itself and always passed -
+        defeating CSRF protection for any request that simply sent no token.
+        """
+        self._disable_harness_csrf_mock()
+        if frappe.conf.get("ignore_csrf"):
+            self.skipTest("ignore_csrf is enabled in this site config")
+        frappe.session.data["csrf_token"] = "session-secret"
+        self.addCleanup(lambda: frappe.session.data.pop("csrf_token", None))
+        self._bind_request(method="POST", headers={})
+        frappe.form_dict.pop("csrf_token", None)
+        with self.assertRaises(CSRFError):
+            CSRFProtection.validate_request()
+
     # ---- whitelisted API endpoints ----
     def test_get_csrf_token_api_returns_token_payload(self):
         result = get_csrf_token()
@@ -257,7 +275,7 @@ class TestRateLimitEngineCoverage(VereningingenTestCase):
             self.assertEqual(result.max_calls, fallback)
             self.addCleanup(
                 lambda: frappe.cache().delete(
-                    f"cor_rate_limit:{result.limit_type}:no_such_operation_zzz:{frappe.session.user}"
+                    f"cor_rate_limit:{frappe.local.site}:{result.limit_type}:no_such_operation_zzz:{frappe.session.user}"
                 )
             )
 
@@ -328,15 +346,18 @@ class TestRateLimitEngineCoverage(VereningingenTestCase):
     # ---- _build_cache_key scopes ----
     def test_build_cache_key_global(self):
         key = self.engine._build_cache_key("op", "global", "interactive")
-        self.assertEqual(key, "cor_rate_limit:interactive:op")
+        # Keys are site-namespaced (audit #7) to isolate counters on shared Redis.
+        self.assertEqual(key, f"cor_rate_limit:{frappe.local.site}:interactive:op")
 
     def test_build_cache_key_per_user(self):
         key = self.engine._build_cache_key("op", "per_user", "interactive")
-        self.assertEqual(key, f"cor_rate_limit:interactive:op:{frappe.session.user}")
+        self.assertEqual(
+            key, f"cor_rate_limit:{frappe.local.site}:interactive:op:{frappe.session.user}"
+        )
 
     def test_build_cache_key_per_ip(self):
         key = self.engine._build_cache_key("op", "per_ip", "interactive")
-        self.assertTrue(key.startswith("cor_rate_limit:interactive:op:"))
+        self.assertTrue(key.startswith(f"cor_rate_limit:{frappe.local.site}:interactive:op:"))
         # The IP segment comes from get_client_ip(); off-request that's "test_environment".
         self.assertIn(self.engine._get_client_ip(), key)
 
@@ -356,7 +377,7 @@ class TestRateLimitEngineCoverage(VereningingenTestCase):
             rate_limit_scope="per_user",
             security_level="medium",
         )
-        key = "cor_rate_limit:batch:test_cov_batch_e2e_op:" + frappe.session.user
+        key = f"cor_rate_limit:{frappe.local.site}:batch:test_cov_batch_e2e_op:" + frappe.session.user
         frappe.cache().delete(key)
         self.addCleanup(lambda: frappe.cache().delete(key))
 
@@ -390,7 +411,7 @@ class TestRateLimitEngineCoverage(VereningingenTestCase):
             rate_limit_scope="per_user",
             security_level="medium",
         )
-        key = "cor_rate_limit:interactive:test_cov_enforce_op:" + frappe.session.user
+        key = f"cor_rate_limit:{frappe.local.site}:interactive:test_cov_enforce_op:" + frappe.session.user
         frappe.cache().delete(key)
         self.addCleanup(lambda: frappe.cache().delete(key))
 
@@ -424,7 +445,7 @@ class TestRateLimitEngineCoverage(VereningingenTestCase):
             rate_limit_scope="per_user",
             security_level="medium",
         )
-        key = "cor_rate_limit:interactive:test_cov_headers_op:" + frappe.session.user
+        key = f"cor_rate_limit:{frappe.local.site}:interactive:test_cov_headers_op:" + frappe.session.user
         frappe.cache().delete(key)
         self.addCleanup(lambda: frappe.cache().delete(key))
 

--- a/verenigingen/tests/security/test_enhanced_validation_coverage.py
+++ b/verenigingen/tests/security/test_enhanced_validation_coverage.py
@@ -99,6 +99,18 @@ class TestValidationRuleType(VereningingenTestCase):
         self.assertFalse(result["valid"])
         self.assertIn("number", result["message"])
 
+    def test_float_nan_rejected(self):
+        """Audit #8: float("nan") parses successfully but must be rejected."""
+        rule = ValidationRule(ValidationType.TYPE, expected_type="float")
+        result = rule.validate("nan", "amount")
+        self.assertFalse(result["valid"])
+        self.assertIn("finite", result["message"])
+
+    def test_float_infinity_rejected(self):
+        """Audit #8: float("inf") must be rejected by the float type rule."""
+        rule = ValidationRule(ValidationType.TYPE, expected_type="float")
+        self.assertFalse(rule.validate("inf", "amount")["valid"])
+
     def test_boolean_valid_accepts_string_flags(self):
         rule = ValidationRule(ValidationType.TYPE, expected_type="boolean")
         for v in ["true", "false", "0", "1", True, False]:
@@ -238,6 +250,20 @@ class TestValidationRuleRange(VereningingenTestCase):
         self.assertTrue(rule.validate(100, "f")["valid"])
         self.assertFalse(rule.validate(4, "f")["valid"])
 
+    def test_nan_rejected(self):
+        """Audit #8: nan must be rejected. Comparisons against nan are always
+        false, so an unchecked nan satisfies both min and max bounds."""
+        rule = ValidationRule(ValidationType.RANGE, min=0.01, max=10000)
+        result = rule.validate("nan", "amount")
+        self.assertFalse(result["valid"])
+        self.assertIn("finite", result["message"])
+
+    def test_infinity_rejected(self):
+        """Audit #8: inf must be rejected by RANGE bounds."""
+        rule = ValidationRule(ValidationType.RANGE, min=0.01, max=10000)
+        self.assertFalse(rule.validate("inf", "amount")["valid"])
+        self.assertFalse(rule.validate("-inf", "amount")["valid"])
+
 
 class TestValidationRuleLength(VereningingenTestCase):
     """ValidationType.LENGTH rule"""
@@ -309,6 +335,17 @@ class TestValidationRulePattern(VereningingenTestCase):
         result = rule.validate("x", "f")
         self.assertFalse(result["valid"])
         self.assertIn("pattern", result["message"].lower())
+
+    def test_pattern_uses_fullmatch_not_prefix_match(self):
+        """Audit #8: a non-anchored pattern must not accept trailing junk.
+
+        re.match anchors only at the start, so r"[A-Z]{2}\\d+" would accept
+        "AB12<script>". fullmatch requires the whole value to conform.
+        """
+        rule = ValidationRule(ValidationType.PATTERN, pattern=r"[A-Z]{2}\d+")
+        self.assertTrue(rule.validate("AB12", "code")["valid"])
+        self.assertFalse(rule.validate("AB12<script>", "code")["valid"])
+        self.assertFalse(rule.validate("AB12 extra", "code")["valid"])
 
 
 class TestValidationRuleEnum(VereningingenTestCase):

--- a/verenigingen/tests/security/test_public_api_coverage_additions.py
+++ b/verenigingen/tests/security/test_public_api_coverage_additions.py
@@ -1,0 +1,36 @@
+"""
+Regression tests for audit #10 coverage additions.
+
+Two previously-undecorated guest-accessible endpoints were brought under the
+@public_api security decorator (adds rate limiting + input validation without
+changing who may call them). These tests verify guest access still works and
+returns the expected dict shapes.
+"""
+
+from verenigingen.templates.pages.membership_application import (
+    get_dues_schedules_for_membership_type,
+)
+from verenigingen.tests.utils.base import VereningingenTestCase
+from verenigingen.verenigingen.doctype.member.member_utils import find_chapter_by_postal_code
+
+
+class TestPublicApiCoverageAdditions(VereningingenTestCase):
+    """@public_api must not break guest access to these read-only endpoints."""
+
+    def test_find_chapter_by_postal_code_guest_accessible(self):
+        with self.as_user("Guest"):
+            result = find_chapter_by_postal_code("1011AB")
+        self.assertIsInstance(result, dict)
+        self.assertIn("success", result)
+
+    def test_find_chapter_by_postal_code_missing_arg(self):
+        with self.as_user("Guest"):
+            result = find_chapter_by_postal_code("")
+        self.assertIsInstance(result, dict)
+        self.assertFalse(result["success"])
+
+    def test_get_dues_schedules_guest_accessible(self):
+        with self.as_user("Guest"):
+            result = get_dues_schedules_for_membership_type("")
+        self.assertIsInstance(result, dict)
+        self.assertFalse(result["success"])

--- a/verenigingen/tests/security/test_public_api_coverage_additions.py
+++ b/verenigingen/tests/security/test_public_api_coverage_additions.py
@@ -7,6 +7,8 @@ changing who may call them). These tests verify guest access still works and
 returns the expected dict shapes.
 """
 
+import frappe
+
 from verenigingen.templates.pages.membership_application import (
     get_dues_schedules_for_membership_type,
 )
@@ -17,20 +19,44 @@ from verenigingen.verenigingen.doctype.member.member_utils import find_chapter_b
 class TestPublicApiCoverageAdditions(VereningingenTestCase):
     """@public_api must not break guest access to these read-only endpoints."""
 
+    def setUp(self):
+        super().setUp()
+        # find_chapter_by_postal_code short-circuits when chapter management is
+        # disabled; enable it so the tests deterministically exercise the real
+        # lookup path (and the fixed internal-call behaviour) rather than the
+        # "disabled" early return.
+        self._orig_ccm = frappe.db.get_single_value(
+            "Verenigingen Settings", "enable_chapter_management"
+        )
+        frappe.db.set_single_value("Verenigingen Settings", "enable_chapter_management", 1)
+        self.addCleanup(
+            frappe.db.set_single_value,
+            "Verenigingen Settings",
+            "enable_chapter_management",
+            self._orig_ccm,
+        )
+
     def test_find_chapter_by_postal_code_guest_accessible(self):
+        # Guest access must succeed (not raise) and return the success shape with
+        # a chapter list - the whole point of audit #10's fix + the internal-call
+        # bug fix (it previously hit a MEDIUM auth check via is_chapter_management_enabled).
         with self.as_user("Guest"):
             result = find_chapter_by_postal_code("1011AB")
         self.assertIsInstance(result, dict)
-        self.assertIn("success", result)
+        self.assertTrue(result["success"])
+        self.assertIn("matching_chapters", result)
+        self.assertIsInstance(result["matching_chapters"], list)
 
     def test_find_chapter_by_postal_code_missing_arg(self):
         with self.as_user("Guest"):
             result = find_chapter_by_postal_code("")
-        self.assertIsInstance(result, dict)
         self.assertFalse(result["success"])
+        self.assertIn("required", result["message"].lower())
 
     def test_get_dues_schedules_guest_accessible(self):
+        # Empty arg is rejected by the endpoint's own validation, but the call
+        # must reach that logic as a Guest (not be blocked by the auth layer).
         with self.as_user("Guest"):
             result = get_dues_schedules_for_membership_type("")
-        self.assertIsInstance(result, dict)
         self.assertFalse(result["success"])
+        self.assertIn("error", result)

--- a/verenigingen/tests/security/test_security_profile_isolation.py
+++ b/verenigingen/tests/security/test_security_profile_isolation.py
@@ -1,0 +1,88 @@
+"""
+Regression tests for shared-mutable-SecurityProfile contamination.
+
+Audit finding #1 (2026-07-02): the api_security_framework wrapper mutated the
+shared class-level SECURITY_PROFILES instance when applying per-endpoint
+overrides (allowed_environments / max_request_size). Because every endpoint of
+a given SecurityLevel shares one profile object, a single @development_only_api
+call would poison the LOW profile's allowed_environments (403-ing all
+self-service/utility endpoints in production), and a custom max_request_size
+would raise the size limit for every other endpoint of that level.
+
+The fix copies the profile (dataclasses.replace) before applying overrides, so
+overrides are request-local. These tests assert the shared template is never
+mutated by decorated endpoints.
+"""
+
+from verenigingen.tests.utils.base import VereningingenTestCase
+from verenigingen.utils.security.api_security_framework import (
+    development_only_api,
+    get_security_framework,
+    standard_api,
+)
+from verenigingen.utils.security.types import EnvironmentLevel, SecurityLevel
+
+
+class TestSecurityProfileIsolation(VereningingenTestCase):
+    """Per-endpoint profile overrides must not mutate the shared templates."""
+
+    def test_development_only_does_not_poison_shared_low_profile(self):
+        """A @development_only_api call must not strip PRODUCTION/STAGING from the
+        shared LOW profile that @self_service_api / @utility_api also use."""
+        framework = get_security_framework()
+        low_profile = framework.SECURITY_PROFILES[SecurityLevel.LOW]
+        original_envs = list(low_profile.allowed_environments)
+
+        # PRODUCTION and STAGING must be allowed pre-call (that is what the
+        # self-service/utility endpoints rely on).
+        self.assertIn(EnvironmentLevel.PRODUCTION, original_envs)
+
+        @development_only_api()
+        def _dev_only_endpoint():
+            return {"ok": True}
+
+        # Invoke the wrapper. In a non-development environment this raises
+        # (correctly blocking the dev endpoint) but the override is applied
+        # BEFORE that check, so it is the ideal trigger for the mutation bug.
+        try:
+            _dev_only_endpoint()
+        except Exception:
+            pass
+
+        self.assertEqual(
+            list(framework.SECURITY_PROFILES[SecurityLevel.LOW].allowed_environments),
+            original_envs,
+            "development_only_api leaked allowed_environments onto the shared LOW profile",
+        )
+        self.assertIn(
+            EnvironmentLevel.PRODUCTION,
+            framework.SECURITY_PROFILES[SecurityLevel.LOW].allowed_environments,
+            "shared LOW profile no longer permits PRODUCTION after a dev-only call",
+        )
+
+    def test_max_request_size_override_does_not_poison_shared_medium_profile(self):
+        """A @standard_api(max_request_size=...) call must not raise the request
+        size limit for every other MEDIUM endpoint."""
+        framework = get_security_framework()
+        medium_profile = framework.SECURITY_PROFILES[SecurityLevel.MEDIUM]
+        original_size = medium_profile.max_request_size
+
+        oversized = original_size + 13 * 1024 * 1024
+
+        @standard_api(max_request_size=oversized)
+        def _big_payload_endpoint():
+            return {"ok": True}
+
+        # The size override is applied before any auth/env check, so invoking the
+        # wrapper triggers the mutation path regardless of whether the call itself
+        # ultimately succeeds.
+        try:
+            _big_payload_endpoint()
+        except Exception:
+            pass
+
+        self.assertEqual(
+            framework.SECURITY_PROFILES[SecurityLevel.MEDIUM].max_request_size,
+            original_size,
+            "max_request_size override leaked onto the shared MEDIUM profile",
+        )

--- a/verenigingen/tests/security/test_self_service_operations.py
+++ b/verenigingen/tests/security/test_self_service_operations.py
@@ -169,3 +169,79 @@ class TestSelfServiceOperations(PortalSelfServiceTestMixin, EnhancedTestCase):
         policy = AuthorizationPolicy()
         levels = policy.ROLE_PROFILE_SECURITY_MAPPING.get("Verenigingen Member", [])
         self.assertEqual(levels, [SecurityLevel.LOW])
+
+    # --- audit finding #3/#5: multi-field + deep-content ownership -----------
+
+    def test_sibling_member_id_cannot_smuggle_foreign_target(self):
+        """Audit #3: passing a matching `member` must NOT let a foreign `member_id`
+        slip past the gate. Every explicit identifier is validated, not just the
+        first one found."""
+        owner = self.create_test_member(birth_date="1990-01-01")
+        intruder = self.create_test_member(birth_date="1991-02-02")
+        intruder_user = self._link_member_to_user(intruder)
+
+        with self._as_user(intruder_user.name):
+            with self.assertRaises(VPermissionError):
+                # member = own (matches) but member_id = victim (foreign)
+                self.framework._validate_self_service_access(
+                    member=intruder.name, member_id=owner.name
+                )
+
+    def test_matching_sibling_fields_pass(self):
+        """Multiple identifiers that all point at the caller's own member pass."""
+        member = self.create_test_member(birth_date="1990-01-01")
+        user = self._link_member_to_user(member)
+
+        with self._as_user(user.name):
+            self.assertTrue(
+                self.framework._validate_self_service_access(
+                    member=member.name, member_id=member.name
+                )
+            )
+
+    def test_content_check_flags_top_level_scalar_member_id(self):
+        """Audit #3: deep content validation inspects top-level scalar identifiers,
+        not just nested dict/list structures."""
+        owner = self.create_test_member(birth_date="1990-01-01")
+        intruder = self.create_test_member(birth_date="1991-02-02")
+
+        with self.assertRaises(VPermissionError):
+            # intruder is the caller; a foreign member_id scalar must be caught
+            self.framework._validate_self_service_request_content(
+                intruder.name, member_id=owner.name
+            )
+
+    def test_content_check_flags_member_inside_json_string(self):
+        """Audit #4: a member reference hidden inside a JSON-encoded string payload
+        is parsed and flagged."""
+        import json as _json
+
+        owner = self.create_test_member(birth_date="1990-01-01")
+        intruder = self.create_test_member(birth_date="1991-02-02")
+
+        payload = _json.dumps({"member": owner.name, "amount": 5})
+        with self.assertRaises(VPermissionError):
+            self.framework._validate_self_service_request_content(intruder.name, data=payload)
+
+    def test_content_check_passes_for_own_member_in_json_string(self):
+        """JSON payload referencing the caller's own member is allowed."""
+        import json as _json
+
+        member = self.create_test_member(birth_date="1990-01-01")
+        payload = _json.dumps({"member": member.name, "amount": 5})
+        # Should not raise
+        self.assertTrue(
+            self.framework._validate_self_service_request_content(member.name, data=payload)
+        )
+
+    def test_explicit_unresolvable_volunteer_fails_closed(self):
+        """Audit #5: an explicit but unresolvable `volunteer` reference must be
+        denied (fail closed), not silently collapse to implicit self-service."""
+        member = self.create_test_member(birth_date="1990-01-01")
+        user = self._link_member_to_user(member)
+
+        with self._as_user(user.name):
+            with self.assertRaises(VPermissionError):
+                self.framework._validate_self_service_access(
+                    volunteer="NONEXISTENT-VOLUNTEER-XYZ", implicit_allowed=True
+                )

--- a/verenigingen/tests/security/test_self_service_operations.py
+++ b/verenigingen/tests/security/test_self_service_operations.py
@@ -223,6 +223,25 @@ class TestSelfServiceOperations(PortalSelfServiceTestMixin, EnhancedTestCase):
         with self.assertRaises(VPermissionError):
             self.framework._validate_self_service_request_content(intruder.name, data=payload)
 
+    def test_content_check_flags_member_inside_json_string_with_leading_whitespace(self):
+        """Audit review #1: a JSON payload with leading whitespace/newline must
+        still be inspected. json.loads tolerates leading whitespace, so a first-
+        char fast-reject would let ' {"member":"VICTIM"}' bypass the inspector
+        while the endpoint still parses it."""
+        owner = self.create_test_member(birth_date="1990-01-01")
+        intruder = self.create_test_member(birth_date="1991-02-02")
+
+        for payload in (
+            ' {"member": "%s"}' % owner.name,
+            '\t{"member": "%s"}' % owner.name,
+            '\n {"member": "%s"}' % owner.name,
+        ):
+            with self.subTest(payload=payload):
+                with self.assertRaises(VPermissionError):
+                    self.framework._validate_self_service_request_content(
+                        intruder.name, data=payload
+                    )
+
     def test_content_check_passes_for_own_member_in_json_string(self):
         """JSON payload referencing the caller's own member is allowed."""
         import json as _json

--- a/verenigingen/tests/www/test_mollie_www_pages_coverage.py
+++ b/verenigingen/tests/www/test_mollie_www_pages_coverage.py
@@ -56,6 +56,13 @@ class TestMollieWwwPagesCoverage(VereningingenTestCase):
             )
             user.insert(ignore_permissions=True)
             self.track_doc("User", user.name)
+
+        # Post the Rule-5 cap, HIGH/CRITICAL access needs an assigned role PROFILE.
+        # Assign the profile matching each role so the admin user clears the page
+        # endpoints' gate; Member maps to LOW and stays correctly denied.
+        from verenigingen.tests.fixtures.role_profile_helper import grant_matching_role_profiles
+
+        grant_matching_role_profiles(email, roles)
         return email
 
     # ===== mollie_subscription_audit.get_context =====

--- a/verenigingen/tests/www/test_monitoring_dashboard_coverage.py
+++ b/verenigingen/tests/www/test_monitoring_dashboard_coverage.py
@@ -48,6 +48,20 @@ class TestMonitoringDashboardCoverage(VereningingenTestCase):
             )
             user.insert(ignore_permissions=True)
             self.track_doc("User", user.name)
+
+        # The dashboard endpoints are @high_security_api. After the audit #2 Rule-5
+        # cap, HIGH access is granted only via an assigned role PROFILE (Rule 4);
+        # a bare role caps at MEDIUM. Assign the profile matching each role so the
+        # admin user passes the gate -- Member still maps to LOW and stays denied.
+        profiles = [r for r in roles if frappe.db.exists("Role Profile", r)]
+        if profiles:
+            user = frappe.get_doc("User", email)
+            user.set("role_profiles", [{"role_profile": p} for p in profiles])
+            user.role_profile_name = profiles[0]
+            user.save(ignore_permissions=True)
+            from verenigingen.utils.security.api_security_framework import get_security_framework
+
+            get_security_framework().auth_engine.invalidate_user_cache(email)
         return email
 
     # ----- get_context: permission gating -----

--- a/verenigingen/utils/account_group_project_framework.py
+++ b/verenigingen/utils/account_group_project_framework.py
@@ -6,6 +6,8 @@ A configurable system for linking P&L account groups to projects and cost center
 import frappe
 from frappe import _
 
+from verenigingen.utils.security.api_security_framework import OperationType, utility_api
+
 
 class AccountGroupProjectFramework:
     """Framework for managing account group to project/cost center mappings"""
@@ -133,24 +135,28 @@ account_group_framework = AccountGroupProjectFramework()
 
 # Convenience functions for external use
 @frappe.whitelist()
+@utility_api(operation_type=OperationType.UTILITY)
 def get_account_group_defaults(account_group):
     """Get defaults for an account group"""
     return account_group_framework.get_defaults_for_transaction(account_group)
 
 
 @frappe.whitelist()
+@utility_api(operation_type=OperationType.UTILITY)
 def validate_account_group_transaction(account_group, project=None, cost_center=None):
     """Validate a transaction for an account group"""
     return account_group_framework.validate_transaction(account_group, project, cost_center)
 
 
 @frappe.whitelist()
+@utility_api(operation_type=OperationType.UTILITY)
 def get_valid_projects_for_account_group(account_group):
     """Get valid projects for an account group"""
     return account_group_framework.get_valid_projects(account_group)
 
 
 @frappe.whitelist()
+@utility_api(operation_type=OperationType.UTILITY)
 def get_valid_cost_centers_for_account_group(account_group):
     """Get valid cost centers for an account group"""
     return account_group_framework.get_valid_cost_centers(account_group)

--- a/verenigingen/utils/address_formatter.py
+++ b/verenigingen/utils/address_formatter.py
@@ -9,8 +9,11 @@ import frappe
 from verenigingen.utils.api_response import APIResponse, api_response_handler
 from verenigingen.utils.error_handling import cache_with_ttl
 from verenigingen.utils.secure_operations import secure_document_operation
-from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
-from verenigingen.utils.security_decorators import development_only
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    development_only_api,
+    high_security_api,
+)
 
 
 def format_address_for_country(address_doc):
@@ -194,7 +197,7 @@ def format_member_address(member_name: str):
 
 
 @frappe.whitelist()
-@development_only()
+@development_only_api()
 def test_address_formatting():
     """Test the address formatting with sample data"""
     try:

--- a/verenigingen/utils/address_matching/performance_tester.py
+++ b/verenigingen/utils/address_matching/performance_tester.py
@@ -12,9 +12,11 @@ from typing import Dict, List, Tuple
 import frappe
 
 from verenigingen.utils.address_matching.optimized_matcher import OptimizedAddressMatcher
+from verenigingen.utils.security.api_security_framework import development_only_api
 
 
 @frappe.whitelist()
+@development_only_api()
 def run_comprehensive_performance_test():
     """Run comprehensive performance tests comparing old vs new implementation"""
 
@@ -348,6 +350,7 @@ def generate_performance_recommendations(results: Dict) -> List[str]:
 
 
 @frappe.whitelist()
+@development_only_api()
 def quick_performance_comparison():
     """Quick performance comparison for immediate feedback"""
 

--- a/verenigingen/utils/api_doc_generator.py
+++ b/verenigingen/utils/api_doc_generator.py
@@ -16,6 +16,7 @@ import frappe
 from frappe import _
 
 from verenigingen.utils.error_handling import get_logger
+from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
 
 
 class APIDocGenerator:
@@ -644,6 +645,7 @@ class APIDocGenerator:
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def generate_api_documentation():
     """Generate API documentation in multiple formats"""
 
@@ -686,6 +688,7 @@ def generate_api_documentation():
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def get_api_endpoints_summary():
     """Get summary of all API endpoints"""
 

--- a/verenigingen/utils/bulk_performance_monitor.py
+++ b/verenigingen/utils/bulk_performance_monitor.py
@@ -17,6 +17,8 @@ import frappe
 from frappe import _
 from frappe.utils import flt, now_datetime
 
+from verenigingen.utils.security.api_security_framework import OperationType, standard_api
+
 
 def collect_performance_metrics() -> Dict:
     """
@@ -242,6 +244,7 @@ def check_performance_thresholds() -> Dict:
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def get_performance_dashboard_data():
     """Get performance data for admin dashboard display."""
     if not frappe.has_permission("Bulk Operation Tracker", "read"):

--- a/verenigingen/utils/csv_import_processor.py
+++ b/verenigingen/utils/csv_import_processor.py
@@ -25,6 +25,8 @@ import frappe
 from frappe import _
 from frappe.utils import get_datetime, now
 
+from verenigingen.utils.security.api_security_framework import OperationType, critical_api
+
 
 def coerce_test_mode(value) -> bool:
     """Coerce a `test_mode` argument to a real bool.
@@ -352,6 +354,7 @@ class CSVImportBackgroundProcessor:
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def queue_csv_import_processing(
     import_doc_name: str, doctype: str, processor_method: str, timeout: int = 3600, queue: str = "long"
 ):

--- a/verenigingen/utils/csv_import_processor.py
+++ b/verenigingen/utils/csv_import_processor.py
@@ -353,6 +353,20 @@ class CSVImportBackgroundProcessor:
         frappe.db.commit()
 
 
+# Import processors that may be dispatched via queue_csv_import_processing.
+# processor_method is caller-supplied and flows straight into frappe.enqueue, so
+# it MUST be constrained to this allow-list — otherwise the endpoint is an
+# arbitrary-method-execution primitive for anyone who can reach it.
+ALLOWED_IMPORT_PROCESSORS = frozenset(
+    {
+        "verenigingen.verenigingen.doctype.mijnrood_csv_import.mijnrood_csv_import.process_import_background",
+        "verenigingen.verenigingen.doctype.procurios_csv_import.procurios_csv_import.process_import_background",
+        "verenigingen.verenigingen.doctype.vip_import.vip_import.process_import_background",
+        "verenigingen.verenigingen_payments.doctype.procurios_mandate_import.procurios_mandate_import.process_import_background",
+    }
+)
+
+
 @frappe.whitelist()
 @critical_api(operation_type=OperationType.ADMIN)
 def queue_csv_import_processing(
@@ -364,14 +378,17 @@ def queue_csv_import_processing(
     Args:
         import_doc_name: Name of the import document
         doctype: DocType name of the import document
-        processor_method: Fully qualified method path to process the import
-                         (e.g., "verenigingen.verenigingen.doctype.mijnrood_csv_import.mijnrood_csv_import.process_import_background")
+        processor_method: Fully qualified method path to process the import.
+                         MUST be one of ALLOWED_IMPORT_PROCESSORS.
         timeout: Job timeout in seconds (default 1 hour)
         queue: Queue name (default "long")
 
     Returns:
         dict: Job enqueue confirmation
     """
+    if processor_method not in ALLOWED_IMPORT_PROCESSORS:
+        frappe.throw(_("Invalid import processor: {0}").format(processor_method), frappe.PermissionError)
+
     frappe.enqueue(
         method=processor_method,
         queue=queue,

--- a/verenigingen/utils/deleted_document_cleanup.py
+++ b/verenigingen/utils/deleted_document_cleanup.py
@@ -19,9 +19,15 @@ from frappe import _
 
 from verenigingen.utils.constants import Roles
 from verenigingen.utils.operation_result import OperationResult
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    critical_api,
+    high_security_api,
+)
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def get_deleted_document_statistics() -> OperationResult[Dict[str, Any]]:
     """
     Get statistics about the Deleted Document table.
@@ -104,6 +110,7 @@ def get_deleted_document_statistics() -> OperationResult[Dict[str, Any]]:
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def clear_all_deleted_documents() -> OperationResult[Dict[str, Any]]:
     """
     Clear ALL deleted documents from the Deleted Document table.
@@ -175,6 +182,7 @@ def clear_all_deleted_documents() -> OperationResult[Dict[str, Any]]:
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def clear_deleted_documents_older_than_days(days=90) -> OperationResult[Dict[str, Any]]:
     """
     Clear deleted documents older than specified days.
@@ -268,6 +276,7 @@ def clear_deleted_documents_older_than_days(days=90) -> OperationResult[Dict[str
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def clear_deleted_documents_by_doctype(doctype: str, older_than_days=None) -> OperationResult[Dict[str, Any]]:
     """
     Clear deleted documents for a specific DocType.
@@ -372,6 +381,7 @@ def clear_deleted_documents_by_doctype(doctype: str, older_than_days=None) -> Op
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def permanently_delete_doctype_documents(
     doctype: str, document_names: str | list
 ) -> OperationResult[Dict[str, Any]]:

--- a/verenigingen/utils/doctype/bank_integration_settings/bank_integration_settings.py
+++ b/verenigingen/utils/doctype/bank_integration_settings/bank_integration_settings.py
@@ -4,6 +4,8 @@
 import frappe
 from frappe.model.document import Document
 
+from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
+
 
 class BankIntegrationSettings(Document):
     """Bank Integration Settings for PSD2 API connections"""
@@ -92,6 +94,7 @@ class BankIntegrationSettings(Document):
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def test_bank_connection():
     """Test bank API connection from client side"""
     settings = frappe.get_single("Bank Integration Settings")
@@ -100,6 +103,7 @@ def test_bank_connection():
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def refresh_oauth_token():
     """Refresh OAuth2 token from client side"""
     settings = frappe.get_single("Bank Integration Settings")

--- a/verenigingen/utils/document_categories.py
+++ b/verenigingen/utils/document_categories.py
@@ -44,6 +44,18 @@ def _get_categories_from_settings() -> dict[str, str]:
     return dict(_FALLBACK_CATEGORIES)
 
 
+def _format_category_options() -> str:
+    """Build the newline-separated Select options string.
+
+    Undecorated core so internal callers (install/migrate lifecycle hooks,
+    Settings save) can invoke it without triggering the whitelisted endpoint's
+    auth/rate-limit stack. The rate limiter fails closed when its COR fixture
+    is not yet loaded (e.g. during install), which would abort the install.
+    """
+    categories = _get_categories_from_settings()
+    return "\n".join(categories.keys())
+
+
 @frappe.whitelist()
 @utility_api(operation_type=OperationType.UTILITY)
 def get_document_category_options():
@@ -51,8 +63,7 @@ def get_document_category_options():
     Get all available document categories for select fields.
     Returns newline-separated options for Frappe Select fields.
     """
-    categories = _get_categories_from_settings()
-    return "\n".join(categories.keys())
+    return _format_category_options()
 
 
 def get_category_icons() -> dict[str, str]:
@@ -91,7 +102,7 @@ def sync_category_options_to_doctypes():
     forms, list views, bulk edit, standard filters, and Report Builder.
     Call this whenever Verenigingen Settings is saved.
     """
-    options_str = get_document_category_options()
+    options_str = _format_category_options()
 
     for doctype, fieldname, leading_blank in _SYNCED_FIELDS:
         value = ("\n" + options_str) if leading_blank else options_str

--- a/verenigingen/utils/document_categories.py
+++ b/verenigingen/utils/document_categories.py
@@ -11,6 +11,8 @@ during installation (see setup/__init__.py).
 
 import frappe
 
+from verenigingen.utils.security.api_security_framework import OperationType, utility_api
+
 # Fallback defaults used only when Settings child table is empty
 # (e.g. fresh install before after_install runs)
 _FALLBACK_CATEGORIES = {
@@ -43,6 +45,7 @@ def _get_categories_from_settings() -> dict[str, str]:
 
 
 @frappe.whitelist()
+@utility_api(operation_type=OperationType.UTILITY)
 def get_document_category_options():
     """
     Get all available document categories for select fields.

--- a/verenigingen/utils/jinja_methods.py
+++ b/verenigingen/utils/jinja_methods.py
@@ -4,8 +4,11 @@ Jinja template methods for Verenigingen app
 
 import frappe
 
+from verenigingen.utils.security.api_security_framework import OperationType, public_api
+
 
 @frappe.whitelist(allow_guest=True)
+@public_api(operation_type=OperationType.PUBLIC)
 def get_brand_css_variables():
     """Get brand color CSS variables for templates"""
     try:

--- a/verenigingen/utils/logger_config.py
+++ b/verenigingen/utils/logger_config.py
@@ -12,6 +12,8 @@ from logging.handlers import RotatingFileHandler
 
 import frappe
 
+from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
+
 
 def setup_security_logger():
     """
@@ -106,6 +108,7 @@ def verify_logger_configuration():
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def get_security_log_info():
     """
     Get information about the security log file.
@@ -119,6 +122,7 @@ def get_security_log_info():
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def get_recent_security_logs(lines=50):
     """
     Get the most recent security log entries.

--- a/verenigingen/utils/member_performance_optimizer.py
+++ b/verenigingen/utils/member_performance_optimizer.py
@@ -487,6 +487,7 @@ member_optimizer = MemberPerformanceOptimizer()
 
 # Convenience functions for common operations
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def create_member_optimized(**kwargs):
     """Whitelisted method for optimized member creation"""
     return member_optimizer.create_member_optimized(kwargs)

--- a/verenigingen/utils/member_portal_utils.py
+++ b/verenigingen/utils/member_portal_utils.py
@@ -7,9 +7,11 @@ from frappe import _
 from frappe.utils import getdate
 
 from verenigingen.utils.constants import Roles
+from verenigingen.utils.security.api_security_framework import OperationType, standard_api, utility_api
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def get_member_portal_stats():
     """
     Get statistics about member portal usage.
@@ -52,6 +54,7 @@ def get_member_portal_stats():
 
 
 @frappe.whitelist()
+@utility_api(operation_type=OperationType.UTILITY)
 def get_user_appropriate_home_page():
     """
     Get the appropriate home page for the current user

--- a/verenigingen/utils/membership_dues_integration.py
+++ b/verenigingen/utils/membership_dues_integration.py
@@ -10,6 +10,7 @@ from frappe.utils import add_days, add_months, getdate, today
 from verenigingen.services.billing.template_configuration_service import load_template_for_membership_type
 from verenigingen.utils.member_utils import get_active_membership_for_member
 from verenigingen.utils.schedule_naming_helper import generate_dues_schedule_name
+from verenigingen.utils.security.api_security_framework import OperationType, critical_api
 
 
 def create_dues_schedule_from_application(membership_application):
@@ -302,6 +303,7 @@ def _calculate_member_paid_ytd_python(customer: str) -> float:
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.FINANCIAL)
 def adjust_dues_schedule(
     schedule_name: str, new_amount=None, new_frequency=None, new_next_date=None, reason=None
 ):

--- a/verenigingen/utils/performance_event_handlers.py
+++ b/verenigingen/utils/performance_event_handlers.py
@@ -23,6 +23,11 @@ from verenigingen.utils.optimized_queries import (
     OptimizedVolunteerQueries,
     validate_member_names,
 )
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    high_security_api,
+    utility_api,
+)
 
 
 class PerformanceEventHandlers:
@@ -308,6 +313,7 @@ def on_sepa_mandate_change(doc, method=None):
 
 # API endpoints for manual optimization triggers
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def trigger_member_optimization(member_names: str | list):
     """
     API endpoint to manually trigger member optimization
@@ -332,6 +338,7 @@ def trigger_member_optimization(member_names: str | list):
 
 
 @frappe.whitelist()
+@utility_api(operation_type=OperationType.UTILITY)
 def get_optimization_status():
     """
     API endpoint to get current optimization system status

--- a/verenigingen/utils/performance_integration.py
+++ b/verenigingen/utils/performance_integration.py
@@ -39,6 +39,7 @@ from verenigingen.utils.performance_event_handlers import (
     optimized_update_member_payment_history,
     optimized_update_member_payment_history_from_invoice,
 )
+from verenigingen.utils.security.api_security_framework import OperationType, critical_api, utility_api
 
 
 class PerformanceIntegration:
@@ -246,24 +247,28 @@ def trigger_bulk_member_optimization(member_names: List[str]):
 
 # API endpoints for safe performance management
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def install_safe_performance_optimizations():
     """API endpoint to install safe performance optimizations"""
     return PerformanceIntegration.install()
 
 
 @frappe.whitelist()
+@utility_api
 def get_performance_system_status():
     """API endpoint to get performance system status"""
     return PerformanceIntegration.get_status()
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def uninstall_performance_optimizations():
     """API endpoint to uninstall performance optimizations"""
     return PerformanceIntegration.uninstall()
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def trigger_member_bulk_optimization(member_names: str | list):
     """API endpoint to trigger bulk member optimization"""
     try:

--- a/verenigingen/utils/portal_customization.py
+++ b/verenigingen/utils/portal_customization.py
@@ -4,8 +4,16 @@ Portal customization utilities for member-focused portal configuration
 
 import frappe
 
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    high_security_api,
+    standard_api,
+    utility_api,
+)
+
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def setup_member_portal_menu():
     """Configure portal menu for association members - disable ERP items, add member items"""
     try:
@@ -121,6 +129,7 @@ def setup_member_portal_menu():
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def reset_portal_menu_to_member_only():
     """Reset portal menu to only show member/volunteer relevant items"""
     try:
@@ -195,6 +204,7 @@ def reset_portal_menu_to_member_only():
 
 
 @frappe.whitelist()
+@utility_api(operation_type=OperationType.UTILITY)
 def get_clean_member_portal_menu():
     """Get a clean list of portal menu items relevant for members"""
     try:
@@ -229,6 +239,7 @@ def get_clean_member_portal_menu():
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def analyze_current_portal_usage():
     """Analyze which portal menu items are actually being used"""
     try:

--- a/verenigingen/utils/project_permissions.py
+++ b/verenigingen/utils/project_permissions.py
@@ -590,6 +590,12 @@ def get_user_project_teams(user: str | None = None):
     """
     if not user:
         user = frappe.session.user
+    elif user != frappe.session.user:
+        # Querying another user's team/chapter/project access is an enumeration
+        # vector; restrict cross-user lookups to privileged roles.
+        privileged = {"System Manager", "Verenigingen Administrator", "Verenigingen System Administrator"}
+        if not privileged.intersection(frappe.get_roles()):
+            frappe.throw(_("Not permitted to view another user's project access"), frappe.PermissionError)
 
     try:
         # Use cached helper function (replaces 2 queries with 1)

--- a/verenigingen/utils/project_permissions.py
+++ b/verenigingen/utils/project_permissions.py
@@ -22,6 +22,7 @@ Projects can be linked to teams/chapters either:
 1. Directly via custom_team or custom_chapter fields
 2. Indirectly via name matching (project name contains team/chapter name)
 """
+
 import re
 from functools import lru_cache
 
@@ -29,6 +30,7 @@ import frappe
 from frappe import _
 
 from verenigingen.utils.constants import Roles
+from verenigingen.utils.security.api_security_framework import OperationType, standard_api
 
 
 # Custom Exceptions
@@ -575,6 +577,7 @@ def get_team_permission_level(team_name, volunteer, permission_type):
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def get_user_project_teams(user: str | None = None):
     """
     Get all teams, chapters, and their projects that a user has access to

--- a/verenigingen/utils/safe_member_optimizer.py
+++ b/verenigingen/utils/safe_member_optimizer.py
@@ -27,6 +27,12 @@ from typing import Any, Dict, List, Optional
 
 import frappe
 
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    high_security_api,
+    utility_api,
+)
+
 
 class SafeMemberOptimizer:
     """
@@ -432,6 +438,7 @@ safe_member_optimizer = SafeMemberOptimizer()
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def enable_safe_optimization(enabled: bool = True):
     """Enable or disable safe member optimization (admin function)"""
     safe_member_optimizer.enabled = bool(enabled)
@@ -440,6 +447,7 @@ def enable_safe_optimization(enabled: bool = True):
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def clear_optimization_caches():
     """Clear all optimization caches (admin function)"""
     safe_member_optimizer.clear_caches()
@@ -447,6 +455,7 @@ def clear_optimization_caches():
 
 
 @frappe.whitelist()
+@utility_api(operation_type=OperationType.UTILITY)
 def get_optimization_stats():
     """Get optimization statistics (admin function) - using Frappe native patterns"""
     try:

--- a/verenigingen/utils/schema_validation.py
+++ b/verenigingen/utils/schema_validation.py
@@ -8,8 +8,11 @@ Validates that the Chapter Board Member schema fixes are properly applied.
 
 import frappe
 
+from verenigingen.utils.security.api_security_framework import development_only_api
+
 
 @frappe.whitelist()
+@development_only_api()
 def validate_chapter_board_schema_fixes():
     """Validate that schema fixes are working correctly"""
 

--- a/verenigingen/utils/security/api_classifier.py
+++ b/verenigingen/utils/security/api_classifier.py
@@ -23,6 +23,7 @@ from verenigingen.utils.security.api_security_framework import (
     APISecurityFramework,
     OperationType,
     SecurityLevel,
+    development_only_api,
     get_security_framework,
 )
 from verenigingen.utils.security.audit_logging import AuditSeverity, get_audit_logger
@@ -792,6 +793,7 @@ def get_api_classifier() -> APIClassifier:
 
 # API endpoints for classification and migration
 @frappe.whitelist()
+@development_only_api()
 def classify_all_api_endpoints():
     """API endpoint to classify all endpoints"""
     if Roles.SYSTEM_MANAGER not in frappe.get_roles():
@@ -813,6 +815,7 @@ def classify_all_api_endpoints():
 
 
 @frappe.whitelist()
+@development_only_api()
 def generate_migration_report():
     """Generate comprehensive migration report"""
     if Roles.SYSTEM_MANAGER not in frappe.get_roles():
@@ -830,6 +833,7 @@ def generate_migration_report():
 
 
 @frappe.whitelist()
+@development_only_api()
 def get_implementation_code(module_path: str, function_name: str):
     """Get implementation code for securing a specific endpoint"""
     if Roles.SYSTEM_MANAGER not in frappe.get_roles():

--- a/verenigingen/utils/security/api_security_framework.py
+++ b/verenigingen/utils/security/api_security_framework.py
@@ -15,6 +15,7 @@ Architecture:
 """
 
 import time
+from dataclasses import replace as dataclass_replace
 from functools import wraps
 from typing import Any, Callable, Dict, List
 
@@ -885,7 +886,15 @@ def api_security_framework(
 
             # Determine security level
             level = security_level or framework.classify_endpoint(func, operation_type)
-            profile = framework.get_security_profile(level)
+            # SECURITY: copy the profile before applying per-endpoint overrides.
+            # get_security_profile() returns the shared class-level SECURITY_PROFILES
+            # instance; mutating it in place would leak an endpoint's overrides
+            # (allowed_environments, max_request_size) onto every other endpoint that
+            # shares the same SecurityLevel. A dev-only endpoint would poison the LOW
+            # profile's allowed_environments and 403 all self-service/utility endpoints
+            # in production; a custom max_request_size would raise the size limit for
+            # every other MEDIUM endpoint. Copy makes the override request-local.
+            profile = dataclass_replace(framework.get_security_profile(level))
 
             # Override profile settings if specified
             if allowed_environments:

--- a/verenigingen/utils/security/api_security_framework.py
+++ b/verenigingen/utils/security/api_security_framework.py
@@ -928,10 +928,15 @@ def api_security_framework(
                         implicit_allowed=self_service_implicit_allowed, **self_service_kwargs
                     )
 
-                    # Enhanced content validation for TOCTOU protection
+                    # Enhanced content validation for TOCTOU protection.
+                    # Resolve the caller's member with the canonical user-first
+                    # resolver (Member.user, then Member.email) — matching the
+                    # ownership gate. An email-only lookup silently skipped this
+                    # deep check for members whose Member.user differs from their
+                    # login email, disabling TOCTOU protection for that class of user.
                     current_user = frappe.session.user
                     if current_user not in ("Administrator", "Guest"):
-                        user_member = frappe.db.get_value("Member", {"email": current_user}, "name")
+                        user_member = framework.self_service_controller.get_user_member(current_user)
                         if user_member:
                             framework._validate_self_service_request_content(user_member, **kwargs)
 
@@ -1250,6 +1255,16 @@ def self_service_api(
         - Authentication required (rejects Guest)
         - LOW security level — any authenticated user passes auth
         - self_service_only=True — caller's member must match the target
+
+    OWNERSHIP CONTRACT (important):
+        The framework only understands member/volunteer identifiers (member,
+        member_name, member_id, volunteer[/_name/_id]). If your endpoint decides
+        what to act on from a DIFFERENT identifier — customer, donor, membership,
+        mandate, payment_plan, a bare `name`, etc. — the framework CANNOT verify
+        ownership of it, and (with implicit_allowed=True) the call is admitted as
+        implicit self-service. Such endpoints MUST perform their own ownership
+        check (resolve the entity to a member and compare to the session user).
+        All current implicit_allowed endpoints do this; keep it that way.
 
     Args:
         operation_type: Classification for rate limiting / audit context

--- a/verenigingen/utils/security/audit_logging.py
+++ b/verenigingen/utils/security/audit_logging.py
@@ -19,6 +19,7 @@ from verenigingen.utils.constants import Roles
 # Lazy import for email_service to avoid circular dependency
 # from verenigingen.services.communication.email_service import get_email_service
 from verenigingen.utils.error_handling import log_error
+from verenigingen.utils.security.api_security_framework import high_security_api
 from verenigingen.utils.security.types import AuditEventType, AuditSeverity, OperationType
 
 
@@ -967,6 +968,7 @@ def audit_log(event_type: str, severity: str = "info", capture_args: bool = Fals
 
 # API endpoints for audit log management
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 @_development_only
 def search_audit_logs(**filters):
     """
@@ -992,6 +994,7 @@ def search_audit_logs(**filters):
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 @_development_only
 def get_audit_statistics(days: int = 7):
     """

--- a/verenigingen/utils/security/authorization.py
+++ b/verenigingen/utils/security/authorization.py
@@ -445,8 +445,13 @@ class SEPAAuthorizationManager:
             return True
 
         try:
-            current_ip = getattr(frappe.local, "request_ip", None)
-            if not current_ip:
+            # Use the centralized, spoofing-hardened resolver (trusted-proxy aware)
+            # rather than raw frappe.local.request_ip, so the SEPA allowlist gets the
+            # same X-Forwarded-For protection as the main framework's IP allowlist.
+            from verenigingen.utils.security.client_ip import get_client_ip
+
+            current_ip = get_client_ip()
+            if not current_ip or current_ip in ("unknown", "test_environment"):
                 # An HTTP request under an active allowlist whose source IP cannot
                 # be determined must be denied (fail closed) - otherwise the
                 # allowlist is trivially bypassed by suppressing the IP.

--- a/verenigingen/utils/security/authorization.py
+++ b/verenigingen/utils/security/authorization.py
@@ -426,25 +426,42 @@ class SEPAAuthorizationManager:
 
             return True
 
-        except Exception:
-            # If timezone check fails, allow operation
-            return True
+        except Exception as e:
+            # Fail CLOSED: business-hours is an opt-in restriction, so if it
+            # cannot be evaluated we deny rather than silently allowing access
+            # outside the intended window.
+            frappe.logger("verenigingen.sepa_auth").warning(f"BUSINESS_HOURS_CHECK_FAILED (denying): {e}")
+            return False
 
     def _check_ip_restrictions(self) -> bool:
         """Check if current IP is allowed for restricted operations"""
         if not self.allowed_ips:
             return True  # No restrictions configured
 
+        # Non-HTTP contexts (background jobs, scheduler, CLI/console) have no
+        # source IP; an IP allowlist governs the network origin of HTTP requests,
+        # so it does not apply to these contexts.
+        if not getattr(frappe.local, "request", None):
+            return True
+
         try:
             current_ip = getattr(frappe.local, "request_ip", None)
             if not current_ip:
-                return True  # Can't determine IP, allow operation
+                # An HTTP request under an active allowlist whose source IP cannot
+                # be determined must be denied (fail closed) - otherwise the
+                # allowlist is trivially bypassed by suppressing the IP.
+                frappe.logger("verenigingen.sepa_auth").warning(
+                    "IP_RESTRICTION_DENIED: HTTP request with no determinable source IP"
+                )
+                return False
 
             # Check if IP is in allowed list
             return current_ip in self.allowed_ips
 
-        except Exception:
-            return True  # If IP check fails, allow operation
+        except Exception as e:
+            # Fail CLOSED on any error while an allowlist is active.
+            frappe.logger("verenigingen.sepa_auth").warning(f"IP_RESTRICTION_CHECK_FAILED (denying): {e}")
+            return False
 
     def _check_batch_permissions(self, context: Dict[str, Any], user: str) -> bool:
         """Check batch-specific permissions"""

--- a/verenigingen/utils/security/authorization.py
+++ b/verenigingen/utils/security/authorization.py
@@ -24,6 +24,7 @@ from frappe import _
 
 from verenigingen.utils.constants import Roles
 from verenigingen.utils.error_handling import PermissionError as VerenigingenPermissionError, log_error
+from verenigingen.utils.security.api_security_framework import utility_api
 from verenigingen.utils.security.audit_logging import AuditEventType, AuditSeverity, log_security_event
 from verenigingen.utils.security.authorization_engine import get_authorization_engine
 from verenigingen.utils.security.types import OperationType
@@ -689,6 +690,7 @@ def require_sepa_admin(func):
 
 # API endpoints for permission management
 @frappe.whitelist(allow_guest=False)
+@utility_api
 def get_user_sepa_permissions(user: str = None):
     # Utility operation: SEPA permission retrieval
     """
@@ -741,6 +743,7 @@ def get_user_sepa_permissions(user: str = None):
 
 
 @frappe.whitelist()
+@utility_api
 def check_sepa_operation_permission(operation: str, context: str = None):
     # Utility operation: SEPA operation permission check
     """

--- a/verenigingen/utils/security/authorization_engine.py
+++ b/verenigingen/utils/security/authorization_engine.py
@@ -64,6 +64,26 @@ class AuthorizationEngine:
         if not user:
             user = frappe.session.user
 
+        # ===== RULE 0: Administrator break-glass =====
+        # The singular `Administrator` bootstrap account is omnipotent, consistent
+        # with Frappe's own platform semantics (has_permission / only_for /
+        # ignore_permissions all treat it as superuser). It is the break-glass and
+        # bootstrap identity: install, migrate, and disaster recovery all run as
+        # Administrator and must be able to reach business logic. Denying it would
+        # create an UNRECOVERABLE lockout if role-profile provisioning ever fails
+        # closed (see get_user_role_profiles' own history of silent fail-closed
+        # regressions) -- the recovery account must not depend on the same data path
+        # it may need to repair. NOTE: this exception is ONLY the literal
+        # Administrator user; every real role, System Manager included, still needs a
+        # vetted role profile for HIGH/CRITICAL access (Rules 4-6 in the policy).
+        if user == "Administrator":
+            return AuthResult(
+                granted=True,
+                rule_matched="rule_0_administrator_break_glass",
+                auth_path="administrator",
+                reason="Administrator bootstrap account has break-glass access",
+            )
+
         # Fetch user data (I/O layer)
         user_profiles = self.get_user_role_profiles(user)
         user_roles = frappe.get_roles(user)

--- a/verenigingen/utils/security/authorization_policy.py
+++ b/verenigingen/utils/security/authorization_policy.py
@@ -41,10 +41,19 @@ class AuthorizationPolicy:
     2        | Guest check                    | All except PUBLIC    | Reject unauthenticated users
     3        | LOW level                      | LOW only             | Any authenticated user allowed
     4        | Role Profile (primary)         | MEDIUM, HIGH, CRIT   | User's assigned role profile grants access
-    5        | Individual Role (secondary)    | MEDIUM, HIGH, CRIT   | User role name matches profile name in mapping
+    5        | Individual Role (secondary)    | MEDIUM only          | User role name matches profile name in mapping (capped at MEDIUM)
     6        | System Manager exception       | MEDIUM only          | System Manager gets MEDIUM access
     7        | DENY                           | All                  | No matching rule found
+
+    SECURITY NOTE: HIGH and CRITICAL access is grantable ONLY through an assigned
+    Role Profile (Rule 4). The individual-role fallback (Rule 5) and the System
+    Manager exception (Rule 6) are both capped at MEDIUM, so a bare role can never
+    confer member-data or financial/admin API access.
     """
+
+    # Security levels that must be granted via an assigned Role Profile only.
+    # Rule 5 (bare individual role) and Rule 6 (System Manager) do not apply here.
+    PROFILE_ONLY_LEVELS = frozenset({SecurityLevel.HIGH, SecurityLevel.CRITICAL})
 
     # Role Profile to Security Level mapping
     # This replaces hardcoded role lists with role profile-based access
@@ -167,16 +176,27 @@ class AuthorizationPolicy:
                 )
 
         # ===== RULE 5: Secondary - Individual role matches profile name =====
-        # This supports backwards compatibility where role names match profile names
-        for role in user_roles:
-            allowed_levels = self.ROLE_PROFILE_SECURITY_MAPPING.get(role, [])
-            if required_level in allowed_levels:
-                return AuthResult(
-                    granted=True,
-                    rule_matched="rule_5_individual_role",
-                    auth_path=f"individual_role:{role}",
-                    reason=f"Individual role {role} grants {required_level.value} access",
-                )
+        # Backwards-compatibility path for users who hold a role whose name matches
+        # a mapping key but have not been assigned the corresponding Role Profile.
+        #
+        # SECURITY: this path is capped at MEDIUM. HIGH (member-data) and CRITICAL
+        # (financial/admin/SEPA) access must come from a vetted Role Profile
+        # assignment (Rule 4), never from a bare role. Otherwise granting a role
+        # such as "Verenigingen Administrator" or "Verenigingen Chapter Board Member"
+        # for an unrelated feature would silently confer elevated API access without
+        # the corresponding role profile — the very escalation the role-profile model
+        # exists to prevent. (LOW is already granted to any authenticated user by
+        # Rule 3, so in practice Rule 5 only adds MEDIUM here.)
+        if required_level not in self.PROFILE_ONLY_LEVELS:
+            for role in user_roles:
+                allowed_levels = self.ROLE_PROFILE_SECURITY_MAPPING.get(role, [])
+                if required_level in allowed_levels:
+                    return AuthResult(
+                        granted=True,
+                        rule_matched="rule_5_individual_role",
+                        auth_path=f"individual_role:{role}",
+                        reason=f"Individual role {role} grants {required_level.value} access",
+                    )
 
         # ===== RULE 6: System Manager exception for MEDIUM =====
         if Roles.SYSTEM_MANAGER in user_roles and required_level == SecurityLevel.MEDIUM:

--- a/verenigingen/utils/security/client_ip.py
+++ b/verenigingen/utils/security/client_ip.py
@@ -69,6 +69,19 @@ def _get_trusted_proxy_networks() -> List[ipaddress.IPv4Network | ipaddress.IPv6
             "trust_private_networks": true  // Optional, defaults to true
         }
 
+    SECURITY / HARDENING:
+        The default trusts all private/loopback ranges so that the common
+        single-host nginx->gunicorn deployment (REMOTE_ADDR=127.0.0.1) reads the
+        real client from X-Forwarded-For without extra config. This is safe ONLY
+        when the front proxy APPENDS to XFF (the standard
+        `proxy_add_x_forwarded_for`). If your proxy passes an attacker-supplied
+        XFF through unchanged, or clients can reach the app server directly from
+        a private network, an attacker can spoof their source IP. In those
+        deployments, set "trust_private_networks": false and list ONLY your real
+        proxy addresses in "trusted_proxies" so XFF is trusted from those hops
+        alone. The CRITICAL-endpoint IP allowlist and per-IP rate limiting rely
+        on this resolution.
+
     Returns:
         List of parsed network objects
     """
@@ -228,9 +241,14 @@ def get_client_ip() -> str:
         if not _is_trusted_proxy(ip, trusted_networks):
             return ip
 
-    # All IPs in chain are trusted proxies (unusual)
-    # Return leftmost (original client per spec)
-    return forwarded_ips[0] if forwarded_ips else remote_addr
+    # Every hop in the chain is a trusted proxy (unusual). Do NOT return the
+    # leftmost XFF entry: that value is fully attacker-controllable (any client
+    # can prepend an arbitrary IP), so returning it would let an attacker forge
+    # a source IP that matches an IP allowlist made of private addresses, or
+    # rotate the value to evade per-IP rate limits. Fall back to the actual
+    # connecting address (remote_addr), which cannot be spoofed. This fails
+    # closed for allowlist checks (a proxy IP won't match a client allowlist).
+    return remote_addr
 
 
 def get_client_ip_with_info() -> dict:

--- a/verenigingen/utils/security/csrf_protection.py
+++ b/verenigingen/utils/security/csrf_protection.py
@@ -13,6 +13,8 @@ import hmac
 import frappe
 from frappe import _
 
+from verenigingen.utils.security.api_security_framework import utility_api
+
 
 class CSRFError(frappe.ValidationError):
     """Raised when CSRF validation fails"""
@@ -146,6 +148,7 @@ class CSRFProtection:
 
 # API endpoints for backwards compatibility
 @frappe.whitelist(allow_guest=False)
+@utility_api
 def get_csrf_token():
     """
     API endpoint to get CSRF token for current user
@@ -170,6 +173,7 @@ def get_csrf_token():
 
 
 @frappe.whitelist(allow_guest=False)
+@utility_api
 def validate_csrf_token(token: str):
     """
     API endpoint to validate CSRF token

--- a/verenigingen/utils/security/csrf_protection.py
+++ b/verenigingen/utils/security/csrf_protection.py
@@ -8,6 +8,8 @@ as it was redundant with Frappe's built-in functionality.
 See archived/security_implementations/CSRF_ARCHIVAL_NOTES.md for details.
 """
 
+import hmac
+
 import frappe
 from frappe import _
 
@@ -70,8 +72,9 @@ class CSRFProtection:
                 raise CSRFError(_("CSRF validation not available for guest users"))
             raise CSRFError(_("No CSRF token in session"))
 
-        # Validate token matches
-        if token != expected_token:
+        # Validate token matches using a constant-time comparison to avoid a
+        # timing oracle on the expected token.
+        if not hmac.compare_digest(str(token), str(expected_token)):
             raise CSRFError(_("CSRF token is invalid"))
 
         return True
@@ -95,10 +98,10 @@ class CSRFProtection:
             # Check form data
             token = frappe.form_dict.get("csrf_token")
 
-        if not token:
-            # Fallback to session token
-            token = frappe.session.data.get("csrf_token")
-
+        # SECURITY: do NOT fall back to the session's own csrf_token here. Doing so
+        # made validate_request() compare the session token against itself, so a
+        # request that simply omitted the CSRF header/field always passed. A token
+        # must be supplied by the client (header or form field) to be validated.
         return token
 
     @classmethod

--- a/verenigingen/utils/security/enhanced_validation.py
+++ b/verenigingen/utils/security/enhanced_validation.py
@@ -7,6 +7,7 @@ specifically designed for association management APIs.
 """
 
 import json
+import math
 import re
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
@@ -136,12 +137,22 @@ class ValidationRule:
                 }
         elif expected_type == "float":
             try:
-                float(value)
+                parsed_float = float(value)
             except (ValueError, TypeError):
                 return {
                     "valid": False,
                     "severity": self.severity.value,
                     "message": self.message or _("{0} must be a number").format(field_name or "Field"),
+                    "rule_type": self.rule_type.value,
+                }
+            # Reject nan/inf: float("nan") and float("inf") parse successfully but
+            # make every subsequent bound comparison false, so a RANGE rule would
+            # accept them (e.g. amount="nan" slipping past min=0.01/max=10000).
+            if not math.isfinite(parsed_float):
+                return {
+                    "valid": False,
+                    "severity": self.severity.value,
+                    "message": self.message or _("{0} must be a finite number").format(field_name or "Field"),
                     "rule_type": self.rule_type.value,
                 }
         elif expected_type == "boolean" and not isinstance(value, bool):
@@ -214,6 +225,16 @@ class ValidationRule:
         try:
             numeric_value = float(value)
 
+            # Reject nan/inf up front: comparisons against nan are always false,
+            # so an unchecked nan would satisfy both min and max bounds.
+            if not math.isfinite(numeric_value):
+                return {
+                    "valid": False,
+                    "severity": self.severity.value,
+                    "message": self.message or _("{0} must be a finite number").format(field_name or "Field"),
+                    "rule_type": self.rule_type.value,
+                }
+
             min_val = self.params.get("min")
             max_val = self.params.get("max")
 
@@ -285,7 +306,10 @@ class ValidationRule:
             return {"valid": True}
 
         try:
-            if not re.match(pattern, str(value)):
+            # Use fullmatch, not match: re.match anchors only at the start, so a
+            # pattern like r"[A-Z]{2}\d+" would accept "AB12<script>". fullmatch
+            # requires the ENTIRE value to conform.
+            if not re.fullmatch(pattern, str(value)):
                 return {
                     "valid": False,
                     "severity": self.severity.value,

--- a/verenigingen/utils/security/rate_limit_engine.py
+++ b/verenigingen/utils/security/rate_limit_engine.py
@@ -65,15 +65,31 @@ class RateLimitEngine:
         Raises:
             VPermissionError: If no COR configuration found
         """
-        # Skip rate limiting during test execution (unless force_check is True)
-        if not force_check and getattr(frappe.flags, "in_test", False):
+        # Skip rate limiting during test execution and privileged server-side
+        # maintenance phases (install / migrate / patch), unless force_check is True.
+        #
+        # Rate limiting exists to throttle external HTTP callers; during install,
+        # migrate, and patch there is no such caller. Critically, the COR fixture
+        # (_generic_api_fallback and the per-operation rules) is loaded by
+        # sync_fixtures, which runs AFTER after_install hooks (see
+        # frappe/installer.py) and after patches — so a security-decorated
+        # function reached from a lifecycle hook or patch would otherwise hit the
+        # fail-closed branch below ("No rate limiting configuration found") and
+        # abort the install/migrate. These flags are only ever set by trusted CLI
+        # maintenance operations, never by an attacker-reachable request.
+        if not force_check and (
+            getattr(frappe.flags, "in_test", False)
+            or getattr(frappe.flags, "in_install", False)
+            or getattr(frappe.flags, "in_migrate", False)
+            or getattr(frappe.flags, "in_patch", False)
+        ):
             return RateLimitResult(
                 allowed=True,
                 current_count=0,
                 max_calls=999,
                 period_seconds=3600,
                 limit_type="test_bypass",
-                reason="Rate limiting skipped in test environment",
+                reason="Rate limiting skipped in test/install/migrate/patch context",
             )
 
         # Extract operation name from operation key

--- a/verenigingen/utils/security/rate_limit_engine.py
+++ b/verenigingen/utils/security/rate_limit_engine.py
@@ -262,13 +262,22 @@ class RateLimitEngine:
         Returns:
             Cache key string
         """
+        # Namespace the counter by site. These keys are read/written via
+        # frappe.cache.incrby / .expire / .get, which are raw redis ops that do
+        # NOT pass through RedisWrapper.make_key (unlike set_value/get_value), so
+        # they carry no site prefix. On a multi-tenant bench sharing one Redis,
+        # an unprefixed key would collapse the same operation/user/IP counter
+        # across every site, letting one tenant exhaust another's rate-limit
+        # budget. Prefix with the site to restore per-site isolation.
+        site = getattr(frappe.local, "site", None) or "unknown-site"
+        prefix = f"cor_rate_limit:{site}:{limit_type}:{operation_name}"
         if scope == "global":
-            return f"cor_rate_limit:{limit_type}:{operation_name}"
+            return prefix
         elif scope == "per_ip":
             client_ip = self._get_client_ip()
-            return f"cor_rate_limit:{limit_type}:{operation_name}:{client_ip}"
+            return f"{prefix}:{client_ip}"
         else:  # per_user (default)
-            return f"cor_rate_limit:{limit_type}:{operation_name}:{frappe.session.user}"
+            return f"{prefix}:{frappe.session.user}"
 
     def _get_client_ip(self) -> str:
         """

--- a/verenigingen/utils/security/self_service_access_controller.py
+++ b/verenigingen/utils/security/self_service_access_controller.py
@@ -10,6 +10,7 @@ DEPENDENCY RULES:
 - MUST NOT import from api_security_framework.py (to avoid circular imports)
 """
 
+import json
 from typing import Any, Callable, Dict, List, Optional
 
 import frappe
@@ -18,6 +19,24 @@ from frappe import _
 from verenigingen.utils.error_handling import PermissionError as VPermissionError
 from verenigingen.utils.security.client_ip import get_client_ip as centralized_get_client_ip
 from verenigingen.utils.security.types import AuditEventType, AuditSeverity
+
+
+def _try_parse_json(value: str):
+    """Best-effort parse of a JSON-encoded string.
+
+    Returns the parsed object on success, or None if the string is not JSON.
+    Used by the self-service content inspector to see member/volunteer
+    references hidden inside JSON string payloads.
+    """
+    if not value or value[0] not in "[{":
+        # Fast reject: only object/array JSON payloads can contain nested
+        # member/volunteer references. Skips the exception cost for plain
+        # scalars, member names, IBANs, etc.
+        return None
+    try:
+        return json.loads(value)
+    except (ValueError, TypeError):
+        return None
 
 
 class SelfServiceAccessController:
@@ -145,34 +164,50 @@ class SelfServiceAccessController:
         # Get user's member record
         user_member = self.get_user_member(current_user)
 
-        # Find target member from request parameters
-        target_member = self._extract_target_member(**kwargs)
+        # Collect EVERY explicit member/volunteer identifier present in the request.
+        # Validating only the first one let an attacker pass a matching `member`
+        # while smuggling a foreign `member_id`/`volunteer` that the endpoint then
+        # acts on. Every explicit target must resolve to the caller's own member.
+        explicit_targets = self._extract_target_members(**kwargs)
 
         # Handle implicit self-service (no explicit target)
-        if not target_member:
+        if not explicit_targets:
             return self._handle_implicit_self_service(current_user, user_member, implicit_allowed)
 
-        # Validate explicit target access
-        return self._validate_target_access(target_member, user_member)
+        # Validate explicit target access - all identifiers must match the caller.
+        for field, target_member in explicit_targets:
+            # An explicit volunteer/member reference that cannot be resolved to a
+            # member (nonexistent, or no member link) is a foreign/invalid target,
+            # not "no target" - fail closed rather than collapsing to implicit self.
+            if target_member is None:
+                raise VPermissionError(
+                    _("Access denied: unable to verify your ownership of '{0}'").format(field)
+                )
+            self._validate_target_access(target_member, user_member)
 
-    def _extract_target_member(self, **kwargs) -> Optional[str]:
+        return True
+
+    def _extract_target_members(self, **kwargs) -> List[tuple]:
         """
-        Extract target member from request parameters.
+        Extract ALL target member identifiers from request parameters.
 
         Args:
             **kwargs: Request parameters
 
         Returns:
-            Target member name or None
+            List of (field_name, resolved_member_or_None) tuples for every member/
+            volunteer identifier present in the request. `volunteer` values are
+            resolved to their linked member (None if unresolvable).
         """
+        targets = []
         for field in self.MEMBER_FIELDS:
             if field in kwargs and kwargs[field]:
                 if field == "volunteer":
-                    # For volunteer operations, get the linked member
-                    return self.get_volunteer_member(kwargs[field])
+                    # For volunteer operations, resolve the linked member.
+                    targets.append((field, self.get_volunteer_member(kwargs[field])))
                 else:
-                    return kwargs[field]
-        return None
+                    targets.append((field, kwargs[field]))
+        return targets
 
     def _handle_implicit_self_service(
         self, current_user: str, user_member: Optional[str], implicit_allowed: bool
@@ -285,6 +320,16 @@ class SelfServiceAccessController:
 
         def inspect_data(data, path=""):
             """Recursively inspect data for member/volunteer references"""
+            if isinstance(data, str):
+                # Frappe delivers nested / child-table payloads as JSON strings.
+                # Parse them so member/volunteer references hidden inside a JSON
+                # string (e.g. data='{"member":"VICTIM"}') are not invisible to
+                # the ownership inspection.
+                parsed = _try_parse_json(data)
+                if isinstance(parsed, (dict, list)):
+                    inspect_data(parsed, path)
+                return
+
             if isinstance(data, dict):
                 for key, value in data.items():
                     current_path = f"{path}.{key}" if path else key
@@ -318,18 +363,19 @@ class SelfServiceAccessController:
                                     }
                                 )
 
-                    # Recursively check nested structures
-                    elif isinstance(value, (dict, list)):
+                    # Recursively check nested structures (dict/list) and
+                    # JSON-encoded strings.
+                    else:
                         inspect_data(value, current_path)
 
             elif isinstance(data, list):
                 for i, item in enumerate(data):
                     inspect_data(item, f"{path}[{i}]")
 
-        # Inspect all parameters
-        for key, value in kwargs.items():
-            if isinstance(value, (dict, list)):
-                inspect_data(value, key)
+        # Inspect all parameters, including top-level scalar member/volunteer
+        # identifiers (member_id, member_name, volunteer_id, ...) which were
+        # previously skipped because only dict/list values were recursed into.
+        inspect_data(kwargs)
 
         return violations
 

--- a/verenigingen/utils/security/self_service_access_controller.py
+++ b/verenigingen/utils/security/self_service_access_controller.py
@@ -28,14 +28,20 @@ def _try_parse_json(value: str):
     Used by the self-service content inspector to see member/volunteer
     references hidden inside JSON string payloads.
     """
-    if not value or value[0] not in "[{":
-        # Fast reject: only object/array JSON payloads can contain nested
-        # member/volunteer references. Skips the exception cost for plain
-        # scalars, member names, IBANs, etc.
+    if not value:
+        return None
+    # Fast reject on the first NON-WHITESPACE char: json.loads (and the endpoints
+    # that consume the payload) tolerate leading whitespace, so peeking at value[0]
+    # alone let ' {"member":"VICTIM"}' slip past the inspector while json.loads
+    # still parsed it. Only object/array payloads can carry nested refs.
+    stripped = value.lstrip()
+    if not stripped or stripped[0] not in "[{":
         return None
     try:
         return json.loads(value)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, RecursionError):
+        # RecursionError: deeply-nested JSON (a cheap ~40KB payload) would
+        # otherwise raise uncaught and 500. Treat unparseable input as "not JSON".
         return None
 
 
@@ -318,8 +324,18 @@ class SelfServiceAccessController:
         """
         violations = []
 
-        def inspect_data(data, path=""):
+        # Bound the traversal depth so a deeply-nested payload cannot exhaust the
+        # stack. Legitimate member/volunteer references live near the surface;
+        # 64 levels is far beyond any real request shape. Fails closed (a payload
+        # nested past the cap simply isn't inspected further, and the ownership
+        # gate + endpoint self-checks still apply).
+        MAX_DEPTH = 64
+
+        def inspect_data(data, path="", depth=0):
             """Recursively inspect data for member/volunteer references"""
+            if depth > MAX_DEPTH:
+                return
+
             if isinstance(data, str):
                 # Frappe delivers nested / child-table payloads as JSON strings.
                 # Parse them so member/volunteer references hidden inside a JSON
@@ -327,7 +343,7 @@ class SelfServiceAccessController:
                 # the ownership inspection.
                 parsed = _try_parse_json(data)
                 if isinstance(parsed, (dict, list)):
-                    inspect_data(parsed, path)
+                    inspect_data(parsed, path, depth + 1)
                 return
 
             if isinstance(data, dict):
@@ -366,11 +382,11 @@ class SelfServiceAccessController:
                     # Recursively check nested structures (dict/list) and
                     # JSON-encoded strings.
                     else:
-                        inspect_data(value, current_path)
+                        inspect_data(value, current_path, depth + 1)
 
             elif isinstance(data, list):
                 for i, item in enumerate(data):
-                    inspect_data(item, f"{path}[{i}]")
+                    inspect_data(item, f"{path}[{i}]", depth + 1)
 
         # Inspect all parameters, including top-level scalar member/volunteer
         # identifiers (member_id, member_name, volunteer_id, ...) which were

--- a/verenigingen/utils/session_cleanup.py
+++ b/verenigingen/utils/session_cleanup.py
@@ -11,6 +11,8 @@ from datetime import timedelta
 import frappe
 from frappe.utils import now_datetime
 
+from verenigingen.utils.security.api_security_framework import development_only_api
+
 
 def cleanup_corrupted_sessions():
     """
@@ -100,7 +102,8 @@ def validate_current_session():
         return {"valid": False, "error": str(e), "warnings": ["Exception during validation"]}
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
+@development_only_api()
 def get_session_debug_info():
     """
     API endpoint to get session debugging information

--- a/verenigingen/utils/session_cleanup_enhanced.py
+++ b/verenigingen/utils/session_cleanup_enhanced.py
@@ -13,6 +13,8 @@ from datetime import datetime, timedelta
 import frappe
 from frappe import _
 
+from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
+
 
 def cleanup_corrupted_sessions():
     """
@@ -179,6 +181,7 @@ def validate_current_session():
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def run_session_cleanup():
     """
     API endpoint to run session cleanup

--- a/verenigingen/utils/validation/application_validators.py
+++ b/verenigingen/utils/validation/application_validators.py
@@ -10,6 +10,7 @@ from frappe import _
 from frappe.utils import getdate, today, validate_email_address
 
 from verenigingen.utils.constants import Roles
+from verenigingen.utils.security.api_security_framework import development_only_api
 
 
 def validate_email(email, allow_existing=False):
@@ -345,6 +346,7 @@ def check_application_eligibility(data, allow_existing_email=False):
 
 
 @frappe.whitelist()
+@development_only_api()
 def debug_application_eligibility():
     """Debug function to test application eligibility validation"""
     # Security check: Only allow debug functions in development or for System Managers

--- a/verenigingen/utils/version_cleanup.py
+++ b/verenigingen/utils/version_cleanup.py
@@ -7,10 +7,11 @@ import frappe
 from frappe import _
 
 from verenigingen.utils.constants import Roles
-from verenigingen.utils.security.api_security_framework import OperationType, critical_api
+from verenigingen.utils.security.api_security_framework import OperationType, critical_api, standard_api
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def clear_all_versions():
     """
     Clear all version history from the Version table.
@@ -71,6 +72,7 @@ def clear_all_versions():
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def get_version_statistics():
     """
     Get statistics about version history storage.
@@ -124,6 +126,7 @@ def get_version_statistics():
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def clear_versions_older_than_days(days=90):
     """
     Clear version history older than specified days.
@@ -352,6 +355,7 @@ def nuclear_truncate_version_and_deleted_tables(confirm_nuclear_truncate=False, 
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def clear_versions_by_doctype(doctype: str, older_than_days=None):
     """
     Clear version history for a specific DocType.

--- a/verenigingen/verenigingen/doctype/brand_settings/brand_settings.py
+++ b/verenigingen/verenigingen/doctype/brand_settings/brand_settings.py
@@ -447,6 +447,26 @@ def get_active_brand_settings():
         settings_doc = frappe.get_single("Brand Settings")
         settings = settings_doc.as_dict()
 
+        # This endpoint is guest-accessible (@public_api). Strip framework
+        # metadata before returning: owner/modified_by expose user emails to
+        # anonymous callers, and the rest is internal bookkeeping. Only brand
+        # config fields (colors, logo, description, …) should be public.
+        for meta_field in (
+            "owner",
+            "modified_by",
+            "modified",
+            "creation",
+            "docstatus",
+            "idx",
+            "name",
+            "doctype",
+            "_user_tags",
+            "_comments",
+            "_assign",
+            "_liked_by",
+        ):
+            settings.pop(meta_field, None)
+
         # Cache for 1 hour
         frappe.cache().set_value("active_brand_settings", settings, expires_in_sec=3600)
         return settings

--- a/verenigingen/verenigingen/doctype/brand_settings/brand_settings.py
+++ b/verenigingen/verenigingen/doctype/brand_settings/brand_settings.py
@@ -431,6 +431,7 @@ class BrandSettings(Document):
 
 
 @frappe.whitelist(allow_guest=True)
+@public_api
 def get_active_brand_settings():
     """Get the brand settings (now a Single doctype)
 

--- a/verenigingen/verenigingen/doctype/donation_campaign/donation_campaign.py
+++ b/verenigingen/verenigingen/doctype/donation_campaign/donation_campaign.py
@@ -9,10 +9,10 @@ from frappe.utils import flt, getdate
 from verenigingen.utils.security.api_security_framework import (
     OperationType,
     critical_api,
+    development_only_api,
     high_security_api,
     standard_api,
 )
-from verenigingen.utils.security_decorators import development_only
 from verenigingen.utils.validation_utilities import DateRangeValidator
 
 
@@ -330,7 +330,7 @@ class DonationCampaign(Document):
 
     @staticmethod
     @frappe.whitelist()
-    @development_only()
+    @development_only_api(operation_type=OperationType.UTILITY)
     def test_enhancements():
         """Test donation campaign enhancements"""
         results = []

--- a/verenigingen/verenigingen/doctype/event_contact_campaign/event_contact_campaign.py
+++ b/verenigingen/verenigingen/doctype/event_contact_campaign/event_contact_campaign.py
@@ -7,6 +7,11 @@ from frappe.model.document import Document
 from frappe.utils import cint
 
 from verenigingen.utils.constants import Roles
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    high_security_api,
+    standard_api,
+)
 
 
 class EventContactCampaign(Document):
@@ -99,6 +104,7 @@ class EventContactCampaign(Document):
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def get_contactable_members(chapter: str) -> list[dict]:
     """
     Get all contactable members for a chapter.
@@ -136,6 +142,7 @@ def get_contactable_members(chapter: str) -> list[dict]:
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def import_contactable_members(docname: str) -> dict:
     """
     Import contactable members into an Event Contact Campaign.
@@ -200,6 +207,7 @@ def import_contactable_members(docname: str) -> dict:
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def get_progress_dashboard(docname: str) -> str:
     """Get the progress dashboard HTML for a campaign."""
     doc = frappe.get_doc("Event Contact Campaign", docname)
@@ -207,6 +215,7 @@ def get_progress_dashboard(docname: str) -> str:
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def get_available_volunteers(docname: str) -> list[dict]:
     """
     Get available volunteers based on the campaign's owner_type.
@@ -272,6 +281,7 @@ def get_available_volunteers(docname: str) -> list[dict]:
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def distribute_members(docname: str, volunteer_ids: str = None) -> dict:
     """
     Distribute members in the contact list among selected volunteers.
@@ -348,6 +358,7 @@ def distribute_members(docname: str, volunteer_ids: str = None) -> dict:
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def clear_assignments(docname: str) -> dict:
     """
     Clear all volunteer assignments from the contact list.

--- a/verenigingen/verenigingen/doctype/member/member.py
+++ b/verenigingen/verenigingen/doctype/member/member.py
@@ -280,6 +280,7 @@ class Member(
         return get_member_address_display_service().get_address_members_html(self)
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.MEMBER_DATA)
     def get_volunteer_details_html(self) -> str:
         """Get HTML content for volunteer details field."""
         from verenigingen.services.member.display.member_volunteer_display_service import (
@@ -1007,6 +1008,7 @@ def assign_member_id(member_name: str):
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def get_volunteer_details_html_for_member(member_name: str) -> str:
     """Get volunteer details HTML for a specific member by name."""
     from verenigingen.services.member.display.member_volunteer_display_service import (

--- a/verenigingen/verenigingen/doctype/member/member_utils.py
+++ b/verenigingen/verenigingen/doctype/member/member_utils.py
@@ -9,6 +9,7 @@ from verenigingen.utils.security.api_security_framework import (
     OperationType,
     critical_api,
     high_security_api,
+    public_api,
     standard_api,
 )
 
@@ -43,10 +44,14 @@ def get_iban_bank_codes():
     }
 
 
-@frappe.whitelist()
-@standard_api(operation_type=OperationType.PUBLIC)
-def is_chapter_management_enabled():
-    """Check if chapter management is enabled in settings"""
+def _chapter_management_enabled():
+    """Plain (un-whitelisted) chapter-management setting check.
+
+    Use this for internal / server-side calls and from guest-accessible
+    endpoints. The whitelisted is_chapter_management_enabled() API delegates
+    here; calling the whitelisted wrapper internally would run its @standard_api
+    (MEDIUM) auth check against the current session and deny guest/portal paths.
+    """
     try:
         return frappe.db.get_single_value("Verenigingen Settings", "enable_chapter_management") == 1
     except (frappe.DoesNotExistError, frappe.ValidationError) as e:
@@ -55,6 +60,13 @@ def is_chapter_management_enabled():
     except frappe.DatabaseError as e:
         frappe.log_error(f"Database error in chapter management check: {str(e)}", "Member Utils")
         return True
+
+
+@frappe.whitelist()
+@standard_api(operation_type=OperationType.PUBLIC)
+def is_chapter_management_enabled():
+    """Check if chapter management is enabled in settings (whitelisted API)."""
+    return _chapter_management_enabled()
 
 
 # get_board_memberships moved to ChapterManagementService
@@ -451,9 +463,15 @@ def get_member_form_settings():
 
 
 @frappe.whitelist(allow_guest=True)
+@public_api(operation_type=OperationType.PUBLIC)
 def find_chapter_by_postal_code(postal_code):
     """Find chapters matching a postal code"""
-    if not is_chapter_management_enabled():
+    # Read the setting directly rather than calling the whitelisted
+    # is_chapter_management_enabled() API: that helper is @standard_api (MEDIUM),
+    # so invoking it from this guest-accessible endpoint ran a MEDIUM auth check
+    # against the (Guest) session and denied the request. _chapter_management_enabled()
+    # is a plain, un-gated helper with the same default-enabled-on-error semantics.
+    if not _chapter_management_enabled():
         return {"success": False, "message": "Chapter management is disabled"}
 
     if not postal_code:

--- a/verenigingen/verenigingen/doctype/member/scheduler.py
+++ b/verenigingen/verenigingen/doctype/member/scheduler.py
@@ -4,7 +4,12 @@ import frappe
 from frappe.utils import now
 from frappe.utils.background_jobs import enqueue
 
-from verenigingen.utils.security.api_security_framework import OperationType, critical_api, high_security_api
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    critical_api,
+    high_security_api,
+    utility_api,
+)
 
 
 def refresh_all_member_financial_histories():
@@ -362,6 +367,7 @@ def update_single_member_duration(member_name: str):
 
 
 @frappe.whitelist()
+@utility_api
 def get_duration_update_stats():
     """
     DEPRECATED: Get statistics about membership duration.

--- a/verenigingen/verenigingen/doctype/membership_dues_schedule/membership_dues_schedule.py
+++ b/verenigingen/verenigingen/doctype/membership_dues_schedule/membership_dues_schedule.py
@@ -16,6 +16,7 @@ from verenigingen.utils.security.api_security_framework import (
     critical_api,
     high_security_api,
     standard_api,
+    utility_api,
 )
 from verenigingen.utils.validation_utilities import DocumentExistenceValidator
 
@@ -1144,6 +1145,7 @@ def generate_dues_invoices(test_mode=False):
 
 
 @frappe.whitelist()
+@utility_api
 def get_parallel_invoice_generation_status():
     """
     Check the status of parallel invoice generation background jobs.

--- a/verenigingen/verenigingen/doctype/mijnrood_csv_import/mijnrood_csv_import.py
+++ b/verenigingen/verenigingen/doctype/mijnrood_csv_import/mijnrood_csv_import.py
@@ -36,7 +36,11 @@ from verenigingen.utils.csv_import_processor import (
 )
 from verenigingen.utils.error_handling import sanitize_error_for_audit
 from verenigingen.utils.safe_member_optimizer import safe_member_optimizer
-from verenigingen.utils.security.api_security_framework import OperationType, critical_api
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    critical_api,
+    high_security_api,
+)
 
 try:
     import pandas as pd
@@ -885,6 +889,7 @@ class MijnroodCSVImport(Document):
             return f"Error generating summary: {str(e)}"
 
     @frappe.whitelist()
+    @critical_api(operation_type=OperationType.ADMIN)
     def retry_failed_account_creations(self):
         """
         Retry failed account creation requests from the associated Bulk Operation Tracker.
@@ -993,6 +998,7 @@ class MijnroodCSVImport(Document):
             frappe.throw(_("Error retrying failed account creations: {0}").format(str(e)))
 
     @frappe.whitelist()
+    @critical_api(operation_type=OperationType.ADMIN)
     def retry_failed_volunteer_creations(self):
         """
         Retry volunteer creation for members that failed during import.
@@ -1785,6 +1791,7 @@ def get_import_template():
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def update_import_tracking_after_retry(import_doc_name: str):
     """
     Update import tracking fields after retry processing completes.
@@ -1820,6 +1827,7 @@ def update_import_tracking_after_retry(import_doc_name: str):
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def process_import_background(import_doc_name: str, test_mode: bool = False):
     """
     Background job function to process member CSV import.

--- a/verenigingen/verenigingen/doctype/movement/movement.py
+++ b/verenigingen/verenigingen/doctype/movement/movement.py
@@ -6,6 +6,8 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import get_url_to_form, getdate, today
 
+from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
+
 
 class Movement(Document):
     def validate(self):
@@ -195,6 +197,7 @@ class Movement(Document):
         self.activity_summary_html = html
 
     @frappe.whitelist()
+    @high_security_api(operation_type=OperationType.MEMBER_DATA)
     def suggest_potential_members(self):
         """API method to get suggested members based on tags"""
         if not self.related_tags:

--- a/verenigingen/verenigingen/doctype/performance_optimization_setup/performance_optimization_setup.py
+++ b/verenigingen/verenigingen/doctype/performance_optimization_setup/performance_optimization_setup.py
@@ -420,6 +420,7 @@ class PerformanceOptimizationSetup(Document):
             frappe.logger().error(f"Rollback failed: {str(e)}")
 
     @frappe.whitelist()
+    @critical_api(operation_type=OperationType.ADMIN)
     def remove_optimizations(self):
         """Manually remove performance optimizations"""
         if not frappe.has_permission(self.doctype, "write"):

--- a/verenigingen/verenigingen/doctype/periodic_donation_agreement/periodic_donation_agreement.py
+++ b/verenigingen/verenigingen/doctype/periodic_donation_agreement/periodic_donation_agreement.py
@@ -8,7 +8,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import add_months, add_years, date_diff, flt, getdate
 
-from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
+from verenigingen.utils.security.api_security_framework import OperationType, high_security_api, utility_api
 
 
 class PeriodicDonationAgreement(Document):
@@ -520,6 +520,7 @@ class PeriodicDonationAgreement(Document):
             frappe.throw(_(errors[0]))
 
     @frappe.whitelist()
+    @utility_api
     def get_anbi_validation_status(self):
         """
         Get comprehensive ANBI validation status for UI feedback and diagnostics.

--- a/verenigingen/verenigingen/doctype/system_alert/system_alert.py
+++ b/verenigingen/verenigingen/doctype/system_alert/system_alert.py
@@ -61,7 +61,7 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import now
 
-from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
+from verenigingen.utils.security.api_security_framework import OperationType, high_security_api, utility_api
 
 
 class SystemAlert(Document):
@@ -222,6 +222,7 @@ def resolve_alert(alert_name: str):
 
 
 @frappe.whitelist()
+@utility_api
 def get_alert_summary():
     """Get alert summary for dashboard"""
     try:

--- a/verenigingen/verenigingen/doctype/verenigingen_email_configuration/verenigingen_email_configuration.py
+++ b/verenigingen/verenigingen/doctype/verenigingen_email_configuration/verenigingen_email_configuration.py
@@ -14,6 +14,7 @@ from frappe.model.document import Document
 from frappe.utils import get_datetime, now_datetime
 
 from verenigingen.utils.constants import Roles
+from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
 
 
 class VerenigingenEmailConfiguration(Document):
@@ -168,6 +169,7 @@ def get_email_configuration() -> VerenigingenEmailConfiguration:
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def send_test_email(recipient: str) -> dict:
     """Send a test email to verify email configuration.
 
@@ -391,6 +393,7 @@ def _discover_notification_keys() -> dict:
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def discover_notification_keys() -> dict:
     """API endpoint to discover notification keys in the codebase.
 
@@ -443,6 +446,7 @@ def discover_notification_keys() -> dict:
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.ADMIN)
 def add_notification_types(notification_types: str) -> dict:
     """Add new notification types to Verenigingen Email Configuration.
 

--- a/verenigingen/verenigingen/report/account_creation_status/account_creation_status.py
+++ b/verenigingen/verenigingen/report/account_creation_status/account_creation_status.py
@@ -17,6 +17,8 @@ Author: Verenigingen Development Team
 import frappe
 from frappe import _
 
+from verenigingen.utils.security.api_security_framework import OperationType, critical_api
+
 
 def execute(filters=None):
     """Generate account creation status report."""
@@ -642,6 +644,7 @@ def get_chart_data():
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def retry_failed_requests_from_report(failure_type=None):
     """
     Wrapper to retry failed requests from the report interface.

--- a/verenigingen/verenigingen/report/chapter_dues_split/chapter_dues_split.py
+++ b/verenigingen/verenigingen/report/chapter_dues_split/chapter_dues_split.py
@@ -11,6 +11,7 @@ import frappe
 from frappe import _
 from frappe.utils import flt, get_first_day, get_last_day, getdate, today
 
+from verenigingen.utils.security.api_security_framework import OperationType, standard_api
 from verenigingen.verenigingen.domain.chapter_dues import DuesAllocationService
 
 
@@ -61,6 +62,7 @@ def get_columns(filters: Optional[Dict]) -> List[Dict]:
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def get_data(filters: Optional[Dict]) -> List[Dict]:
     """
     Get report data grouped by chapter.

--- a/verenigingen/verenigingen/report/database_table_size_analysis/database_table_size_analysis.py
+++ b/verenigingen/verenigingen/report/database_table_size_analysis/database_table_size_analysis.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 
 from verenigingen.utils.constants import Roles
+from verenigingen.utils.security.api_security_framework import OperationType, critical_api
 
 
 def execute(filters=None):
@@ -144,6 +145,7 @@ def get_chart_data(data):
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def optimize_all_tables():
     """
     Run OPTIMIZE TABLE on all tables to reclaim space.
@@ -186,6 +188,7 @@ def optimize_all_tables():
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def analyze_all_tables():
     """
     Run ANALYZE TABLE on all tables to update statistics.

--- a/verenigingen/verenigingen/report/member_end_date_reconstruction/member_end_date_reconstruction.py
+++ b/verenigingen/verenigingen/report/member_end_date_reconstruction/member_end_date_reconstruction.py
@@ -7,6 +7,12 @@ import frappe
 from frappe import _
 from frappe.utils import add_months, get_last_day, get_quarter_ending, getdate
 
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    critical_api,
+    high_security_api,
+)
+
 
 def execute(filters=None):
     """
@@ -291,6 +297,7 @@ def get_member_billing_frequency(member_name):
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def apply_suggestion(member_id: str, suggested_date):
     """Apply suggested end date to member record"""
 
@@ -320,6 +327,7 @@ def apply_suggestion(member_id: str, suggested_date):
 
 
 @frappe.whitelist()
+@critical_api(operation_type=OperationType.ADMIN)
 def apply_all_suggestions():
     """Apply all high-confidence suggestions in batch"""
 

--- a/verenigingen/verenigingen/report/membership_dues_coverage_analysis/membership_dues_coverage_analysis.py
+++ b/verenigingen/verenigingen/report/membership_dues_coverage_analysis/membership_dues_coverage_analysis.py
@@ -9,7 +9,12 @@ from frappe import _
 from frappe.utils import add_days, cint, date_diff, flt, getdate, today
 
 from verenigingen.utils.secure_operations import secure_document_operation
-from verenigingen.utils.security.api_security_framework import OperationType, high_security_api
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    development_only_api,
+    high_security_api,
+    standard_api,
+)
 from verenigingen.utils.validation_utilities import DateRangeValidator, validate_document_exists
 
 
@@ -1367,6 +1372,7 @@ def generate_catchup_invoices(members: str | list, from_date=None, to_date=None)
 
 
 @frappe.whitelist()
+@high_security_api(operation_type=OperationType.MEMBER_DATA)
 def export_gap_analysis(filters: dict | str | None):
     """Export detailed gap analysis to Excel"""
 
@@ -1425,6 +1431,7 @@ def export_gap_analysis(filters: dict | str | None):
 
 
 @frappe.whitelist()
+@development_only_api(operation_type=OperationType.UTILITY)
 def debug_coverage_fields():
     """Debug function to check coverage field existence and data"""
 
@@ -1522,6 +1529,7 @@ def debug_coverage_fields():
 
 
 @frappe.whitelist()
+@standard_api(operation_type=OperationType.REPORTING)
 def get_coverage_timeline_data(member: str, from_date=None, to_date=None):
     """Get detailed coverage timeline data for visualization"""
 

--- a/verenigingen/web_form/donation_form/donation_form.py
+++ b/verenigingen/web_form/donation_form/donation_form.py
@@ -7,6 +7,7 @@ import frappe
 from frappe import _
 
 from verenigingen.services.communication.email_service import get_email_service
+from verenigingen.utils.security.api_security_framework import public_api
 
 
 def get_context(context):
@@ -51,6 +52,7 @@ def get_existing_donor():
 
 
 @frappe.whitelist(allow_guest=True)
+@public_api
 def process_donation_form(data):
     """Process the donation form submission"""
     try:

--- a/verenigingen/web_form/periodic_donation_agreement_form/periodic_donation_agreement_form.py
+++ b/verenigingen/web_form/periodic_donation_agreement_form/periodic_donation_agreement_form.py
@@ -14,6 +14,11 @@ from frappe import _
 from frappe.utils import flt, getdate
 
 from verenigingen.services.communication.email_service import get_email_service
+from verenigingen.utils.security.api_security_framework import (
+    OperationType,
+    self_service_api,
+    utility_api,
+)
 
 # Rate limiting configuration
 RATE_LIMIT_SUBMISSIONS_PER_HOUR = 5
@@ -110,6 +115,7 @@ def get_or_create_donor_for_user():
 
 
 @frappe.whitelist()
+@utility_api
 def calculate_payment_amount(annual_amount, payment_frequency: str):
     """Calculate payment amount based on annual amount and frequency"""
     annual = flt(annual_amount)
@@ -125,6 +131,7 @@ def calculate_payment_amount(annual_amount, payment_frequency: str):
 
 
 @frappe.whitelist()
+@utility_api
 def validate_bsn(bsn: str):
     """Validate BSN format and checksum"""
     from verenigingen.api.anbi_operations import validate_bsn as validate_bsn_api
@@ -134,6 +141,7 @@ def validate_bsn(bsn: str):
 
 
 @frappe.whitelist()
+@self_service_api(operation_type=OperationType.FINANCIAL, implicit_allowed=True)
 def process_agreement_form(data):
     """Process the periodic donation agreement form submission
 
@@ -397,6 +405,7 @@ def get_submission_email_content(agreement, donor):
 
 
 @frappe.whitelist()
+@utility_api
 def get_agreement_terms():
     """Get terms and conditions for periodic donation agreements"""
     return """


### PR DESCRIPTION
## Summary

Hardens the custom API-security middleware and brings the app's whitelisted API
surface under the security framework. Two phases:

**Phase 1 — middleware audit (7 commits).** A 4-agent audit of
`verenigingen/utils/security/` + `secure_operations.py` found and fixed 8 issues
(+ skeptical review of the fixes):
- Shared-mutable `SECURITY_PROFILES` singleton → copy via `dataclasses.replace`
  before per-endpoint overrides (a `@development_only_api` hit was poisoning the
  LOW profile in prod).
- **Rule 5 cap**: bare-role fallback and the System Manager exception are capped
  at MEDIUM; HIGH/CRITICAL now require an assigned **Role Profile** (Rule 4).
- Self-service ownership hardening (validate all identifiers, inspect scalars +
  JSON payloads with an `lstrip` fast-reject, fail-closed volunteer).
- Spoofable leftmost-XFF client IP; site-namespaced rate-limit counter keys;
  `nan`/`inf` rejection + `re.fullmatch`; dead CSRF self-compare; SEPA IP/hours
  fail-closed.

**Phase 2 — endpoint coverage sweep + follow-ups (5 commits).** `verenigingen/api/`
was already 100% covered; the ~160 unprotected `@frappe.whitelist()` endpoints
live elsewhere (utils, doctypes, services, reports, email, mijnrood_sync,
web_form, templates). Classified each by function body + real callers and
decorated **140** by least-privilege tier (55 high_security, 24 utility, 21
critical, 17 development_only, 14 standard, 4 public, 4 self_service, 1 webhook);
158 unprotected → 18.

Notable Phase-2 decisions:
- `event_contact_campaign` PII endpoints use `@high_security_api`, not
  `@standard_api` (operation_type does not raise the tier; the Volunteer profile
  is MEDIUM, so `@standard_api` would let any volunteer harvest a chapter's
  contact list).
- **18 endpoints deliberately left undecorated** (documented in commits): 7
  member.py shims (already enforce `check_permission`; a decorator would mask the
  DocPerm error), 6 pure IBAN/name utilities + 1 enqueue target (the framework's
  auth/rate-limit stack runs on in-process calls too and is CI-invisible — would
  abort SEPA batch loops at the ~101st row), and 2 `cleanup_chart_of_accounts`
  (previously had decorators removed over a `frappe.call` "User None is disabled"
  bug; still to be validated).

Follow-up fixes surfaced by the sweep:
- Fixed 7 pre-existing `test_admin_tools_security` failures caused by the Phase-1
  Rule 5 cap (the sibling test file was updated but these were missed).
- Closed 3 adjacent pre-existing gaps: arbitrary-method exec via `processor_method`
  in `queue_csv_import_processing` (allow-list), user enumeration in
  `get_user_project_teams` (privilege check for cross-user), and guest email leak
  via `get_active_brand_settings.as_dict()` (strip framework metadata).
- Secured the Zabbix monitoring endpoints: `get_metrics_for_zabbix` / `health_check`
  were guest with auth commented out (anonymous metrics/internals leak) → now
  require an `X-Zabbix-Token`; the auto-remediation webhook (which can flush
  cache / restart Redis) was dead in prod AND fail-open → now guest+mandatory
  HMAC signature, fails closed, with its own dedicated secret.

## ⚠️ Deploy / operational notes (required)

1. **Role profiles**: HIGH/CRITICAL API access now requires an assigned Role
   Profile. Confirmed with the owner that all users have one; verify before
   deploy or elevated users lose HIGH/CRITICAL access.
2. **Zabbix**: set `zabbix_api_token` and `zabbix_webhook_secret` per site
   (site_config; not in repo). Configure Zabbix to send `X-Zabbix-Token: <token>`
   on metrics/health and `X-Zabbix-Signature: <hex hmac-sha256 of raw body>` on
   the webhook. Optional: `zabbix_allowed_ips`, `zabbix_allow_guest`.
3. **`bench restart`** after deploy — the metrics/health/webhook `allow_guest`
   registration is resolved at import; workers must reload.

## Testing
- Security framework 42/42, profile-isolation 2/2, admin_tools 19/19,
  project_permissions 27/27, brand_settings 27/27 — green.
- Every decorated endpoint runtime-verified (`_security_protected`), all changed
  modules import cleanly; Zabbix auth verified over HTTP (401 without token/sig,
  200/handler with).

## Still open
- 2 `cleanup_chart_of_accounts` endpoints (need the `frappe.call` "User None is
  disabled" interaction test before re-decorating).

https://claude.ai/code/session_01FRUAEQWKKBMhrNjobFVKn9
